### PR TITLE
ci: publish workflow for @emilia-protocol/verify

### DIFF
--- a/.github/workflows/publish-verify-sdk.yml
+++ b/.github/workflows/publish-verify-sdk.yml
@@ -1,0 +1,49 @@
+name: Publish Verify SDK
+
+# Opt every JavaScript-based action into the Node.js 24 runner.
+# GitHub forces this default in June 2026; doing it now eliminates the
+# deprecation-warning noise on every run and surfaces any Node-24 incompat
+# early. Affects actions/checkout, actions/setup-node, actions/upload-artifact, etc.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "verify-v*"
+
+jobs:
+  publish:
+    name: Publish @emilia-protocol/verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    defaults:
+      run:
+        working-directory: packages/verify
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "20"
+          registry-url: https://registry.npmjs.org
+
+      # Zero-dependency package — no install step. The package.json files
+      # array publishes only index.js, index.d.ts, README.md, and LICENSE.
+
+      - name: Run tests
+        run: node --test test.js
+
+      - name: Verify package contents
+        run: npm pack --dry-run
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
Adds a CI publish workflow for \`@emilia-protocol/verify\` (modeled exactly on the existing \`publish-typescript-sdk.yml\`). The package has been published manually following \`docs/operations/NPM-PUBLISH-CHECKLIST.md\`; this lifts the toil into CI and makes the release process auditable.

- Trigger: push tag \`verify-v*\` or manual \`workflow_dispatch\`
- Working directory: \`packages/verify\` (matches the npm \`repository.directory\` field)
- Zero-dependency package, so no \`npm install\` step
- Runs the existing \`node --test test.js\` (11 tests) before publishing
- \`npm pack --dry-run\` surfaces tarball contents in the run log

## Future release flow
\`\`\`bash
cd packages/verify
npm version patch
cd ../..
git push
git tag verify-v\$(jq -r .version packages/verify/package.json)
git push --tags
\`\`\`

## Test plan
- [x] Local: \`node --test test.js\` — 11/11 pass
- [x] Local: \`npm pack --dry-run\` shows expected 4-file tarball (index.js, index.d.ts, README.md, LICENSE)
- [ ] CI green on push
- [ ] Followup: tag \`ts-sdk-v0.9.0\` after this merges to publish the long-overdue TS SDK update (npm currently has v0.1.0; repo is v0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)