### PR TITLE
seo: remove 'pending counsel review' from privacy meta description

### DIFF
--- a/app/legal/privacy/layout.js
+++ b/app/legal/privacy/layout.js
@@ -2,7 +2,9 @@ export const metadata = {
   title: 'Privacy Policy — EMILIA Protocol',
   description:
     'How EMILIA Protocol collects, uses, and protects personal data. ' +
-    'GDPR / CCPA / SOX-aligned. Working version pending final counsel review.',
+    'Aligned with GDPR, UK GDPR, and CCPA. Functions as the working ' +
+    'data processing addendum until an executed customer-specific DPA ' +
+    'supersedes it.',
   alternates: { canonical: '/legal/privacy' },
   openGraph: {
     title: 'EMILIA Protocol Privacy Policy',


### PR DESCRIPTION
Trailing fix for PR #91: the caveat survived in the meta description of /legal/privacy (indexed by Google, shown in Open Graph cards). Replaced with a concrete one-liner about the working-DPA function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)