### PR TITLE
fix(ci): skip DCO for Dependabot + drop approval from auto-merge

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -13,6 +13,11 @@ on:
 
 jobs:
   dco:
+    # Skip DCO for Dependabot PRs — the bot can't add Signed-off-by to its
+    # own commits, and the bumps it ships don't carry copyrightable
+    # contribution. A skipped job satisfies required status checks per
+    # GitHub's documented behavior, so this doesn't open a hole.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -93,17 +93,17 @@ jobs:
           echo "- **eligible**: $ELIGIBLE"         >> "$GITHUB_STEP_SUMMARY"
           echo "- **reason**: $REASON"             >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Approve PR
-        if: steps.decide.outputs.eligible == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          REASON: ${{ steps.decide.outputs.reason }}
-        run: |
-          gh pr review --approve "$PR_URL" \
-            --body "Auto-approved by dependabot-auto-merge — $REASON"
+      # NOTE: An "Approve PR" step is intentionally absent. The
+      # `futureenterprises` org has "Allow GitHub Actions to create and
+      # approve pull requests" disabled, so a `gh pr review --approve`
+      # call would fail. Instead, we configure branch protection on
+      # `main` to NOT require approving review for Dependabot PRs (they
+      # already require all required-status-checks to pass via auto-merge).
+      # `gh pr merge --auto` queues the merge for whenever protection is
+      # satisfied — that includes both CI green and any approval already
+      # present, but it does not REQUIRE the workflow to add an approval.
 
-      - name: Enable auto-merge (queues until CI is green)
+      - name: Enable auto-merge (queues until branch protection is satisfied)
         if: steps.decide.outputs.eligible == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes the two real failure modes observed on PRs #84 and #85: DCO can't sign-off bot commits (skip job for dependabot), and the auto-merge approve step fails because the org disables Actions PR approval (drop the approve step, rely on `gh pr merge --auto`).