### PR TITLE
feat(k6): re-enable nightly perf gate against current handshake API

### DIFF
--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -17,25 +17,16 @@ on:
         required: false
         default: 'smoke'
 
-  # Scheduled runs are disabled pending an update to tests/k6/baseline.js.
-  # The current test sends the legacy handshake shape
-  # ({initiator_id, responder_id, nonce, policy_id: 'policy-baseline'})
-  # but migration 036_handshake_policies.sql changed policy_id to a UUID
-  # FK and the route schema now requires {mode, parties:[{role,entity_ref}]}.
-  # The handshake step 500s on the policy UUID lookup.
-  #
-  # State that *has* been done (do not redo):
-  #   - perf-test-entity-001 + test-responder-001 entities are registered
-  #     in the prod Supabase (UUIDs in the entities table)
-  #   - PERF_TEST_API_KEY GitHub secret is set to perf-test-entity-001's key
-  #   - default base_url points at https://www.emiliaprotocol.ai
-  #
-  # To re-enable the cron, update tests/k6/baseline.js to send the new
-  # handshake shape and resolve a real handshake_policies.policy_id (UUID),
-  # then verify with: gh workflow run k6.yml --ref main
-  # schedule:
-  #   - cron: '0 3 * * *'   # 03:00 UTC daily — smoke test
-  #   - cron: '0 2 * * 0'   # 02:00 UTC every Sunday — full staircase test
+  # Scheduled runs hit production (www.emiliaprotocol.ai) using
+  # perf-test-entity-001 / test-responder-001 (seeded in prod Supabase) and
+  # the PERF_TEST_API_KEY secret. tests/k6/baseline.js setup() resolves
+  # POLICY_KEY → policy_id (UUID) via GET /api/handshake-policies once
+  # before scenarios start, so the test stays decoupled from any specific
+  # UUID. Smoke is ~500 reqs/night at 5 VUs × 30s — small enough to be
+  # filterable from prod metrics by the dedicated entity ids.
+  schedule:
+    - cron: '0 3 * * *'   # 03:00 UTC daily — smoke test
+    - cron: '0 2 * * 0'   # 02:00 UTC every Sunday — full staircase test
 
 jobs:
   baseline:

--- a/app/api/handshake-policies/route.js
+++ b/app/api/handshake-policies/route.js
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// GET /api/handshake-policies — list active handshake policies.
+//
+// Read-only listing of rows from the handshake_policies table. Returns the
+// policy_id (UUID FK target for POST /api/handshake), the human-readable
+// policy_key, version, name, and mode. Filters to status='active' so callers
+// don't accidentally start a handshake against a deprecated policy.
+//
+// Auth-gated to a valid EP API key. The result is operator metadata — not
+// secret, but exposing it to unauthenticated callers reveals the operator's
+// policy lineup, which is unnecessary for the public surface.
+//
+// Used by tests/k6/baseline.js to resolve a real policy_id at startup; also
+// useful for any client that needs to find the UUID for a known policy_key.
+
+import { NextResponse } from 'next/server';
+import { authenticateRequest } from '@/lib/supabase';
+import { getGuardedClient } from '@/lib/write-guard';
+import { EP_ERROR_CODES } from '@/lib/errors/taxonomy';
+import { epError } from '@/lib/errors/response';
+import { logger } from '@/lib/logger.js';
+
+export async function GET(request) {
+  try {
+    const auth = await authenticateRequest(request);
+    if (auth.error) return epError(EP_ERROR_CODES.UNAUTHORIZED);
+
+    const supabase = getGuardedClient();
+    const { searchParams } = new URL(request.url);
+    const policyKey = searchParams.get('policy_key');
+
+    let query = supabase
+      .from('handshake_policies')
+      .select('policy_id, policy_key, version, name, mode, status')
+      .eq('status', 'active')
+      .order('policy_key', { ascending: true })
+      .order('version', { ascending: false });
+
+    if (policyKey) {
+      query = query.eq('policy_key', policyKey);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      logger.error('handshake-policies list error:', error);
+      return epError(EP_ERROR_CODES.INTERNAL, error.message);
+    }
+
+    return NextResponse.json({
+      protocol_version: 'EP/1.1',
+      policies: data || [],
+      _note: 'Use policy_id as the policy_id field in POST /api/handshake.',
+    });
+  } catch (err) {
+    logger.error('handshake-policies error:', err);
+    return epError(EP_ERROR_CODES.INTERNAL);
+  }
+}

--- a/tests/k6/baseline.js
+++ b/tests/k6/baseline.js
@@ -9,17 +9,21 @@
  * ops runbook or use the k6 Cloud schedule.
  *
  * Usage:
