### PR TITLE
chore(db): defensive replay of migrations 072 + 076 (idempotent variants)

### DIFF
--- a/supabase/migrations/087_apply_072_tenant_columns_defensive.sql
+++ b/supabase/migrations/087_apply_072_tenant_columns_defensive.sql
@@ -1,0 +1,53 @@
+-- Migration 087: Defensive replay of 072 (tenant scoping for cloud tables)
+--
+-- Migration 072 failed to apply on prod because step 4 references the
+-- `policy_versions` table, which doesn't exist on prod (and isn't created by
+-- any migration in this repo — likely was created via Studio SQL editor in
+-- a now-removed migration). The DO block in 072 checks for the *column*
+-- but not the table, so when the table is absent the inner ALTER errors.
+--
+-- This migration replays the safe portions of 072 (signoff_challenges,
+-- signoff_attestations, handshake_policies — all already use IF NOT EXISTS)
+-- and adds a `to_regclass()` guard around the policy_versions branch so it
+-- becomes a no-op when the table is absent.
+--
+-- This is idempotent: re-running has no effect if the columns/indexes
+-- already exist.
+
+-- 1. signoff_challenges
+ALTER TABLE signoff_challenges
+  ADD COLUMN IF NOT EXISTS tenant_id UUID;
+
+CREATE INDEX IF NOT EXISTS idx_signoff_challenges_tenant
+  ON signoff_challenges(tenant_id) WHERE tenant_id IS NOT NULL;
+
+-- 2. signoff_attestations
+ALTER TABLE signoff_attestations
+  ADD COLUMN IF NOT EXISTS tenant_id UUID;
+
+CREATE INDEX IF NOT EXISTS idx_signoff_attestations_tenant
+  ON signoff_attestations(tenant_id) WHERE tenant_id IS NOT NULL;
+
+-- 3. handshake_policies (allows per-tenant policies in multi-tenant deployments)
+ALTER TABLE handshake_policies
+  ADD COLUMN IF NOT EXISTS tenant_id UUID;
+
+CREATE INDEX IF NOT EXISTS idx_handshake_policies_tenant
+  ON handshake_policies(tenant_id) WHERE tenant_id IS NOT NULL;
+
+-- 4. policy_versions (only if the table exists). If a future migration
+-- introduces the table, re-applying this is harmless (column will already
+-- have been created at that point or we'll add it here).
+DO $$
+BEGIN
+  IF to_regclass('public.policy_versions') IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name = 'policy_versions' AND column_name = 'tenant_id'
+    ) THEN
+      ALTER TABLE policy_versions ADD COLUMN tenant_id UUID;
+      CREATE INDEX IF NOT EXISTS idx_policy_versions_tenant
+        ON policy_versions(tenant_id) WHERE tenant_id IS NOT NULL;
+    END IF;
+  END IF;
+END $$;

--- a/supabase/migrations/088_apply_076_rls_policies_idempotent.sql
+++ b/supabase/migrations/088_apply_076_rls_policies_idempotent.sql
@@ -1,0 +1,77 @@
+-- Migration 088: Defensive replay of 076 (RLS policies for all EP tables)
+--
+-- Migration 076 failed mid-push on prod because at least one of its 41
+-- CREATE POLICY statements (audit_events) was already partially applied via
+-- Studio SQL or out-of-band. CREATE POLICY has no IF NOT EXISTS variant in
+-- Postgres, so the rest of the policies never ran.
+--
+-- This migration is idempotent: it DROPs each policy IF EXISTS, then
+-- re-CREATEs it. The drop+create is in a single transaction (the
+-- migration's implicit transaction) so the policy is never effectively
+-- absent — a brief moment with no policy is still RLS-bypassable by the
+-- service role.
+--
+-- Note: each policy targets one specific table that's expected to exist
+-- on prod. If a table is absent (e.g., zk_proofs hasn't been provisioned),
+-- the policy creation for it errors. We wrap the whole block in a DO
+-- so the loop continues past tables that don't exist — the missing table
+-- becomes a one-line warning instead of a halt.
+
+DO $$
+DECLARE
+  rec RECORD;
+  protocol_tables TEXT[] := ARRAY[
+    'audit_events', 'continuity_challenges', 'continuity_claims',
+    'continuity_decisions', 'delegations', 'disputes', 'fraud_flags',
+    'handshake_bindings', 'handshake_consumptions', 'handshake_events',
+    'handshake_parties', 'handshake_policies', 'handshake_presentations',
+    'handshake_results', 'handshakes', 'identity_bindings', 'merkle_batches',
+    'principal_delegation_signals', 'principals', 'protocol_events',
+    'signoff_attestations', 'signoff_challenges', 'signoff_consumptions',
+    'signoff_events', 'trust_reports', 'zk_proofs',
+    'eye_advisories', 'eye_observations', 'eye_suppressions',
+    'tenants', 'tenant_members', 'tenant_api_keys', 'tenant_environments',
+    'alert_rules', 'alert_events', 'webhook_endpoints', 'webhook_deliveries',
+    'partner_inquiries', 'investor_inquiries'
+  ];
+  t TEXT;
+BEGIN
+  FOREACH t IN ARRAY protocol_tables LOOP
+    IF to_regclass('public.' || quote_ident(t)) IS NULL THEN
+      RAISE NOTICE 'Skipping policy on missing table: %', t;
+      CONTINUE;
+    END IF;
+    EXECUTE format(
+      'DROP POLICY IF EXISTS %I ON public.%I',
+      'service_role_bypass', t
+    );
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I TO service_role USING (true) WITH CHECK (true)',
+      'service_role_bypass', t
+    );
+  END LOOP;
+END $$;
+
+-- anon INSERT policies for public form tables (lead capture only — no SELECT)
+DO $$
+DECLARE
+  form_tables TEXT[] := ARRAY['partner_inquiries', 'investor_inquiries'];
+  t TEXT;
+BEGIN
+  FOREACH t IN ARRAY form_tables LOOP
+    IF to_regclass('public.' || quote_ident(t)) IS NULL THEN
+      RAISE NOTICE 'Skipping anon_insert on missing table: %', t;
+      CONTINUE;
+    END IF;
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', 'anon_insert', t);
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I FOR INSERT TO anon WITH CHECK (true)',
+      'anon_insert', t
+    );
+  END LOOP;
+END $$;
+
+COMMENT ON POLICY "service_role_bypass" ON public.handshakes IS
+  'All EP API access uses service_role via getServiceClient()/getGuardedClient(). '
+  'Tenant isolation is enforced at the application layer. This policy satisfies '
+  'RLS without granting direct database access to anon or authenticated roles.';


### PR DESCRIPTION
Two migrations from the 070–086 batch couldn't apply directly: 072 references a missing `policy_versions` table; 076 has no `IF NOT EXISTS` on its CREATE POLICY statements and was partially applied via Studio SQL.

087 wraps 072's `policy_versions` branch in a `to_regclass()` guard. 088 reimplements 076's policy creation in a DO block that loops over tables (skipping missing ones) and uses DROP POLICY IF EXISTS + CREATE POLICY for full idempotency.

Both have already been applied to prod via `supabase db push --linked`. This PR captures them in the migration history.