### PR TITLE
ci: opt all workflows into Node.js 24 (FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true)

### DIFF
--- a/.github/workflows/alloy.yml
+++ b/.github/workflows/alloy.yml
@@ -1,5 +1,12 @@
 name: Alloy
 
+# Opt every JavaScript-based action into the Node.js 24 runner.
+# GitHub forces this default in June 2026; doing it now eliminates the
+# deprecation-warning noise on every run and surfaces any Node-24 incompat
+# early. Affects actions/checkout, actions/setup-node, actions/upload-artifact, etc.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     paths:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: CI
 
+# Opt every JavaScript-based action into the Node.js 24 runner.
+# GitHub forces this default in June 2026; doing it now eliminates the
+# deprecation-warning noise on every run and surfaces any Node-24 incompat
+# early. Affects actions/checkout, actions/setup-node, actions/upload-artifact, etc.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,12 @@
 name: CodeQL
 
+# Opt every JavaScript-based action into the Node.js 24 runner.
+# GitHub forces this default in June 2026; doing it now eliminates the
+# deprecation-warning noise on every run and surfaces any Node-24 incompat
+# early. Affects actions/checkout, actions/setup-node, actions/upload-artifact, etc.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: [main, develop]

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,5 +1,12 @@
 name: DCO
 
+# Opt every JavaScript-based action into the Node.js 24 runner.
+# GitHub forces this default in June 2026; doing it now eliminates the
+# deprecation-warning noise on every run and surfaces any Node-24 incompat
+# early. Affects actions/checkout, actions/setup-node, actions/upload-artifact, etc.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -1,5 +1,12 @@
 name: k6 Performance Baseline
 
+# Opt every JavaScript-based action into the Node.js 24 runner.
+# GitHub forces this default in June 2026; doing it now eliminates the
+# deprecation-warning noise on every run and surfaces any Node-24 incompat
+# early. Affects actions/checkout, actions/setup-node, actions/upload-artifact, etc.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   # Manual trigger: run against any environment
   workflow_dispatch:

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,5 +1,12 @@
 name: Publish MCP Server to npm
 
+# Opt every JavaScript-based action into the Node.js 24 runner.
+# GitHub forces this default in June 2026; doing it now eliminates the
+# deprecation-warning noise on every run and surfaces any Node-24 incompat
+# early. Affects actions/checkout, actions/setup-node, actions/upload-artifact, etc.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     tags:

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -1,5 +1,12 @@
 name: Publish Python SDK
 
+# Opt every JavaScript-based action into the Node.js 24 runner.
+# GitHub forces this default in June 2026; doing it now eliminates the
+# deprecation-warning noise on every run and surfaces any Node-24 incompat
+# early. Affects actions/checkout, actions/setup-node, actions/upload-artifact, etc.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/publish-typescript-sdk.yml
+++ b/.github/workflows/publish-typescript-sdk.yml
@@ -1,5 +1,12 @@
 name: Publish TypeScript SDK
 
+# Opt every JavaScript-based action into the Node.js 24 runner.
+# GitHub forces this default in June 2026; doing it now eliminates the
+# deprecation-warning noise on every run and surfaces any Node-24 incompat
+# early. Affects actions/checkout, actions/setup-node, actions/upload-artifact, etc.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,12 @@
 name: Release Provenance
 
+# Opt every JavaScript-based action into the Node.js 24 runner.
+# GitHub forces this default in June 2026; doing it now eliminates the
+# deprecation-warning noise on every run and surfaces any Node-24 incompat
+# early. Affects actions/checkout, actions/setup-node, actions/upload-artifact, etc.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   release:
     types: [published]

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,5 +1,12 @@
 name: Secret Scanning
 
+# Opt every JavaScript-based action into the Node.js 24 runner.
+# GitHub forces this default in June 2026; doing it now eliminates the
+# deprecation-warning noise on every run and surfaces any Node-24 incompat
+# early. Affects actions/checkout, actions/setup-node, actions/upload-artifact, etc.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: [main, develop]

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,5 +1,12 @@
 name: Security Scan
 
+# Opt every JavaScript-based action into the Node.js 24 runner.
+# GitHub forces this default in June 2026; doing it now eliminates the
+# deprecation-warning noise on every run and surfaces any Node-24 incompat
+# early. Affects actions/checkout, actions/setup-node, actions/upload-artifact, etc.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/tlc.yml
+++ b/.github/workflows/tlc.yml
@@ -1,5 +1,12 @@
 name: TLC Model Checker
 
+# Opt every JavaScript-based action into the Node.js 24 runner.
+# GitHub forces this default in June 2026; doing it now eliminates the
+# deprecation-warning noise on every run and surfaces any Node-24 incompat
+# early. Affects actions/checkout, actions/setup-node, actions/upload-artifact, etc.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     paths:


### PR DESCRIPTION
Drops the Node 20 deprecation warning from every CI run and forces JS actions onto Node 24 now instead of in June 2026 when it'd be urgent. Covers all 12 workflow files at workflow scope. YAML-validated locally.