### PR TITLE
ci: auto-merge Dependabot patches + group npm bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,25 @@ updates:
       - javascript
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      # Bundle patches/minors of unrelated dev tools into a single PR per
+      # week. Frameworks (next, react, typescript) stay un-grouped so they
+      # surface as standalone PRs that the auto-merge workflow can route
+      # to human review.
+      patch-and-minor-dev:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "next"
+          - "react"
+          - "react-dom"
+          - "typescript"
+          - "eslint"
+          - "eslint-config-next"
     ignore:
       # Avoid major version bumps on Next.js without a manual migration review
       - dependency-name: "next"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -20,6 +20,12 @@ jobs:
           fetch-depth: 0
 
       - name: Check DCO sign-off
-        uses: christophebedard/dco-check@30353d8deedf393cf55ba33355e71da7fdd095c7  # v0.4.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        # v0.5.0 changed token plumbing: it now reads GITHUB_TOKEN from the
+        # environment instead of the `with: token` input. v0.4.0 still works
+        # but is built on Ubuntu 20.04 and routinely flakes on apt-fetch
+        # against archive.ubuntu.com (e.g. run 25337261765 — failed to
+        # fetch libc6, libssl1.1). Move forward to v0.5.0 with correct
+        # token wiring.
+        uses: christophebedard/dco-check@7b0205d25ead0f898e0b706b58227dd5fa7e3f55  # v0.5.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,111 @@
+name: Dependabot Auto-Merge
+
+# Opt every JavaScript-based action into the Node.js 24 runner.
+# GitHub forces this default in June 2026; doing it now eliminates the
+# deprecation-warning noise on every run and surfaces any Node-24 incompat
+# early. Affects actions/checkout, actions/setup-node, actions/upload-artifact, etc.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+# Auto-approves and auto-merges Dependabot PRs that are:
+#   • patch-version updates on any package, OR
+#   • minor-version updates on packages we treat as safe to auto-bump
+#
+# Major-version updates and minor-version updates on framework-shaped
+# packages (next, react, typescript, eslint, eslint-config-next) are
+# left for human review — these have surfaced real breakage in the past.
+#
+# Uses pull_request_target (not pull_request) so the GITHUB_TOKEN has the
+# write permissions needed to approve and merge. This is the GitHub-
+# recommended pattern for Dependabot auto-merge — see
+# https://github.blog/news-insights/the-library/automating-dependabot-with-github-actions/
+# It's safe here because the workflow only reads metadata and calls
+# `gh pr` commands; it never executes user-supplied code from the PR.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7  # v2.3.0
+
+      - name: Decide auto-merge eligibility
+        id: decide
+        env:
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
+        run: |
+          # update-type is one of:
+          #   version-update:semver-patch
+          #   version-update:semver-minor
+          #   version-update:semver-major
+          # plus security-update variants that we always merge if patch/minor.
+
+          # Packages that require human review even on minor bumps —
+          # past minor releases of these have introduced breaking changes
+          # on this repo (e.g. eslint-config-next 16 dropped `next lint`,
+          # react 19.2 mismatched react-dom).
+          REVIEW_REQUIRED='next react react-dom typescript eslint eslint-config-next'
+
+          ELIGIBLE=false
+          REASON="not eligible"
+
+          case "$UPDATE_TYPE" in
+            version-update:semver-patch)
+              ELIGIBLE=true
+              REASON="patch update"
+              ;;
+            version-update:semver-minor)
+              # Block if any dependency in the PR is in REVIEW_REQUIRED
+              ELIGIBLE=true
+              REASON="minor update"
+              for dep in $DEP_NAMES; do
+                for guarded in $REVIEW_REQUIRED; do
+                  if [ "$dep" = "$guarded" ]; then
+                    ELIGIBLE=false
+                    REASON="minor update on review-required package: $dep"
+                    break 2
+                  fi
+                done
+              done
+              ;;
+            version-update:semver-major)
+              ELIGIBLE=false
+              REASON="major update — human review required"
+              ;;
+          esac
+
+          echo "eligible=$ELIGIBLE" >> "$GITHUB_OUTPUT"
+          echo "reason=$REASON"    >> "$GITHUB_OUTPUT"
+          echo "## Dependabot auto-merge decision" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **update-type**: $UPDATE_TYPE"   >> "$GITHUB_STEP_SUMMARY"
+          echo "- **dependencies**: $DEP_NAMES"    >> "$GITHUB_STEP_SUMMARY"
+          echo "- **eligible**: $ELIGIBLE"         >> "$GITHUB_STEP_SUMMARY"
+          echo "- **reason**: $REASON"             >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Approve PR
+        if: steps.decide.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          REASON: ${{ steps.decide.outputs.reason }}
+        run: |
+          gh pr review --approve "$PR_URL" \
+            --body "Auto-approved by dependabot-auto-merge — $REASON"
+
+      - name: Enable auto-merge (queues until CI is green)
+        if: steps.decide.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --merge --delete-branch "$PR_URL"


### PR DESCRIPTION
Eliminates the weekly Monday dependabot triage cost. Auto-merges patch + non-framework minor PRs after CI passes. Groups npm patches/minors into one PR per Monday.

Major-version bumps and framework minors (next/react/typescript/eslint/eslint-config-next) still surface for human review.