### PR TITLE
fix(handshake): surface error detail in 500 responses

### DIFF
--- a/app/api/handshake/route.js
+++ b/app/api/handshake/route.js
@@ -59,7 +59,14 @@ export async function POST(request) {
     return NextResponse.json(result, { status: 201 });
   } catch (err) {
     logger.error('Handshake initiation error:', err);
-    return epError(EP_ERROR_CODES.INTERNAL);
+    // Surface known-class error messages (HandshakeError, ProtocolWriteError)
+    // as `detail` so the API caller sees the specific failure cause instead
+    // of a generic 500. Bare Error instances stay opaque to avoid leaking
+    // stack traces from internal exceptions.
+    const detail = (err?.code && err?.message)
+      ? `${err.code}: ${err.message}`
+      : null;
+    return epError(EP_ERROR_CODES.INTERNAL, detail);
   }
 }
 


### PR DESCRIPTION
Tiny diagnostic — pass HandshakeError/ProtocolWriteError {code,message} as response detail so callers don't need server logs to debug 500s. Bare Errors still return null detail. Discovered while debugging the k6 integration.