- *   k6 run tests/k6/baseline.js -e BASE_URL=https://staging.example.com -e API_KEY=ep_test_...
+ *   k6 run tests/k6/baseline.js -e BASE_URL=https://www.emiliaprotocol.ai -e API_KEY=ep_live_...
  *
  * Required env:
  *   BASE_URL   - Target environment base URL (no trailing slash)
- *   API_KEY    - Valid EP API key for auth (must have test entity pre-registered)
- *   ENTITY_ID  - Entity ID registered in the target environment
+ *   API_KEY    - Valid EP API key for auth (must own ENTITY_ID)
+ *   ENTITY_ID  - Initiator entity ID, pre-registered in the target environment
+ *   RESPONDER_ID (optional, defaults to 'test-responder-001') — responder party
+ *   POLICY_KEY   (optional, defaults to 'authorized_signer_basic_v1') — handshake policy_key.
+ *                The setup() function resolves this to a real policy_id (UUID)
+ *                via GET /api/handshake-policies?policy_key=... once at startup.
  */
 
 import http from 'k6/http';
 import { check, sleep } from 'k6';
-import { Counter, Rate, Trend } from 'k6/metrics';
+import { Counter } from 'k6/metrics';
 
 // ---------------------------------------------------------------------------
 // SLO thresholds (from BENCHMARK_BASELINE.md)
@@ -99,21 +103,48 @@ const handshakeErrors = new Counter('handshake_errors');
 const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
 const API_KEY  = __ENV.API_KEY  || 'ep_test_key';
 const ENTITY_ID = __ENV.ENTITY_ID || 'test-entity-001';
+const RESPONDER_ID = __ENV.RESPONDER_ID || 'test-responder-001';
+const POLICY_KEY = __ENV.POLICY_KEY || 'authorized_signer_basic_v1';
 
 const HEADERS = {
   'Authorization': `Bearer ${API_KEY}`,
   'Content-Type': 'application/json',
 };
 
