### PR TITLE
chore(deps): batch 2 — sdks/typescript TS 5.6 → 6.0.3

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -44,7 +44,7 @@
   "homepage": "https://emiliaprotocol.ai",
   "devDependencies": {
     "@types/node": "^25.6.0",
-    "typescript": "^5.6.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   }
 }

--- a/sdks/typescript/tsconfig.json
+++ b/sdks/typescript/tsconfig.json
@@ -11,7 +11,8 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Reapplies PR #52 with the types:[node] fix. Verified locally with tsc --noEmit.