-function randomNonce() {
-  return `k6-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+// ---------------------------------------------------------------------------
+// Setup — runs once per test, before scenarios start.
+//
+// Resolves POLICY_KEY → policy_id (UUID). Migration 036 changed the
+// handshakes.policy_id column to a UUID FK on handshake_policies, so the
+// route requires a real UUID, not a free-form string. Previous test versions
+// hardcoded `policy_id: 'policy-baseline'` and 500'd on every request.
+// ---------------------------------------------------------------------------
+export function setup() {
+  const res = http.get(
+    `${BASE_URL}/api/handshake-policies?policy_key=${encodeURIComponent(POLICY_KEY)}`,
+    { headers: HEADERS },
+  );
+  if (res.status !== 200) {
+    throw new Error(
+      `[setup] Failed to fetch handshake-policies (HTTP ${res.status}): ${res.body}`,
+    );
+  }
+  const body = JSON.parse(res.body);
+  const policy = (body.policies || [])[0];
+  if (!policy || !policy.policy_id) {
+    throw new Error(
+      `[setup] No active handshake_policy found for policy_key="${POLICY_KEY}". ` +
+      `Seed one (see supabase/migrations/036_handshake_policies.sql) or pass POLICY_KEY=<existing>.`,
+    );
+  }
+  return { policyId: policy.policy_id };
 }
 
 // ---------------------------------------------------------------------------
 // Default scenario
 // ---------------------------------------------------------------------------
 
-export default function () {
+export default function (data) {
   // ── 1. Trust evaluation (read — expected to be fast) ─────────────────────
   const trustRes = http.post(
     `${BASE_URL}/api/trust/evaluate`,
@@ -128,13 +159,18 @@ export default function () {
   sleep(0.1);
 
   // ── 2. Handshake initiation (protocol write — hot path) ──────────────────
+  // POST /api/handshake schema (see lib/handshake/schema.js validateInitiateBody):
+  //   { mode, policy_id (UUID), parties: [{role, entity_ref}, ...] }
+  // The initiator's entity_ref MUST equal the authenticated entity's id.
   const initiateRes = http.post(
     `${BASE_URL}/api/handshake`,
     JSON.stringify({
-      initiator_id: ENTITY_ID,
-      responder_id: 'test-responder-001',
-      nonce: randomNonce(),
-      policy_id: 'policy-baseline',
+      mode: 'basic',
+      policy_id: data.policyId,
+      parties: [
+        { role: 'initiator', entity_ref: ENTITY_ID },
+        { role: 'responder', entity_ref: RESPONDER_ID },
+      ],
     }),
     { headers: HEADERS, tags: { route: 'handshake_create' } },
   );

--- a/tests/k6/staircase.js
+++ b/tests/k6/staircase.js
@@ -94,9 +94,10 @@ const p95TrustEval     = new Trend('p95_trust_eval_latency');
 // Config
 // ---------------------------------------------------------------------------
 
-const BASE_URL  = __ENV.BASE_URL   || 'http://localhost:3000';
-const API_KEY   = __ENV.API_KEY    || 'ep_test_key';
-const ENTITY_ID = __ENV.ENTITY_ID  || 'bench-entity-001';
+const BASE_URL   = __ENV.BASE_URL    || 'http://localhost:3000';
+const API_KEY    = __ENV.API_KEY     || 'ep_test_key';
+const ENTITY_ID  = __ENV.ENTITY_ID   || 'bench-entity-001';
+const POLICY_KEY = __ENV.POLICY_KEY  || 'authorized_signer_basic_v1';
 
 const AUTH_HEADERS = {
   'Authorization': `Bearer ${API_KEY}`,
@@ -107,20 +108,32 @@ const READ_HEADERS = {
   'Content-Type': 'application/json',
 };
 
-function randomNonce() {
-  return `k6-staircase-${Math.random().toString(36).slice(2)}-${Date.now()}`;
-}
-
 function randomResponder() {
   const ids = ['responder-a', 'responder-b', 'responder-c', 'responder-d'];
   return ids[Math.floor(Math.random() * ids.length)];
+}
+
+// setup() resolves POLICY_KEY → policy_id (UUID). See baseline.js comment.
+export function setup() {
+  const res = http.get(
+    `${BASE_URL}/api/handshake-policies?policy_key=${encodeURIComponent(POLICY_KEY)}`,
+    { headers: AUTH_HEADERS },
+  );
+  if (res.status !== 200) {
+    throw new Error(`[setup] handshake-policies fetch failed (HTTP ${res.status}): ${res.body}`);
+  }
+  const policy = (JSON.parse(res.body).policies || [])[0];
+  if (!policy?.policy_id) {
+    throw new Error(`[setup] No active policy for policy_key="${POLICY_KEY}"`);
+  }
+  return { policyId: policy.policy_id };
 }
 
 // ---------------------------------------------------------------------------
 // Default scenario function
 // ---------------------------------------------------------------------------
 
-export default function () {
+export default function (data) {
   // ── 1. Trust evaluation — read path, should scale well ─────────────────
   const evalRes = http.post(
     `${BASE_URL}/api/trust/evaluate`,
@@ -152,10 +165,12 @@ export default function () {
   const hsRes = http.post(
     `${BASE_URL}/api/handshake`,
     JSON.stringify({
-      initiator_id:  ENTITY_ID,
-      responder_id:  randomResponder(),
-      nonce:         randomNonce(),
-      policy_id:     'policy-staircase-bench',
+      mode: 'basic',
+      policy_id: data.policyId,
+      parties: [
+        { role: 'initiator', entity_ref: ENTITY_ID },
+        { role: 'responder', entity_ref: randomResponder() },
+      ],
     }),
     { headers: AUTH_HEADERS, tags: { route: 'handshake_create' } },
   );

--- a/tests/route-coverage.test.js
+++ b/tests/route-coverage.test.js
@@ -126,6 +126,10 @@ const OPENAPI_EXEMPTIONS = [
   '/api/receipt',
   '/api/trust',
   '/api/discovery/keys',
+  // Handshake policy lookup — read-only helper used by k6 perf tests
+  // (and any client that needs to resolve policy_key → policy_id UUID).
+  // OpenAPI spec to be added in a follow-up.
+  '/api/handshake-policies',
   // EP Commit routes — OpenAPI spec to be added in a follow-up.
   '/api/commit/issue',
   '/api/commit/verify',


### PR DESCRIPTION
## Summary

Closes the last open gap from #56: the k6 nightly perf gate was disabled because `tests/k6/baseline.js` sent the legacy handshake shape, which migration `036_handshake_policies.sql` made invalid (policy_id became a UUID FK; route schema now requires `{mode, parties:[{role,entity_ref}]}`).

This PR ships:

1. **New endpoint** [app/api/handshake-policies/route.js](app/api/handshake-policies/route.js) — auth-gated `GET /api/handshake-policies?policy_key=...` that lists active rows from the `handshake_policies` table.
2. **k6 baseline + staircase** — `setup()` resolves `policy_key` → UUID once at startup; request body uses the current schema.
3. **k6 workflow** — both crons re-enabled (03:00 UTC nightly smoke, 02:00 UTC Sunday staircase).

## Test plan

- [ ] CI passes on this PR
- [ ] After merge: Vercel prod deploys with the new `/api/handshake-policies` endpoint
- [ ] `gh workflow run k6.yml --ref main` succeeds against prod
- [ ] Nightly cron at 03:00 UTC tomorrow doesn't 100%-fail in the budget alerts

## Why an endpoint instead of a hardcoded UUID

The `handshake_policies.policy_id` is generated via `gen_random_uuid()` in migration 036 — every environment has a different UUID for the same `policy_key`. Hardcoding a value would couple the test to a specific deployment. The endpoint keeps the test environment-portable and is useful for other clients that need the same lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)