### PR TITLE
Track 3: instant revocation + continuous-eval (EP-REVOCATION-v1 + EP-EYE-SET-v1)

### DIFF
--- a/PIPs/PIP-011-revocation-continuous-eval.md
+++ b/PIPs/PIP-011-revocation-continuous-eval.md
@@ -1,0 +1,135 @@
+# PIP-011: Instant Revocation + Continuous-Eval — Signed Revocation Statement + Eye Security Event Token
+
+**Status:** Draft
+**Type:** Extension (additive)
+**Created:** 2026-06-14
+**Author(s):** Iman Schrock
+**Requires:** PIP-001 (Core Freeze)
+
+## Abstract
+
+This PIP defines an **additive profile** of two signed objects and their
+fail-closed verifier checks that close the two gaps a one-time
+authorization receipt cannot close by itself: **how a previously-valid
+authorization is withdrawn** (instant revocation) and **how a relying
+party learns mid-flight that the posture behind a long-lived
+authorization has degraded** (continuous evaluation). The two wire tags
+are:
+
+- **`EP-REVOCATION-v1`** — a detached, signed revocation statement that
+  binds a revoker's named, pinned key to an exact target
+  `{ target_type, target_id, action_hash }`, so a relying party can be
+  *handed* portable, offline-verifiable proof that a specific
+  authorization is revoked; and
+- **`EP-EYE-SET-v1`** — an Eye advisory emitted as a **Security Event
+  Token (RFC 8417)** in JWS-compact serialization (EdDSA), carrying a
+  CAEP-style posture-change event that is scope-bound, signed under a
+  pinned emitter key, and carries the **never-the-sole-gate** invariant
+  in-band, so a long-lived authorization can be tightened or revoked when
+  posture drops.
+
+Together they form the loop the agentic-trust roadmap names: *Eye detects
+a posture drop → emits a signed SET → a relying party issues a revocation
+→ verifiers that consult revocation fail closed.*
+
+The profile is **purely additive and by-composition only**. It does
+**not** modify `EP-RECEIPT-v1`, its JCS canonicalization, its Ed25519
+signature, or the frozen §6.3 offline-verification algorithm; it touches
+neither `packages/verify` nor `packages/issue`. Both objects live
+**outside** the frozen receipt: a verifier that does not understand them
+verifies the embedded receipt exactly as today. Verifying the profile
+introduces **no new trust root** — it imports the frozen `canonicalize()`
+as the single serialization source of truth and adds only local detached
+EdDSA / JWS verification primitives, which grant no trust by themselves.
+Both verifiers **fail closed**: a self-asserted, unpinned key confers
+nothing (mirroring `executor_key_pinned` in PIP-010 and `signer_key_unpinned`
+in the WYSIWYS profile).
+
+## Motivation
+
+EP receipts answer "did a named human authorize this exact action?" at a
+point in time. Two things they do not answer on their own:
+
+1. **Withdrawal.** Today revocation in EP is server-state only
+   (`commit.revokeCommit`, signoff revocation). There is no portable
+   artifact a relying party can be handed and check **offline** to prove
+   a previously-valid authorization is now revoked. `EP-REVOCATION-v1`
+   is that artifact.
+2. **Drift of posture under a long-lived authorization.** An agent
+   authorization that was sound when granted can become unsafe while it
+   is still valid. `EP-EYE-SET-v1` lets Eye emit a verifiable, scope-bound
+   posture-change signal a relying party can act on — without Eye ever
+   becoming a gate.
+
+## Specification (summary)
+
+Normative detail lives in `docs/EP-REVOCATION-SPEC.md` and
+`docs/EP-EYE-SET-SPEC.md`; the authoritative attack catalogues are
+`conformance/vectors/revocation.v1.json` and
+`conformance/vectors/eye-set.v1.json`.
+
+### EP-REVOCATION-v1 (`lib/revocation/revocation.js`)
+
+- `buildRevocation({ target, revoker_id, reason, signer })` mints a
+  statement over `canonicalize({ @version, target_type, target_id,
+  action_hash, revoker_id, revoked_at, reason })`, signed by the revoker.
+- `verifyRevocation(target, statement, opts)` fails closed unless: the
+  `@version` matches; the statement binds the **exact**
+  `(target_type, target_id, action_hash)` the verifier holds (revoking A
+  must never revoke B); `revoker_id` resolves to a key the verifier
+  **pinned** and the proof key equals it; `revoked_at` is present and
+  well-formed; the signature verifies under the pinned key over the
+  verifier-recomputed bytes; and (when `opts.maxAgeSeconds` is set)
+  freshness holds. `isRevoked(target, statements, opts)` returns true iff
+  a valid binding statement exists.
+
+### EP-EYE-SET-v1 (`lib/eye/eye-set.js`)
+
+- `buildEyeSet(advisory, { signer, audience, ... })` emits a JWS-compact
+  SET (`alg: EdDSA`, `typ: secevent+jwt`, `kid`) whose payload carries the
+  scope-bound `sub_id` (the advisory's `scope_binding_hash`, never a raw
+  ref) and a single CAEP-style event member with the non-attributable
+  advisory facts plus `never_sole_gate: true`. A `clear` (or non-actionable)
+  status is refused at build time.
+- `verifyEyeSet(setCompact, opts)` fails closed on: a non-EdDSA `alg`
+  (including `none` / algorithm confusion — checked first); a wrong `typ`;
+  an unpinned or substituted emitter key; a forged signature or a payload
+  tampered after signing (verified over the **presented** segments);
+  missing/ill-typed claims; an audience mismatch when `opts.audience` is
+  set; staleness when `opts.requireFresh` is set; a non-actionable status;
+  or a missing/non-true `never_sole_gate` marker. It returns an advisory
+  **posture** for the relying party to act on — never `allow`/`deny`,
+  never an authorization.
+
+## Honest residual (out of scope)
+
+- **Revocation freshness/completeness.** Offline verification proves a
+  revocation statement is authentic and binds its target. It does **not**
+  prove the relying party holds the *latest* revocation state — "has this
+  been revoked by a statement I do not hold?" is a freshness/transparency
+  problem (revocation feed / transparency log / short receipt TTL), like
+  OCSP/CRL, and is **out of scope** of the offline check. The artifact
+  answers "is THIS revocation real and for THIS target", not "is the
+  absence of a revocation trustworthy".
+- **SSF/CAEP/SET are prior art.** This profile does not claim
+  continuous-eval, the SET format, or the never-sole-gate invariant as
+  novel. The only contribution is the verifiable, scope-bound SET that
+  carries the invariant in-band, with the same redaction posture as the
+  Eye webhook notifier.
+- **A compromised emitter / revoker key** is out of scope; both rely on
+  the relying party pinning the correct key (identified-but-not-trusted).
+
+## Backwards compatibility
+
+Fully backwards compatible. No change to `EP-RECEIPT-v1` or the frozen
+verifier. Consumers that do not implement this PIP are unaffected; the
+two objects are independent, opt-in artifacts a relying party chooses to
+consult.
+
+## Reference implementation + conformance
+
+- `lib/revocation/revocation.js`, `lib/eye/eye-set.js`
+- `conformance/vectors/revocation.v1.json`,
+  `conformance/vectors/eye-set.v1.json`
+- `tests/revocation.test.js`, `tests/eye-set.test.js` (live-crypto
+  adversarial suites; every catalogued vector asserted by id)

--- a/conformance/vectors/eye-set.v1.json
+++ b/conformance/vectors/eye-set.v1.json
@@ -1,0 +1,86 @@
+{
+  "@version": "EP-EYE-SET-VECTORS-v1",
+  "wire_tag": "EP-EYE-SET-v1",
+  "spdx": "Apache-2.0",
+  "spec": "docs/EP-EYE-SET-SPEC.md",
+  "implementation": "lib/eye/set.js (buildEyeSet, verifyEyeSet)",
+  "description": "Negative + positive conformance vectors for the EP-EYE-SET-v1 profile: an Eye continuous-eval advisory carried as an RFC 8417 Security Event Token (CAEP-style) in JWS-COMPACT serialization (header.payload.signature). buildEyeSet(advisory, { signer, audience }) emits a secevent+jwt with header { alg:'EdDSA', typ:'secevent+jwt', kid }, payload { iss, iat, jti, aud, sub_id (the scope-bound scope_binding_hash, NEVER a raw subject/actor/target identifier — same redaction posture as lib/eye/webhook-notify.js), events: { '<CAEP-style event URI>': { status, reason_codes, recommended_policy_action, advisory_hash, expires_at, never_sole_gate:true } } }, signed EdDSA via node:crypto over the JWS signing input. verifyEyeSet(setCompact, opts) FAILS CLOSED: it validates the JWS signature under the key PINNED for the kid/iss (an unpinned/self-asserted kid confers nothing), rejects 'alg':'none' and algorithm confusion, requires typ='secevent+jwt' and the required SET claims, enforces audience match when opts.audience is set, enforces freshness (exp not past / iat not too old) when required, and requires the in-band never_sole_gate:true marker. verifyEyeSet NEVER returns allow/deny and NEVER authorizes — it returns the advisory POSTURE for a relying party to ACT on (tighten/revoke). A 'clear' status is not an actionable posture-change event and MUST NOT be emitted as one. The cryptographic material is minted LIVE in tests/eye-set.test.js (real Ed25519 keys, real EdDSA signatures over the real JWS signing input) so every negative is a genuine forgery / tamper / confusion attempt, not hand-edited JSON that fails for an unrelated reason. This file is the AUTHORITATIVE catalogue: each id is asserted by name in the test.",
+  "prior_art_note": "HONEST BOUNDARY. SET (RFC 8417), JWS (RFC 7515), and OpenID SSF/CAEP — including continuous evaluation and the 'a signal is never the sole authorization gate' posture — are PRIOR ART. This profile does NOT claim continuous-eval, the SET envelope, or the never-sole-gate invariant itself as novel; they are documented prior art (see docs/EMILIA-EYE-ADVISORY-SPEC.md Section 9.1 / Section 11). The only contribution here is the verifiable, scope-bound SET that carries the never-sole-gate invariant IN-BAND (events[...].never_sole_gate:true, re-checked by the verifier) together with the redaction posture (sub_id is the re-derivable scope_binding_hash, never a raw identifier).",
+  "residual_risk": "An Eye SET INFORMS a relying party; it is NEVER the sole gate and NEVER authorizes. verifyEyeSet returns a POSTURE (tighten / revoke / hold) for the relying party to combine, tighten-only, with its own base decision — it never returns allow/deny. What this profile PROVES: a SET that verifies under the PINNED emitter key carries an attributable, scope-bound, fresh advisory posture that has not been tampered with since signing, and that explicitly marks itself never_sole_gate. What it does NOT prove, and is OUT OF SCOPE: (1) A FULLY COMPROMISED EMITTER. A compromised Eye operator holding the pinned signing key can emit a truthful-looking SET for a posture it did not actually compute (over- or under-tightening). Pinning bounds this to a NAMED key whose claims are attributable; it does not make a compromised emitter's claims true. The residual is addressed only by emitter host/TEE attestation and key-management hygiene, a layer ABOVE this envelope. (2) SOLE-GATE MISUSE BY THE RELYING PARTY. The never_sole_gate marker is carried and re-checked in-band, but a relying party that ignores its own base policy and reads the posture AS authorization defeats the invariant; that is an integration error this envelope cannot prevent by mathematics. (3) Under-tightening from a WITHHELD or stale SET. A missing SET is treated by a conformant relying party as 'no posture change' (fail-open as an input, never as a relax of the base gate); staleness never relaxes. Do not read valid:true as 'allow'.",
+  "must_reject": [
+    {
+      "id": "a_forged_jws_signature",
+      "title": "Forged JWS signature over the signing input",
+      "attack": "header.payload are a well-formed elevated SET, but the signature segment is a real Ed25519 signature over UNRELATED bytes (or random bytes), not over the ASCII signing input b64u(header)+'.'+b64u(payload). The verifier reconstructs the signing input from the presented header.payload and verifies under the pinned key; the signature does not verify. A verifier that trusts the segment without recomputing the signing input would accept it.",
+      "expected": { "valid": false, "failing_check": "jws_signature_valid" }
+    },
+    {
+      "id": "b_unpinned_emitter_kid",
+      "title": "SET signed by an UNPINNED emitter key (self-asserted kid)",
+      "attack": "A structurally valid elevated SET whose signature genuinely verifies under the keypair the producer minted, but the header.kid / payload.iss pair is NOT in the verifier's pinned key map (opts.pinnedKeys has no key for it). A self-asserted kid confers nothing: anyone can mint a keypair and a correct-looking SET. Fail closed on the unpinned emitter. Mirrors execution-integrity f_unpinned_executor_key and wysiwys c3_unpinned_display_signer_key.",
+      "expected": { "valid": false, "failing_check": "emitter_key_pinned" }
+    },
+    {
+      "id": "c_wrong_pinned_key_substitution",
+      "title": "Wrong pinned key — emitter-key substitution",
+      "attack": "The kid/iss IS pinned, but the SET was signed by a DIFFERENT private key than the one pinned for that kid/iss. The signature math is internally consistent against the producer's own public key, yet fails under the key the verifier PINNED for this kid. Key substitution does not pass. The verifier verifies only under the pinned key, never under a producer-supplied public key.",
+      "expected": { "valid": false, "failing_check": "jws_signature_valid" }
+    },
+    {
+      "id": "d_alg_none_confusion",
+      "title": "'alg':'none' / algorithm confusion",
+      "attack": "The JOSE header advertises alg:'none' (unsecured JWS) with an empty signature segment, or advertises a non-EdDSA alg to provoke confusion. The verifier MUST reject any alg other than the pinned 'EdDSA' BEFORE attempting verification and MUST never treat an unsecured token as signed. A verifier that branched on the attacker-controlled alg would accept an unsigned token.",
+      "expected": { "valid": false, "failing_check": "alg_is_eddsa" }
+    },
+    {
+      "id": "e_tampered_payload_status_downgrade",
+      "title": "Tampered payload — status downgraded after signing",
+      "attack": "A genuine elevated/review_required SET is signed by the pinned key, then the payload segment is re-encoded with events[...].status downgraded (e.g. review_required -> caution, or elevated -> clear) to relax the posture a relying party would take. Because the signature covers the signing input over the ORIGINAL payload, re-deriving the signing input from the TAMPERED payload makes the signature fail. The downgrade is detected as a signature failure, not silently honored.",
+      "expected": { "valid": false, "failing_check": "jws_signature_valid" }
+    },
+    {
+      "id": "f_audience_mismatch",
+      "title": "Audience mismatch when opts.audience is set",
+      "attack": "A correctly signed, fresh elevated SET whose payload.aud is 'rp:bank-a', presented to a verifier that pins opts.audience='rp:bank-b'. The SET was minted for a different relying party; replaying it at the wrong audience MUST be rejected when an expected audience is supplied. (When opts.audience is unset the audience is not gated — see z2.)",
+      "expected": { "valid": false, "failing_check": "audience_match" }
+    },
+    {
+      "id": "g_expired_set_exp_past",
+      "title": "Expired SET — exp in the past when freshness required",
+      "attack": "A correctly signed elevated SET whose events[...].expires_at (and/or a payload exp) is in the PAST, verified with opts.requireFresh (or opts.now beyond exp). A stale advisory MUST NOT carry a live posture: an expired SET is rejected on freshness, never used to tighten OR relax. Mirrors the advisory freshness MUST in the Eye spec (consumers treat a past-expires_at advisory as stale).",
+      "expected": { "valid": false, "failing_check": "fresh" }
+    },
+    {
+      "id": "h_iat_too_old",
+      "title": "Stale issuance — iat older than the allowed window when freshness required",
+      "attack": "A correctly signed elevated SET whose iat is far in the past (older than opts.maxAgeSec) even though exp parsing alone might pass, verified with freshness required. An ancient issuance is treated as stale and rejected so an attacker cannot replay a long-lived old SET to drive posture. Freshness is enforced on BOTH iat age and exp.",
+      "expected": { "valid": false, "failing_check": "fresh" }
+    },
+    {
+      "id": "i_missing_never_sole_gate_marker",
+      "title": "Missing the never_sole_gate marker",
+      "attack": "A correctly signed, fresh elevated SET under the pinned key whose event object OMITS never_sole_gate (or sets it to a non-true value). The in-band invariant is load-bearing: a posture-change event that does not carry never_sole_gate:true is malformed for this profile and MUST be rejected, so a relying party can never be handed a posture that fails to assert it is not the sole gate.",
+      "expected": { "valid": false, "failing_check": "never_sole_gate_present" }
+    },
+    {
+      "id": "j_clear_status_emitted_as_event",
+      "title": "'clear' status emitted as an actionable posture-change event",
+      "attack": "A correctly signed, fresh SET under the pinned key whose event carries status:'clear'. 'clear' is the default-path, no-change posture (Eye spec Section 6: clear -> allow_normal_flow, no requirement change); it is NOT a posture-CHANGE event and MUST NOT be emitted as one. Permitting a signed 'clear' event would let a replayed/forged 'clear' be read as an affirmative 'authorized' signal — exactly the sole-gate misuse the profile refuses. buildEyeSet MUST refuse to emit it and verifyEyeSet MUST reject it.",
+      "expected": { "valid": false, "failing_check": "status_is_actionable" }
+    }
+  ],
+  "must_accept": [
+    {
+      "id": "z_well_formed_elevated_set_pinned_fresh",
+      "title": "Well-formed elevated SET — verifies under the pinned key, returns the posture",
+      "shape": "A well-formed 'elevated' advisory (reason_codes non-empty, recommended_policy_action present, scope_binding_hash present, fresh expires_at). buildEyeSet(advisory, { signer, audience:'rp:bank-a' }) emits a secevent+jwt: header { alg:'EdDSA', typ:'secevent+jwt', kid }, payload { iss, iat, jti, aud:'rp:bank-a', sub_id = the scope_binding_hash (NOT a raw identifier), events:{ '<event-uri>': { status:'elevated', reason_codes, recommended_policy_action, advisory_hash, expires_at, never_sole_gate:true } } }, signed EdDSA over the JWS signing input via node:crypto. verifyEyeSet(setCompact, { pinnedKeys, audience:'rp:bank-a', requireFresh:true }) verifies under the PINNED key, confirms typ + required claims + audience + freshness + never_sole_gate:true, and returns the advisory POSTURE (status, reason_codes, recommended_policy_action) for the relying party to ACT on — NOT allow/deny and NOT an authorization.",
+      "expected": { "valid": true }
+    },
+    {
+      "id": "z2_well_formed_review_required_no_audience_pin",
+      "title": "Well-formed review_required SET — accepted with no audience pin",
+      "shape": "A well-formed 'review_required' advisory emitted as a SET and verified with opts.audience UNSET (audience not gated) but with the pinned key, required claims, freshness, and never_sole_gate:true all satisfied. The verifier accepts and returns the review_required posture (the most-tightening recommended_policy_action, e.g. require_signoff/escalate). Not gating the audience is a deliberate verifier choice; everything else still fails closed. The returned value is a posture for the relying party to combine tighten-only with its base decision — never allow/deny.",
+      "expected": { "valid": true }
+    }
+  ]
+}

--- a/conformance/vectors/revocation.v1.json
+++ b/conformance/vectors/revocation.v1.json
@@ -1,0 +1,79 @@
+{
+  "@version": "EP-REVOCATION-STATEMENT-VECTORS-v1",
+  "wire_tag": "EP-REVOCATION-v1",
+  "spdx": "Apache-2.0",
+  "spec": "docs/EP-REVOCATION-SPEC.md",
+  "implementation": "lib/revocation/statement.js (buildRevocation, verifyRevocation, isRevoked)",
+  "description": "Attack-catalogue-first negative + positive conformance vectors for the EP-REVOCATION-v1 portable revocation profile. An EP-REVOCATION-v1 statement is an ADDITIVE, signed, OFFLINE-verifiable claim that a previously-valid authorization is now revoked. It binds a target { target_type: receipt|commit|delegation, target_id, action_hash (or commit hash) } and carries revoker_id + revoked_at + reason, signed by the revoker's Ed25519 key. verifyRevocation(target, statement, opts) FAILS CLOSED: it accepts only a statement whose proof verifies under a key PINNED for revoker_id (identified-but-not-trusted — an unpinned/self-asserted key confers NOTHING; mirrors lib/execution/integrity.js executor_key_pinned and lib/wysiwys/render.js signer_key_unpinned), that BINDS the exact target the verifier is handed (BOTH target_id and action_hash must match — a statement for action A cannot revoke action B), whose @version matches, and whose revoked_at is present (and, when opts requires, within an allowed freshness window). isRevoked(target, statements, opts) returns true IFF a VALID binding revocation statement exists for the target. The cryptographic material is minted LIVE in tests/revocation.test.js because the revocation proofs must be genuine Ed25519 signatures over canonical bytes; every negative here is a real forgery, never hand-edited JSON that fails for an unrelated reason. This file is the AUTHORITATIVE catalogue of the attacks every conformant verifier MUST reject (valid:false) and the well-formed cases it MUST accept (valid:true). Each id here is asserted by name in the test.",
+  "residual_risk": "Offline verification proves the revocation statement is AUTHENTIC and BINDS the exact target. It does NOT prove you hold the LATEST revocation state. 'Has this authorization been revoked by a statement I do not hold?' is a freshness / transparency problem — exactly the gap OCSP/CRL exist to fill — and is OUT OF SCOPE of the offline check. A relying party that needs liveness MUST consult a revocation feed / transparency log, or rely on a short receipt TTL; the offline artifact answers 'is THIS revocation real and for THIS target', NOT 'is the absence of a revocation trustworthy'. Treating absence-of-statement as proof-of-not-revoked is a relying-party error this profile cannot prevent. The opts freshness window bounds how stale a PRESENTED statement may be; it does nothing about a revocation that was never handed to the verifier. EXPERIMENTAL; governed by an Extension PIP; no production or customer claim; reports no metrics; this profile makes no completeness or liveness claim.",
+  "must_reject": [
+    {
+      "id": "a_forged_signature",
+      "title": "Forged / broken revoker signature",
+      "attack": "The statement binds the exact target and names a pinned revoker_id, but its proof.signature_b64u does not verify under the pinned revoker key (bytes flipped, or produced by a different private key than the one whose public key is pinned). The only added trust is the revoker's attested signature; if it does not verify under the pinned key, the statement is rejected.",
+      "expected": { "valid": false, "failing_check": "revoker_signature_valid" }
+    },
+    {
+      "id": "b_unpinned_revoker_key",
+      "title": "Revocation signed by an UNPINNED revoker key (self-asserted)",
+      "attack": "A structurally valid statement whose proof verifies under the key embedded in proof.public_key, but revoker_id is NOT in the verifier's pinned revokerKeys map (or no registry is supplied). The revoker is identified but NOT trusted: a self-asserted key the verifier never pinned confers nothing — anyone can mint a keypair and sign 'X is revoked'. Fail closed; never fall back to the self-asserted public_key. Mirrors lib/execution/integrity.js f_unpinned_executor_key and lib/wysiwys/render.js signer_key_unpinned.",
+      "expected": { "valid": false, "failing_check": "revoker_key_pinned" }
+    },
+    {
+      "id": "c_wrong_pinned_key_substitution",
+      "title": "Revocation signed by the WRONG pinned key (key substitution)",
+      "attack": "revoker_id maps to a pinned key, and the signature verifies under the key carried in the proof — but the proof.public_key is NOT the key pinned for that revoker_id (a different, attacker-controlled key substituted in). Signature math passes; key binding fails. The verifier pins by revoker_id and rejects a proof whose public_key differs from the pinned key.",
+      "expected": { "valid": false, "failing_check": "revoker_key_pinned" }
+    },
+    {
+      "id": "d_bound_to_different_target_id",
+      "title": "Statement bound to a DIFFERENT target_id",
+      "attack": "A genuine, validly-signed revocation for target_id R-A is presented against the target the verifier is handed, R-B (same target_type). The statement is being replayed/stapled onto another authorization. The verifier rejects when the statement's target_id != the handed target's target_id.",
+      "expected": { "valid": false, "failing_check": "target_bound" }
+    },
+    {
+      "id": "e_bound_to_different_action_hash",
+      "title": "Statement bound to a different action_hash (revoke-A-presented-for-B)",
+      "attack": "A genuine, validly-signed revocation whose target_id happens to match, but whose action_hash binds action A while the verifier is handed the target for action B. Revoking A must NOT revoke B. The verifier requires BOTH target_id AND action_hash to match the handed target and rejects on the action_hash mismatch.",
+      "expected": { "valid": false, "failing_check": "target_bound" }
+    },
+    {
+      "id": "f_wrong_version",
+      "title": "Wrong @version",
+      "attack": "The statement binds the exact target and is validly signed, but its @version is not EP-REVOCATION-v1 (e.g. a future/forked tag). A verifier that ignored @version could be tricked by a statement minted under different semantics. Fail closed on version mismatch.",
+      "expected": { "valid": false, "failing_check": "version" }
+    },
+    {
+      "id": "g_tampered_fields_after_signing",
+      "title": "Tampered fields after signing (revoked_at / reason changed -> sig over other bytes)",
+      "attack": "A genuine statement is signed, then revoked_at and/or reason are edited in the presented object. The proof now signs DIFFERENT bytes than the ones the verifier independently recomputes from the presented {@version, target_type, target_id, action_hash, revoker_id, revoked_at, reason}. The verifier recomputes the signed payload from the presented fields and rejects; a verifier that trusts a producer-supplied signed_payload blob would accept it.",
+      "expected": { "valid": false, "failing_check": "signature_binds_statement" }
+    },
+    {
+      "id": "h_missing_revoked_at",
+      "title": "Missing revoked_at (no freshness anchor)",
+      "attack": "A validly-signed statement that binds the exact target but omits revoked_at entirely. Without a revoked_at there is no anchor for replay/freshness reasoning and no record of WHEN the revocation took effect. Fail closed: revoked_at MUST be present and well-formed.",
+      "expected": { "valid": false, "failing_check": "revoked_at_present" }
+    },
+    {
+      "id": "i_stale_beyond_freshness_window",
+      "title": "Stale beyond an opts freshness window (optional)",
+      "attack": "A genuine, validly-signed, exactly-bound statement whose revoked_at is older than opts.maxAgeSeconds relative to opts.now. When the relying party demands a freshness window, a statement older than that window is rejected. NOTE: this bounds how stale a PRESENTED statement may be; it does NOT close the absence-of-statement gap (see residual_risk). Only applies when opts.maxAgeSeconds is set.",
+      "expected": { "valid": false, "failing_check": "freshness" }
+    }
+  ],
+  "must_accept": [
+    {
+      "id": "z_well_formed_binding_revocation",
+      "title": "Well-formed revocation, pinned revoker, exact target binding",
+      "shape": "An EP-REVOCATION-v1 statement over target { target_type, target_id, action_hash } that EXACTLY matches the target the verifier is handed; revoked_at present and (when a window is required) within opts.maxAgeSeconds of opts.now; @version correct; proof is a real Ed25519 signature over the independently-recomputed canonical bytes, verifying under the key PINNED for revoker_id. verifyRevocation -> valid:true and isRevoked(target, [statement], opts) -> true. This proves the revocation is AUTHENTIC and binds THIS target; it does NOT prove this is the LATEST revocation state (residual: revocation feed / transparency log, out of scope).",
+      "expected": { "valid": true }
+    },
+    {
+      "id": "z2_is_revoked_true_among_unrelated",
+      "title": "isRevoked true when one valid binding statement sits among unrelated ones",
+      "shape": "A set of statements is handed to isRevoked(target, statements, opts): one is the valid binding revocation for the handed target (as in z); the others are valid revocations for DIFFERENT targets (different target_id and/or action_hash). isRevoked returns true because at least one VALID binding statement exists for the target, and ignores the unrelated ones. Confirms the aggregate helper does not require the matching statement to be first or alone.",
+      "expected": { "valid": true }
+    }
+  ]
+}

--- a/docs/EP-EYE-SET-SPEC.md
+++ b/docs/EP-EYE-SET-SPEC.md
@@ -1,0 +1,357 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright EMILIA Protocol, Inc. -->
+
+# EP-EYE-SET — Eye Continuous-Eval as a Security Event Token (SPECIFICATION PROPOSAL)
+
+**Status:** Draft / Experimental specification proposal
+**Type:** Extension (additive over EP Core v1.0; composition target named in EMILIA-EYE-ADVISORY-SPEC §9.1)
+**Requires:** PIP-001 (EP Core v1.0 Freeze), EP-RECEIPT-v1; `docs/EMILIA-EYE-ADVISORY-SPEC.md`
+**Wire tag:** `EP-EYE-SET-v1`
+**Token type:** `secevent+jwt` (RFC 8417 Security Event Token, JWS-COMPACT)
+**Reference implementation:** `lib/eye/set.js` (`buildEyeSet`, `verifyEyeSet`)
+**Conformance vectors:** `conformance/vectors/eye-set.v1.json`
+**Conformance tests:** `tests/eye-set.test.js`
+
+> This is a **specification proposal** plus a **reference implementation**. It is
+> **experimental**. It is **not** a production claim, asserts **no** customers, and
+> reports **no** metrics. It MUST be ratified by a PIP before it can be called part
+> of the protocol. It adds **no new trust assumptions** beyond a single detached
+> EdDSA verification of the Eye emitter's claim under a **pinned** key — which
+> grants no authority on its own.
+>
+> **An Eye SET INFORMS; it is NEVER the sole gate and NEVER authorizes.**
+> `verifyEyeSet()` returns an advisory **posture** for a relying party to *act on*
+> (tighten / revoke / hold). It **never** returns allow/deny. Read
+> [§7 Residual Risk](#7-residual-risk--out-of-scope) before relying on anything here.
+
+---
+
+## 1. Abstract
+
+The Eye advisory spec (`docs/EMILIA-EYE-ADVISORY-SPEC.md`) defines a computed,
+per-scope **advisory** — `status` (`clear` | `caution` | `elevated` |
+`review_required`), `reason_codes`, `recommended_policy_action`,
+`scope_binding_hash`, `advisory_hash`, `issued_at`, `expires_at` — and is explicit
+(§9) that the v1 advisory is **unsigned**: its authenticity rests on the
+authenticated channel, and its durable verifiable record is the EP receipt. §9.1
+names a **forward-compatible path**: carry the advisory as a **Security Event Token
+(RFC 8417)** JWS, and transport it CAEP-style, *supplying the verifiable
+scope-binding and the "never the sole gate" invariant that SSF/CAEP deliberately
+leave undefined.*
+
+This profile **builds that SET emission**, additively, without touching the frozen
+Core:
+
+1. `buildEyeSet(advisory, { signer, audience })` — emits the advisory as a
+   `secevent+jwt` in **JWS-COMPACT** serialization (`header.payload.signature`),
+   signed **EdDSA** via `node:crypto`. No new dependency.
+
+2. `verifyEyeSet(setCompact, opts)` — a **fail-closed** verifier that validates the
+   JWS under a key **pinned for the kid/iss**, rejects `alg:'none'` / algorithm
+   confusion, checks `typ`, the required SET claims, audience (when pinned),
+   freshness (when required), and the **in-band `never_sole_gate:true` marker** —
+   then returns the advisory **posture**, never allow/deny.
+
+The redaction posture of `lib/eye/webhook-notify.js` is reused: the SET's subject
+identifier (`sub_id`) is the re-derivable **`scope_binding_hash`**, **never** a raw
+`subject_ref` / `actor_ref` / `target_ref` / `issuer_ref`.
+
+### 1.1 Honest boundary — what is prior art vs. what is contributed
+
+**Prior art (NOT claimed novel here):** SET (RFC 8417), JWS (RFC 7515), and OpenID
+SSF/CAEP — including continuous evaluation *and* the posture that a signal "is never
+the sole authorization gate." The never-sole-gate invariant itself is documented
+prior art (Eye spec §8, §9.1, §11). **Contribution:** the *verifiable, scope-bound*
+SET that carries the never-sole-gate invariant **in-band** (an event member
+`never_sole_gate:true`, re-checked by the verifier) together with the **redaction
+posture** (`sub_id` = `scope_binding_hash`, never a raw identifier). Nothing in the
+RFC 8417 / JWS path is reinvented.
+
+---
+
+## 2. Relationship to the Frozen Core (additive, no modification)
+
+The EP Core is frozen under **PIP-001**. This profile:
+
+- **Does not** modify the `EP-RECEIPT-v1` wire format, canonicalization, or
+  signature path; does not touch `packages/verify` or `packages/issue`.
+- **Imports** the frozen `canonicalize()` from `@emilia-protocol/issue`
+  (`lib/eye/set.js` → `../../packages/issue/index.js`, exactly as
+  `lib/provenance/chain.js` and `lib/execution/integrity.js` do) wherever canonical
+  bytes are needed; it re-implements **nothing** cryptographic of the receipt path.
+- Carries the SET **alongside** Eye's transport — it is an emission *of the
+  advisory*, not a mutation of the receipt. The advisory recorded inside an
+  `EP-RECEIPT-v1` claim context remains the durable record; the SET is an
+  independently verifiable, attributable copy of the same non-attributable facts.
+- Does **not** make Eye a gate. The Eye spec's monotonicity / tighten-only
+  contract (§6, §7.4, §8) is unchanged: a non-`clear` posture can only ever
+  **tighten** a relying party's base decision, never relax it.
+
+---
+
+## 3. The SET emission (`buildEyeSet`)
+
+### 3.1 Signature
+
+```
+buildEyeSet(advisory, { signer, audience }) -> "<b64u(header)>.<b64u(payload)>.<b64u(signature)>"
+```
+
+- `advisory` — an `eye-advisory-v1`-shaped object. Its `status` MUST be an
+  **actionable posture-change** status (`caution` | `elevated` | `review_required`).
+  A `clear` status is the default-path, no-change posture and **MUST NOT** be
+  emitted as a posture-change event (§3.4).
+- `signer` — `{ kid, privateKey }` (an Ed25519 private key, `node:crypto`
+  `KeyObject` or equivalent). The `kid` names the emitter key a relying party will
+  pin.
+- `audience` — the intended relying party identifier, placed in `aud`.
+
+### 3.2 JOSE header
+
+```json
+{ "alg": "EdDSA", "typ": "secevent+jwt", "kid": "<emitter kid>" }
+```
+
+`alg` is fixed to `EdDSA`. `typ` is fixed to `secevent+jwt` (RFC 8417 §2.3). `kid`
+identifies the pinned emitter key.
+
+### 3.3 SET payload (claims)
+
+```json
+{
+  "iss": "<emitter issuer id>",
+  "iat": 1711393200,
+  "jti": "<unique token id>",
+  "aud": "<relying-party id>",
+  "sub_id": "sha256:<scope_binding_hash>",
+  "events": {
+    "https://schemas.emiliaprotocol.ai/secevent/eye-advisory": {
+      "status": "elevated",
+      "reason_codes": ["device_fingerprint_changed", "high_severity_signal_active"],
+      "recommended_policy_action": "step_up_auth",
+      "advisory_hash": "sha256:<hex>",
+      "expires_at": "2026-03-25T20:00:00Z",
+      "never_sole_gate": true
+    }
+  }
+}
+```
+
+- `iss`, `iat`, `jti`, `aud` are standard SET/JWT claims. `iat` is seconds since
+  epoch; `jti` is a unique identifier for replay/dedup.
+- **`sub_id` is the scope-bound `scope_binding_hash`** — a re-derivable SHA-256 over
+  the scope fields, **never** a raw `subject_ref` / `actor_ref` / `target_ref` /
+  `issuer_ref`. This is the same "fact, not opinion" posture as
+  `lib/eye/webhook-notify.js#redactAdvisory`: a relying party that knows the scope
+  can re-derive `sub_id`; it leaks nothing attributable on its own.
+- **`events`** is keyed by a single CAEP-style **event URI**
+  (`https://schemas.emiliaprotocol.ai/secevent/eye-advisory`). The event member
+  carries **only non-attributable advisory facts**: `status`, `reason_codes`,
+  `recommended_policy_action`, `advisory_hash`, `expires_at`, and the explicit
+  **`never_sole_gate: true`** marker.
+- The event member carries **no** raw identifiers, no transaction volumes, no
+  evidence contents, and no allow/deny verdict — mirroring the webhook redaction
+  contract.
+
+### 3.4 `clear` is not an event
+
+`buildEyeSet` **MUST refuse** to emit a SET for `status:'clear'`. `clear` maps to
+`allow_normal_flow` / no requirement change (Eye spec §6); emitting it as a signed
+posture-change event would let a replayed or forged `clear` be read as an
+affirmative "authorized" signal — exactly the sole-gate misuse the profile refuses.
+A `clear` (or unknown) status is a build-time rejection.
+
+### 3.5 Signing
+
+The signature is **EdDSA over the JWS signing input** — the ASCII string
+`b64u(header) + "." + b64u(payload)` (RFC 7515 §5.1) — produced with `node:crypto`.
+b64u is base64url **without** padding. No new dependency is introduced.
+
+---
+
+## 4. The verifier (`verifyEyeSet`) — FAIL CLOSED
+
+```
+verifyEyeSet(setCompact, opts) -> {
+  valid,            // boolean
+  checks,           // { alg_is_eddsa, emitter_key_pinned, jws_signature_valid,
+                    //   typ_ok, claims_present, audience_match, fresh,
+                    //   never_sole_gate_present, status_is_actionable }
+  errors,           // string[]
+  posture           // present only when valid:true — see §4.2; NEVER allow/deny
+}
+```
+
+`opts`:
+
+| Option | Meaning |
+| --- | --- |
+| `pinnedKeys` | **Required.** Map from `(kid` and/or `iss)` → the pinned Ed25519 public key. An emitter not present here is **unpinned** and rejected. |
+| `audience` | When set, `payload.aud` MUST equal it; when unset, audience is not gated. |
+| `requireFresh` | When set (or by relying-party policy), `iat`/`exp` freshness is enforced. |
+| `maxAgeSec` | Maximum `iat` age when freshness is required. |
+| `now` | Injectable clock (seconds) for deterministic tests. |
+
+Given the compact SET, the verifier (each step fail-closed):
+
+1. **Parse & `alg` gate.** Split on `.`; decode the header. **REJECT** any `alg`
+   other than `EdDSA` — including `alg:'none'` and any non-EdDSA value — **before**
+   any verification. An unsecured token is never treated as signed.
+   (`alg_is_eddsa`)
+2. **`typ` gate.** `typ` MUST be `secevent+jwt`. (`typ_ok`)
+3. **Pin the emitter key.** Resolve the public key from `opts.pinnedKeys` for the
+   header `kid` / payload `iss`. If there is no pinned key, **REJECT** — a
+   self-asserted `kid` confers nothing (mirrors execution-integrity
+   `f_unpinned_executor_key`, wysiwys `c3_unpinned_display_signer_key`).
+   (`emitter_key_pinned`)
+4. **Verify the JWS signature.** Recompute the signing input
+   `b64u(header) + "." + b64u(payload)` from the **presented** header/payload and
+   verify the signature under the **pinned** key only — never under a
+   producer-supplied public key. A forged signature, a wrong/substituted key, or a
+   payload **tampered after signing** (e.g. a status downgrade) all fail here.
+   (`jws_signature_valid`)
+5. **Required claims.** `iss`, `iat`, `jti`, `aud`, `sub_id`, and exactly one
+   `events` member carrying `status`, `reason_codes`, `recommended_policy_action`,
+   `advisory_hash`, `expires_at` MUST be present and well-typed. (`claims_present`)
+6. **Audience.** When `opts.audience` is set, `payload.aud` MUST equal it; otherwise
+   **REJECT**. (`audience_match`)
+7. **Freshness.** When required, `expires_at`/`exp` MUST not be in the past and
+   `iat` MUST not be older than `maxAgeSec`. A stale SET is rejected, never used to
+   tighten **or** relax. (`fresh`)
+8. **Actionable status.** The event `status` MUST be `caution` | `elevated` |
+   `review_required`. A signed `clear` event is **REJECTED**.
+   (`status_is_actionable`)
+9. **Never-sole-gate marker.** The event member MUST carry `never_sole_gate: true`.
+   Its absence (or a non-`true` value) is a **rejection**. (`never_sole_gate_present`)
+
+`valid = AND(all gating checks)`.
+
+### 4.1 What the verifier NEVER does
+
+`verifyEyeSet` **never** returns `allow` / `deny` and **never** authorizes. There is
+no decision vocabulary in its output. It returns a **posture** the relying party
+combines, **tighten-only**, with its own base decision (Eye spec §7.4). The
+never-sole-gate invariant is therefore carried **in-band** (the marker) *and*
+enforced **structurally** (the verifier exposes no allow/deny path).
+
+### 4.2 The returned posture (on `valid:true`)
+
+```json
+{
+  "status": "elevated",
+  "reason_codes": ["device_fingerprint_changed", "high_severity_signal_active"],
+  "recommended_policy_action": "step_up_auth",
+  "scope_binding_hash": "sha256:<hex>",
+  "advisory_hash": "sha256:<hex>",
+  "expires_at": "2026-03-25T20:00:00Z",
+  "never_sole_gate": true
+}
+```
+
+This is **advice**, not a command (Eye spec §6). The relying party MUST recompute
+`scope_binding_hash` against the action it is gating (Eye spec §7.3) and apply the
+posture tighten-only. It MUST NOT read this as authorization.
+
+---
+
+## 5. Conformance vectors
+
+`conformance/vectors/eye-set.v1.json` is the authoritative catalogue; every id is
+asserted by name in `tests/eye-set.test.js`. The negatives are minted with **real**
+Ed25519 keys and **real** EdDSA signatures over the **real** JWS signing input, so
+each is a genuine forgery / tamper / confusion attempt, not hand-edited JSON.
+
+| Vector id | Scenario | Verdict | Gating check |
+| --- | --- | --- | --- |
+| `a_forged_jws_signature` | Signature over unrelated bytes | reject | `jws_signature_valid` |
+| `b_unpinned_emitter_kid` | Self-asserted, unpinned kid | reject | `emitter_key_pinned` |
+| `c_wrong_pinned_key_substitution` | Signed by a different key than pinned | reject | `jws_signature_valid` |
+| `d_alg_none_confusion` | `alg:'none'` / algorithm confusion | reject | `alg_is_eddsa` |
+| `e_tampered_payload_status_downgrade` | Status downgraded after signing | reject | `jws_signature_valid` |
+| `f_audience_mismatch` | `aud` ≠ `opts.audience` | reject | `audience_match` |
+| `g_expired_set_exp_past` | `expires_at` in the past | reject | `fresh` |
+| `h_iat_too_old` | `iat` older than `maxAgeSec` | reject | `fresh` |
+| `i_missing_never_sole_gate_marker` | Marker absent / not `true` | reject | `never_sole_gate_present` |
+| `j_clear_status_emitted_as_event` | `clear` emitted as posture event | reject | `status_is_actionable` |
+| `z_well_formed_elevated_set_pinned_fresh` | Pinned, fresh, audience-matched, marked | accept | — |
+| `z2_well_formed_review_required_no_audience_pin` | Pinned, fresh, no audience pin, marked | accept | — |
+
+Run: `npx vitest run tests/eye-set.test.js`.
+
+---
+
+## 6. Security considerations
+
+- **Pin the emitter; never trust a self-asserted `kid`.** The only added trust is a
+  detached EdDSA verification under a **pinned** key. An unpinned or substituted key
+  is a rejection — self-asserted keys confer nothing.
+- **`alg` is fixed, checked first.** `alg:'none'` and algorithm confusion are
+  rejected before any verification; an unsecured token is never treated as signed.
+- **Tamper = signature failure.** Because the signature covers the signing input
+  over the original payload, any post-signing edit (notably a status downgrade) is
+  caught as a signature failure, not silently honored.
+- **Redaction posture.** `sub_id` is the re-derivable `scope_binding_hash`, never a
+  raw identifier; the event member carries only non-attributable facts (mirrors
+  `lib/eye/webhook-notify.js`). The SET is safe to transport to a relying party
+  without leaking who the scope is.
+- **Staleness never relaxes; absence never relaxes.** A stale or missing SET is
+  treated as *no posture change* (fail-open **as an input**), never as a relax of
+  the relying party's base gate (Eye spec §7.2).
+- **No new primitive, no new trust.** EdDSA-over-JWS via `node:crypto`; no new
+  dependency; the frozen `canonicalize()` is reused where canonical bytes are
+  needed. The SET grants no authority by itself.
+
+---
+
+## 7. Residual Risk — out of scope
+
+**An Eye SET INFORMS; it is never the sole gate and never authorizes.** This profile
+makes the advisory *attributable, scope-bound, tamper-evident, and fresh-checked*
+under a pinned emitter key, and carries the never-sole-gate invariant in-band. It
+does not, and cannot, do the following — these are **out of scope**:
+
+- **A fully compromised emitter.** An Eye operator holding the pinned signing key
+  can emit a truthful-looking SET for a posture it did not actually compute
+  (over-tightening, or — bounded by the never-sole-gate property — under-tightening).
+  Pinning bounds this to a **named** key whose claims are attributable; it does not
+  make a compromised emitter's claims **true**. The residual is addressed only by
+  emitter host/TEE attestation and key-management hygiene, a layer **above** this
+  envelope — **not** by this envelope's mathematics. (Mirrors the
+  identified-but-not-trusted framing of execution-integrity's executor and PIP-007's
+  initiator.)
+- **Sole-gate misuse by the relying party.** The `never_sole_gate:true` marker is
+  carried and re-checked in-band, and `verifyEyeSet` exposes no allow/deny path. But
+  a relying party that ignores its own base policy and *reads the posture as
+  authorization* defeats the invariant. That is an integration error this envelope
+  cannot prevent by cryptography; conformance is an integrator obligation (Eye spec
+  §8, §10), evidenced by tests, not asserted in prose.
+- **Under-tightening from a withheld or stale SET.** A relying party that never
+  receives the SET proceeds on its base decision (Eye is fail-open as an *input*).
+  Staleness never relaxes; absence never relaxes. The envelope cannot compel an
+  emitter to speak.
+
+`valid:true` means *a pinned, named emitter made this fresh, scope-bound, in-band
+never-sole-gate posture claim, untampered since signing* — **not** "allow," and
+**not** "the posture is objectively correct."
+
+> **Framing (reuse this language).** "The Eye SET carries Eye's advisory posture as
+> an RFC 8417 Security Event Token, signed under a pinned emitter key, scope-bound by
+> `scope_binding_hash`, and marked never-sole-gate in-band. A relying party verifies
+> it offline and combines the posture **tighten-only** with its own base decision. It
+> is **never** the sole gate and **never** authorizes; `verifyEyeSet` returns a
+> posture, never allow/deny. SET/JWS/SSF/CAEP and the never-sole-gate posture are
+> prior art; the contribution is the verifiable, scope-bound SET that carries the
+> invariant in-band plus the redaction posture. A fully compromised emitter is out of
+> scope — pin the emitter key."
+
+---
+
+## 8. Governance
+
+This profile is **experimental** and MUST be ratified by an Extension PIP before it
+is part of the protocol. It changes no frozen Core object and is governed exactly as
+`EP-WYSIWYS` / `EP-EXECUTION-INTEGRITY-v1` (PIP-010) and `EP-PROVENANCE-CHAIN-v1`
+(PIP-009): composition, not ownership; additive signed claim + fail-closed verifier
+check; honest residual stated plainly. It realizes the forward-compatible path the
+Eye advisory spec named in §9.1 without modifying the v1 advisory or the receipt
+flow.

--- a/docs/EP-REVOCATION-SPEC.md
+++ b/docs/EP-REVOCATION-SPEC.md
@@ -1,0 +1,357 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright EMILIA Protocol, Inc. -->
+
+# EP-REVOCATION — Portable, Offline-Verifiable Revocation Statement (SPECIFICATION PROPOSAL)
+
+**Status:** Draft / Experimental specification proposal
+**Type:** Extension (additive over EP Core v1.0)
+**Requires:** PIP-001 (EP Core v1.0 Freeze), EP-RECEIPT-v1
+(`standards/draft-schrock-ep-authorization-receipts-01.md` §3, §6.3)
+**Wire tag:** `EP-REVOCATION-v1`
+**Reference implementation:** `lib/revocation/statement.js`
+**Conformance vectors:** `conformance/vectors/revocation.v1.json`
+**Conformance tests:** `tests/revocation.test.js`
+
+> This is a **specification proposal** plus a reference implementation. It is
+> **experimental**. It is **not** a production claim, asserts **no** customers,
+> and reports **no** metrics. It MUST be ratified by a PIP before it can be
+> called part of the protocol. It adds **no new trust assumptions** beyond those
+> already required to verify an EP-RECEIPT-v1 receipt, plus a single detached
+> Ed25519 verification of the revoker's claim — which grants no authority on its
+> own.
+>
+> **Offline verification answers "is THIS revocation real and for THIS
+> target." It does NOT answer "is the absence of a revocation trustworthy."**
+> Read [§7 Residual Risk](#7-residual-risk--what-offline-revocation-does-not-prove)
+> before relying on anything here. Treating absence-of-statement as
+> proof-of-not-revoked is a relying-party error this profile **cannot** prevent.
+
+---
+
+## 1. Abstract
+
+Revocation in EP today is **server-state only**. `revokeCommit()`
+(`lib/commit.js`) flips a commit to `status:'revoked'`; `revokeAttestation()` /
+`revokeChallenge()` (`lib/signoff/revoke.js`) do the same for signoff records.
+All of these are *queries against a live datastore*. There is **no portable
+artifact** a relying party can be **handed** to prove — offline, with no call
+back to the issuer — that a previously-valid authorization is now revoked.
+
+This profile defines that artifact: **`EP-REVOCATION-v1`**, a signed revocation
+statement that **binds a target** and is **offline-verifiable**. A relying party
+who is handed the statement plus the target it concerns can verify, with no
+network and no trust in the bearer, that:
+
+1. a **named, pinned** revoker signed it (identified-but-not-trusted), and
+2. it binds the **exact** target the relying party is reasoning about.
+
+It composes the **frozen** `canonicalize()` from `@emilia-protocol/issue` for the
+signed bytes and touches no Core object. It does **not** replace server-state
+revocation; it is the **portable, hand-it-to-someone** form of the same fact.
+
+What this profile does **not** do is tell you whether a revocation you do **not
+hold** exists — the freshness/liveness problem OCSP and CRLs exist to address.
+That is stated plainly and kept out of scope in [§7](#7-residual-risk--what-offline-revocation-does-not-prove).
+
+---
+
+## 2. Relationship to the Frozen Core (additive, no modification)
+
+The EP Core is frozen under **PIP-001**. This profile:
+
+- **Does not** modify the `EP-RECEIPT-v1` wire format, canonicalization, or
+  signature path.
+- **Does not** modify `packages/verify` or `packages/issue`, nor the existing
+  server-state revocation (`lib/commit.js`, `lib/signoff/revoke.js`).
+- **Imports** the frozen `canonicalize()` as the single source of
+  canonicalization truth (`lib/revocation/statement.js` →
+  `../../packages/issue/index.js`), exactly as `lib/provenance/chain.js`,
+  `lib/execution/integrity.js`, and `lib/wysiwys/render.js` do.
+- Stores / transports the statement **alongside** the receipt (e.g. in a
+  provenance bundle's optional block, an audit event, or a sidecar file),
+  **never** inside the signed receipt body. Verifiers that predate this profile
+  verify receipts unchanged; new verifiers add the revocation check.
+
+This is the same composition pattern as the execution-integrity binding
+(`lib/execution/integrity.js`, PIP-010) and the WYSIWYS display attestation
+(`docs/EP-WYSIWYS-SPEC.md`): an **additive signed claim + a fail-closed verifier
+check** over a key the verifier **pins**.
+
+---
+
+## 3. The revocation statement (`EP-REVOCATION-v1`)
+
+A revocation statement is the revoker's signed claim that a named target is
+revoked.
+
+```json
+{
+  "@version": "EP-REVOCATION-v1",
+  "target_type": "receipt",
+  "target_id": "rcpt_01J...",
+  "action_hash": "sha256:<hex>",
+  "revoker_id": "ep:key:revoker#1",
+  "revoked_at": "2026-06-14T20:41:00Z",
+  "reason": "policy change — key compromise suspected",
+  "proof": {
+    "algorithm": "Ed25519",
+    "revoker_key_id": "ep:key:revoker#1",
+    "signed_payload_b64u": "<b64u canonicalize(SIGNED_FIELDS)>",
+    "signature_b64u": "<b64u Ed25519 signature over signed_payload>",
+    "public_key": "<b64u SPKI DER>"
+  }
+}
+```
+
+### 3.1 Target
+
+| Field         | Meaning |
+| ------------- | ------- |
+| `target_type` | One of `receipt` \| `commit` \| `delegation`. |
+| `target_id`   | The identifier of the thing being revoked (receipt id, commit id, delegation id). |
+| `action_hash` | The `action_hash` the receipt committed to (the **frozen** `actionHash`, I-D §3), or the commit hash for a `commit` target. Binds the statement to the **exact** authorization, so a statement for action A cannot be replayed against action B. |
+
+Both `target_id` **and** `action_hash` are part of the binding (§5). A statement
+revokes the **(target_id, action_hash)** pair, never just an id.
+
+### 3.2 Revoker + provenance
+
+| Field        | Meaning |
+| ------------ | ------- |
+| `revoker_id` | The party asserting the revocation; the verifier **pins** the key for this id (§5.3). Identified, **not** trusted on assertion. |
+| `revoked_at` | RFC 3339 instant the revocation took effect. **REQUIRED.** It is the freshness/replay anchor; a statement without it is rejected (§5.4). |
+| `reason`     | Human-readable cause. Covered by the signature, so it cannot be edited after signing. |
+
+### 3.3 Proof
+
+- `proof` is **optional at the object level** but **REQUIRED** by the verifier:
+  an unsigned statement is a bare claim that confers nothing and is rejected by
+  `verifyRevocation()`.
+- The signature covers the **canonical bytes** of the fixed **SIGNED_FIELDS**
+  set:
+
+  ```
+  canonicalize({
+    "@version":    "EP-REVOCATION-v1",
+    target_type, target_id, action_hash,
+    revoker_id, revoked_at, reason
+  })
+  ```
+
+  Order is irrelevant — `canonicalize()` sorts keys. The verifier
+  **independently recomputes** these bytes from the **presented** fields and
+  rejects a signature over any other bytes (§5.5), so `revoked_at` / `reason` /
+  the target cannot be edited after signing.
+- `revoker_key_id` names the revoker key; the verifier pins it via
+  `opts.revokerKeys` and rejects a proof under any other key (§5.3).
+
+The signing-side helper is `buildRevocation({ target, revoker, revokedAt,
+reason, signer })`; it refuses to mint a statement that does not bind a complete
+target (honesty gate — a signed claim asserts a fact that was structurally
+well-formed at signing time).
+
+---
+
+## 4. API
+
+```
+buildRevocation({ target, revoker_id, revoked_at, reason, signer }) -> statement
+verifyRevocation(target, statement, opts) -> { valid, checks, errors }
+isRevoked(target, statements, opts)       -> boolean
+```
+
+- **`target`** handed to the verifier is `{ target_type, target_id, action_hash }`
+  — the thing the relying party is reasoning about, derived from the receipt /
+  commit it holds, never from the statement.
+- **`isRevoked(target, statements, opts)`** returns `true` **iff** at least one
+  statement in `statements` returns `valid:true` from `verifyRevocation(target,
+  statement, opts)`. It does **not** require the matching statement to be first
+  or alone (vector `z2`). It is the aggregate convenience over a bag of
+  statements a relying party may have collected.
+
+---
+
+## 5. Verifier rule (`verifyRevocation`) — FAIL CLOSED
+
+```
+verifyRevocation(target, statement, opts) -> { valid, checks, errors }
+```
+
+Given the **target the relying party holds** and a candidate statement, the
+verifier evaluates the following gating checks. **Any one false ⇒ `valid:false`.**
+`valid = AND(all gating checks)`.
+
+### 5.1 `version`
+`statement["@version"]` MUST equal `EP-REVOCATION-v1`. A statement under any
+other tag is rejected (vector `f`) — a forked/future tag may carry different
+semantics and is never honored as this version.
+
+### 5.2 `target_bound`
+The statement MUST bind the **exact** target the verifier was handed: both
+`statement.target_type === target.target_type`,
+`statement.target_id === target.target_id`, **and**
+`hexOf(statement.action_hash) === hexOf(target.action_hash)`. A statement for a
+different `target_id` (vector `d`) or a different `action_hash`
+(vector `e`, "revoke-A-presented-for-B") is rejected. **Revoking A must never
+revoke B.**
+
+### 5.3 `revoker_key_pinned` (identified-but-not-trusted)
+`revoker_id` MUST resolve to a key the verifier has **pinned** via
+`opts.revokerKeys[revoker_id].public_key`, and the proof's `public_key` MUST
+equal that pinned key.
+
+- No pin (or no registry supplied) ⇒ **reject** (vector `b`). An unpinned,
+  self-asserted key confers **nothing** — anyone can mint a keypair and sign "X
+  is revoked." The verifier **never** falls back to the proof's own
+  `public_key`. This mirrors `executor_key_pinned`
+  (`lib/execution/integrity.js`) and `signer_key_unpinned`
+  (`lib/wysiwys/render.js`).
+- A pinned `revoker_id` whose proof carries a **different** key ⇒ **reject**
+  (vector `c`, key substitution): the signature may verify under the substituted
+  key, but the key binding fails.
+
+### 5.4 `revoked_at_present`
+`revoked_at` MUST be present and a well-formed RFC 3339 instant (vector `h`). It
+is the freshness/replay anchor; without it there is no record of *when* the
+revocation took effect and no basis for §5.6.
+
+### 5.5 `revoker_signature_valid` + `signature_binds_statement`
+The verifier **recomputes** the SIGNED_FIELDS canonical bytes from the
+**presented** statement fields, then requires the proof to:
+
+- (a) verify under the **pinned** key over **exactly** those recomputed bytes
+  (`revoker_signature_valid`) — a forged or broken signature is rejected
+  (vector `a`); and
+- (b) be a signature over the **recomputed** bytes, not a producer-supplied
+  `signed_payload` blob (`signature_binds_statement`) — if `revoked_at` or
+  `reason` (or any signed field) was edited after signing, the recomputed bytes
+  differ from what was signed and the statement is rejected (vector `g`).
+
+The verifier never trusts `proof.signed_payload_b64u`; it is recomputed.
+
+### 5.6 `freshness` (optional)
+**Only** when `opts.maxAgeSeconds` is set: the statement is rejected if
+`revoked_at` is older than `opts.maxAgeSeconds` relative to `opts.now`
+(default: wall clock) (vector `i`). This bounds how stale a **presented**
+statement may be. **It does nothing about a revocation that was never handed to
+the verifier** — see [§7](#7-residual-risk--what-offline-revocation-does-not-prove).
+When `opts.maxAgeSeconds` is unset, `freshness` is vacuously true.
+
+### 5.7 Fail-closed obligations (any one ⇒ `valid:false`)
+
+- `@version` is not `EP-REVOCATION-v1`.
+- The statement does not bind the **exact** `(target_type, target_id,
+  action_hash)` the verifier holds.
+- `revoker_id` is unpinned, or the proof key is not the pinned key.
+- `revoked_at` is absent or malformed.
+- The proof is absent, forged, or signs bytes other than the recomputed
+  SIGNED_FIELDS.
+- (When required) `revoked_at` is older than the freshness window.
+
+---
+
+## 6. Conformance vectors
+
+`conformance/vectors/revocation.v1.json` is the authoritative, attack-catalogue-first
+catalogue; every id is asserted by name in `tests/revocation.test.js`. The
+negatives are minted with **real** Ed25519 keys and **real** detached proofs
+over canonical bytes, so each is a genuine forgery attempt, not hand-edited JSON
+that fails for an unrelated reason.
+
+| Vector id | Scenario | Verdict | Gating check |
+| --- | --- | --- | --- |
+| `a_forged_signature` | Proof does not verify under the pinned revoker key | reject | `revoker_signature_valid` |
+| `b_unpinned_revoker_key` | `revoker_id` not pinned (self-asserted key) | reject | `revoker_key_pinned` |
+| `c_wrong_pinned_key_substitution` | Proof key != the key pinned for `revoker_id` | reject | `revoker_key_pinned` |
+| `d_bound_to_different_target_id` | Statement binds a different `target_id` | reject | `target_bound` |
+| `e_bound_to_different_action_hash` | Statement binds a different `action_hash` (revoke-A-for-B) | reject | `target_bound` |
+| `f_wrong_version` | `@version` is not `EP-REVOCATION-v1` | reject | `version` |
+| `g_tampered_fields_after_signing` | `revoked_at`/`reason` edited after signing | reject | `signature_binds_statement` |
+| `h_missing_revoked_at` | No `revoked_at` anchor | reject | `revoked_at_present` |
+| `i_stale_beyond_freshness_window` | `revoked_at` older than `opts.maxAgeSeconds` | reject | `freshness` |
+| `z_well_formed_binding_revocation` | Pinned revoker, exact target binding, real proof | accept | — |
+| `z2_is_revoked_true_among_unrelated` | One valid binding statement among unrelated ones | accept | — |
+
+Run: `npx vitest run tests/revocation.test.js`.
+
+---
+
+## 7. Residual Risk — what offline revocation does NOT prove
+
+**This profile proves a revocation statement is AUTHENTIC and BINDS the target.
+It does NOT prove you hold the LATEST revocation state.** That distinction is the
+whole risk, and it is stated here plainly.
+
+What this profile **does** prove (offline, no network):
+
+- The statement was **signed by a named, pinned revoker** — an unpinned or
+  self-asserted key confers nothing.
+- The statement **binds the exact `(target_id, action_hash)`** the relying party
+  is reasoning about — a revocation for action A cannot revoke action B.
+- The signed fields (target, `revoker_id`, `revoked_at`, `reason`) were **not
+  edited after signing**.
+- (When required) the statement is **no older than** the relying party's
+  freshness window.
+
+What this profile **does NOT** prove, and what is **out of scope**:
+
+- **That no revocation exists that you were not handed.** "Has this authorization
+  been revoked by a statement I do not hold?" is a **freshness / liveness /
+  transparency** question — exactly the gap **OCSP** and **CRLs** exist to fill.
+  The offline check answers *"is THIS revocation real and for THIS target,"* not
+  *"is the absence of a revocation trustworthy."* **Treating
+  absence-of-statement as proof-of-not-revoked is a relying-party error this
+  profile cannot prevent.**
+- **Liveness in general.** The `opts.maxAgeSeconds` window bounds how stale a
+  **presented** statement may be; it does **nothing** about a revocation that was
+  never delivered to the verifier. A relying party that needs liveness **MUST**
+  consult a revocation **feed / transparency log**, or rely on a **short receipt
+  TTL** — a layer **above** this artifact, not a property of it.
+- **That the revoker was entitled to revoke.** This profile verifies *who* signed
+  and *what* it binds; whether `revoker_id` had the authority to revoke this
+  target is an authorization-policy question for the relying party's pinning
+  policy (who you pin as a revoker for a given target), not a property of the
+  signature.
+
+> **Framing (reuse this language).** "An EP-REVOCATION-v1 statement is a portable,
+> offline-verifiable proof that a named, pinned revoker revoked *this specific
+> target*. It is the CRL/OCSP *response* — proof a specific revocation is real —
+> not the CRL/OCSP *service*: it does not tell you about revocations you were
+> never handed. A relying party that needs to know the *absence* of a revocation
+> is trustworthy must consult a revocation feed or rely on short receipt TTLs.
+> This artifact raises the cost of denying a revocation that *did* happen; it
+> does not make the absence of a revocation trustworthy."
+
+---
+
+## 8. Security considerations
+
+- **Canonicalization is load-bearing.** The signed bytes reuse the frozen
+  `canonicalize()`; signer and verifier MUST produce identical bytes. The
+  reference re-imports the frozen function rather than re-implementing it.
+- **Pin by `revoker_id`, never by self-assertion.** The verifier resolves the
+  key from `opts.revokerKeys` and rejects any proof not under the pinned key.
+  Who you pin as a revoker for a given target is the relying party's policy and
+  is the real authorization boundary.
+- **Bind both target_id and action_hash.** Binding only an id would let a
+  revocation for one action be replayed against a re-issued authorization with
+  the same id but a different action; the `action_hash` closes that.
+- **Recompute the signed payload.** The verifier never trusts a producer-supplied
+  `signed_payload_b64u`; tampered `revoked_at`/`reason` fail because the
+  recomputed bytes differ from what was signed.
+- **Freshness ≠ completeness.** A freshness window bounds staleness of a
+  *presented* statement; it is not a substitute for a revocation feed. Do not
+  read `valid:true` as "not revoked elsewhere."
+- **One new primitive, no new trust.** The only added primitive is detached
+  Ed25519 verification of the revoker's claim; it grants no authority by itself.
+
+---
+
+## 9. Governance
+
+This profile is **experimental** and MUST be ratified by an Extension PIP before
+it is part of the protocol. It changes no frozen Core object and is governed
+exactly as `EP-PROVENANCE-CHAIN-v1` (PIP-009), `EP-EXECUTION-INTEGRITY-v1`
+(PIP-010), and the WYSIWYS display-attestation profile: composition, not
+ownership; an additive signed claim + a fail-closed verifier check; honest
+residual stated plainly.

--- a/lib/eye/eye-set.js
+++ b/lib/eye/eye-set.js
@@ -1,0 +1,570 @@
+/**
+ * EMILIA Protocol — Eye continuous-eval as a Security Event Token (EP-EYE-SET-v1)
+ *
+ * @license Apache-2.0
+ *
+ * REFERENCE IMPLEMENTATION of an ADDITIVE emission over Eye's advisory path.
+ * Spec: docs/EP-EYE-SET-SPEC.md. Conformance: conformance/vectors/eye-set.v1.json.
+ * EXPERIMENTAL — governed by an Extension PIP; not a production or customer
+ * claim; reports no metrics. It MUST be ratified by a PIP before it can be
+ * called part of the protocol.
+ *
+ *   computed Eye advisory (status / reason_codes / recommended_policy_action /
+ *     scope_binding_hash / advisory_hash / expires_at — docs/EMILIA-EYE-ADVISORY-SPEC.md)
+ *       -> carried as an RFC 8417 Security Event Token (CAEP-style), JWS-COMPACT
+ *         -> header { alg:'EdDSA', typ:'secevent+jwt', kid }, EdDSA over the
+ *            JWS signing input (RFC 7515 §5.1) via node:crypto
+ *           -> verified offline under a key PINNED for the kid/iss (fail closed)
+ *             -> returns the advisory POSTURE for a relying party to ACT on
+ *
+ * WHAT THIS ADDS. The Eye advisory (EMILIA-EYE-ADVISORY-SPEC §9) is itself
+ * UNSIGNED in v1 — its authenticity rests on the authenticated channel and its
+ * durable verifiable record is the EP receipt. §9.1 names a forward-compatible
+ * path: carry the advisory as a SET (RFC 8417) JWS, CAEP-style, supplying the
+ * verifiable scope-binding and the "never the sole gate" invariant that SSF/CAEP
+ * deliberately leave undefined. This module builds exactly that emission +
+ * verifier, additively, without touching the frozen Core.
+ *
+ * NEVER A GATE. verifyEyeSet() returns an advisory POSTURE (status, reason_codes,
+ * recommended_policy_action) for a relying party to combine TIGHTEN-ONLY with its
+ * own base decision. It NEVER returns allow/deny and NEVER authorizes — there is
+ * no decision vocabulary in its output. The never-sole-gate invariant is carried
+ * IN-BAND (events[...].never_sole_gate:true, re-checked here) and enforced
+ * STRUCTURALLY (this verifier exposes no allow/deny path). A 'clear' status is
+ * the default-path no-change posture (Eye spec §6) and is NOT a posture-CHANGE
+ * event: buildEyeSet refuses to emit it and verifyEyeSet rejects it, so a
+ * replayed/forged 'clear' can never be read as an affirmative "authorized" signal.
+ *
+ * REDACTION POSTURE (reused from lib/eye/webhook-notify.js#redactAdvisory).
+ * The SET's subject identifier sub_id is the re-derivable scope_binding_hash —
+ * NEVER a raw subject_ref / actor_ref / target_ref / issuer_ref. The event member
+ * carries only non-attributable facts (status, reason_codes,
+ * recommended_policy_action, advisory_hash, expires_at, never_sole_gate). A
+ * relying party that knows the scope can re-derive sub_id; the SET leaks nothing
+ * attributable on its own.
+ *
+ * FROZEN CORE (PIP-001). This file does NOT modify the EP-RECEIPT-v1 wire
+ * format, canonicalization, or signature, and it does NOT touch packages/verify
+ * or packages/issue. It imports the frozen canonicalize() READ-ONLY (the same
+ * relative-import convention as lib/provenance/chain.js and
+ * lib/execution/integrity.js) wherever canonical bytes are needed, and
+ * re-implements NOTHING cryptographic of the receipt path. The only added
+ * primitive is a small detached-EdDSA/JWS over node:crypto — no new dependency.
+ *
+ * FAIL CLOSED. verifyEyeSet() returns { valid:false } on ANY of: a non-EdDSA alg
+ * (incl. 'none'); a wrong typ; an unpinned or substituted emitter key; a forged
+ * signature or a payload tampered after signing (e.g. a status downgrade);
+ * missing/ill-typed required claims; an audience mismatch when opts.audience is
+ * set; staleness (exp past / iat too old) when freshness is required; a
+ * non-actionable ('clear'/unknown) status; or a missing/non-true never_sole_gate
+ * marker. Each gate is checked before it can matter; the alg gate runs first so
+ * an unsecured token is never treated as signed.
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ * HONEST BOUNDARY (state this plainly). SET (RFC 8417), JWS (RFC 7515), and
+ * OpenID SSF/CAEP — including continuous evaluation AND the posture that a signal
+ * "is never the sole authorization gate" — are PRIOR ART. This profile does NOT
+ * claim continuous-eval, the SET envelope, or the never-sole-gate invariant
+ * itself as novel; they are documented prior art (Eye spec §8, §9.1, §11). The
+ * only contribution is the verifiable, scope-bound SET that carries the invariant
+ * IN-BAND together with the redaction posture (sub_id = scope_binding_hash). An
+ * Eye SET INFORMS; it is never the sole gate and never authorizes.
+ *
+ * HONEST RESIDUAL — out of scope. A FULLY COMPROMISED EMITTER is out of scope:
+ * an Eye operator holding the pinned signing key can emit a truthful-looking SET
+ * for a posture it did not actually compute (over- or, bounded by never-sole-gate,
+ * under-tightening). Pinning bounds this to a NAMED key whose claims are
+ * attributable; it does not make a compromised emitter's claims true — that is
+ * addressed only by emitter host/TEE attestation and key-management hygiene, a
+ * layer ABOVE this envelope, not its mathematics. SOLE-GATE MISUSE by a relying
+ * party that reads the posture as authorization defeats the invariant; this
+ * envelope cannot prevent that integration error by cryptography. A WITHHELD or
+ * STALE SET is treated as "no posture change" (fail-open as an INPUT, never a
+ * relax of the base gate); staleness never relaxes; absence never relaxes. Read
+ * valid:true as "a pinned, named emitter made this fresh, scope-bound, in-band
+ * never-sole-gate posture claim, untampered since signing" — NOT "allow," and NOT
+ * "the posture is objectively correct."
+ * ──────────────────────────────────────────────────────────────────────────
+ */
+
+import crypto from 'node:crypto';
+
+// Compose the FROZEN v1 issuer's canonicalizer. Imported READ-ONLY by relative
+// path to the in-repo package source — the SAME convention as
+// lib/provenance/chain.js and lib/execution/integrity.js — so this file uses the
+// identical bytes as the published @emilia-protocol/issue by construction. We
+// re-implement nothing cryptographic of the receipt path.
+import { canonicalize } from '../../packages/issue/index.js';
+
+export const EYE_SET_VERSION = 'EP-EYE-SET-v1';
+
+/** RFC 8417 token type for a Security Event Token in JWS-COMPACT serialization. */
+export const EYE_SET_TYP = 'secevent+jwt';
+
+/** The single CAEP-style event URI that keys the SET's `events` map. */
+export const EYE_ADVISORY_EVENT_URI =
+  'https://schemas.emiliaprotocol.ai/secevent/eye-advisory';
+
+// Status that is the default-path, no-change posture. NEVER emitted as a
+// posture-change event; rejected by the verifier as non-actionable (Eye spec §6).
+const CLEAR_STATUS = 'clear';
+
+// The actionable posture-change statuses. A SET event MUST carry one of these.
+// (Mirrors EYE_STATUSES minus 'clear' — webhook-notify.js STATUS_RANK 1..3.)
+const ACTIONABLE_STATUSES = Object.freeze(['caution', 'elevated', 'review_required']);
+
+// ── small helpers ─────────────────────────────────────────────────────────────
+
+/** base64url WITHOUT padding (RFC 7515 §2). */
+function b64uEncode(buf) {
+  return Buffer.from(buf).toString('base64url');
+}
+
+/** Decode a base64url segment to a Buffer; never throws (returns null on junk). */
+function b64uDecode(seg) {
+  try {
+    if (typeof seg !== 'string' || seg.length === 0) return null;
+    // Reject anything that is not strict base64url so a malformed segment fails
+    // closed rather than silently decoding to lossy bytes.
+    if (!/^[A-Za-z0-9_-]+$/.test(seg)) return null;
+    return Buffer.from(seg, 'base64url');
+  } catch {
+    return null;
+  }
+}
+
+/** Parse a base64url JSON segment into an object; null on any failure. */
+function decodeJsonSegment(seg) {
+  const buf = b64uDecode(seg);
+  if (!buf) return null;
+  try {
+    const obj = JSON.parse(buf.toString('utf8'));
+    return obj && typeof obj === 'object' && !Array.isArray(obj) ? obj : null;
+  } catch {
+    return null;
+  }
+}
+
+/** A non-empty string. */
+const isStr = (v) => typeof v === 'string' && v.length > 0;
+
+/** A non-empty array of non-empty strings. */
+function isStrArray(v) {
+  return Array.isArray(v) && v.length > 0 && v.every(isStr);
+}
+
+/** Whole, finite, non-negative seconds-since-epoch. */
+function isEpochSeconds(v) {
+  return typeof v === 'number' && Number.isFinite(v) && v >= 0 && Number.isInteger(v);
+}
+
+/**
+ * Resolve the pinned Ed25519 public key for an emitter. A self-asserted kid/iss
+ * confers nothing: the key is looked up ONLY in the verifier-supplied pinned map,
+ * keyed by kid first then iss. Returns the base64url SPKI-DER string or null.
+ * (Mirrors execution-integrity's executorKeys[keyId].public_key resolution.)
+ */
+function resolvePinnedKey(pinnedKeys, kid, iss) {
+  if (!pinnedKeys || typeof pinnedKeys !== 'object') return null;
+  const entry =
+    (isStr(kid) ? pinnedKeys[kid] : undefined) ??
+    (isStr(iss) ? pinnedKeys[iss] : undefined);
+  if (!entry) return null;
+  // Accept either { public_key } (the pinned-key convention used across
+  // lib/execution + lib/provenance) or a bare base64url string.
+  if (typeof entry === 'string') return entry.length > 0 ? entry : null;
+  return isStr(entry.public_key) ? entry.public_key : null;
+}
+
+/**
+ * Verify a detached Ed25519 signature over `signingInput` (ASCII bytes) under a
+ * base64url SPKI-DER public key. Returns true/false; never throws. This is the
+ * ONLY signature primitive added here and it grants NO trust by itself — the
+ * caller gates on it AND on the key being pinned (identified-but-not-trusted).
+ * Mirrors verifyEd25519 in lib/execution/integrity.js.
+ */
+function verifyEd25519(signingInput, publicKeyB64u, signatureB64u) {
+  try {
+    if (!publicKeyB64u || !signatureB64u) return false;
+    const sig = b64uDecode(signatureB64u);
+    if (!sig) return false;
+    const key = crypto.createPublicKey({
+      key: Buffer.from(publicKeyB64u, 'base64url'),
+      format: 'der',
+      type: 'spki',
+    });
+    return crypto.verify(null, Buffer.from(signingInput, 'ascii'), key, sig);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Pull the single advisory event member out of a SET payload. Returns the member
+ * object or null when there is not exactly one event under the expected URI (the
+ * profile fixes exactly one CAEP-style event).
+ */
+function singleEvent(payload) {
+  const events = payload?.events;
+  if (!events || typeof events !== 'object' || Array.isArray(events)) return null;
+  const keys = Object.keys(events);
+  if (keys.length !== 1) return null;
+  if (keys[0] !== EYE_ADVISORY_EVENT_URI) return null;
+  const member = events[keys[0]];
+  return member && typeof member === 'object' && !Array.isArray(member) ? member : null;
+}
+
+// ── emission (Eye emitter side) ───────────────────────────────────────────────
+
+/**
+ * buildEyeSet — emit an Eye advisory as an RFC 8417 Security Event Token in
+ * JWS-COMPACT serialization (`<b64u(header)>.<b64u(payload)>.<b64u(signature)>`),
+ * signed EdDSA over the JWS signing input via node:crypto. No new dependency.
+ *
+ * REFUSES 'clear' (and any non-actionable status): a `clear` status is the
+ * default-path, no-change posture (Eye spec §6) and emitting it as a signed
+ * posture-change event would let a replayed/forged `clear` be read as an
+ * affirmative "authorized" signal — the exact sole-gate misuse the profile
+ * refuses (spec §3.4 / vector j_clear_status_emitted_as_event).
+ *
+ * The subject id (sub_id) is the re-derivable scope_binding_hash, NEVER a raw
+ * subject/actor/target/issuer reference (redaction posture of
+ * lib/eye/webhook-notify.js#redactAdvisory). The event member carries only
+ * non-attributable advisory facts plus the in-band never_sole_gate:true marker.
+ *
+ * @param {object} advisory - an eye-advisory-v1-shaped object. MUST carry a
+ *   non-empty scope_binding_hash, an actionable status, non-empty reason_codes,
+ *   a recommended_policy_action (or the spec's recommended_action), advisory_hash,
+ *   and expires_at.
+ * @param {object} args
+ * @param {{ kid:string, iss?:string, privateKey:import('crypto').KeyObject,
+ *           sign?:(input:string)=>string }} args.signer
+ *   - the emitter's signing material. `kid` names the pinned emitter key. A raw
+ *     Ed25519 `privateKey` KeyObject is signed with node:crypto; alternatively a
+ *     `sign(signingInput)->b64u` callback may be supplied (EP never needs to hold
+ *     the key). `iss` defaults to `kid`.
+ * @param {string} [args.audience] - the intended relying-party id, placed in `aud`.
+ * @param {string} [args.jti] - unique token id (defaults to a random UUID).
+ * @param {number} [args.iat] - issued-at seconds (defaults to now).
+ * @param {number} [args.exp] - optional JWT exp seconds (a top-level expiry in
+ *   addition to the event's expires_at).
+ * @returns {string} the compact SET.
+ */
+export function buildEyeSet(advisory, { signer, audience, jti, iat, exp } = {}) {
+  if (!advisory || typeof advisory !== 'object') {
+    throw new Error('buildEyeSet requires an advisory object');
+  }
+  if (!signer || !isStr(signer.kid)) {
+    throw new Error('buildEyeSet requires signer.{kid}');
+  }
+  const hasSignCb = typeof signer.sign === 'function';
+  if (!hasSignCb && !signer.privateKey) {
+    throw new Error('buildEyeSet requires signer.privateKey or signer.sign');
+  }
+
+  const status = advisory.status;
+  // clear (and any non-actionable status) is a build-time rejection (§3.4).
+  if (status === CLEAR_STATUS) {
+    throw new Error(
+      "buildEyeSet: 'clear' is the default-path no-change posture and MUST NOT be "
+      + 'emitted as a posture-change event (fail-closed; see vector j_clear_status_emitted_as_event)',
+    );
+  }
+  if (!ACTIONABLE_STATUSES.includes(status)) {
+    throw new Error(
+      `buildEyeSet: status "${status}" is not an actionable posture-change status `
+      + `(expected one of ${ACTIONABLE_STATUSES.join(' | ')})`,
+    );
+  }
+
+  const scopeBindingHash = advisory.scope_binding_hash;
+  if (!isStr(scopeBindingHash)) {
+    throw new Error('buildEyeSet requires advisory.scope_binding_hash (the scope-bound sub_id; never a raw ref)');
+  }
+  const reasonCodes = advisory.reason_codes;
+  if (!isStrArray(reasonCodes)) {
+    throw new Error('buildEyeSet requires non-empty advisory.reason_codes for an actionable status');
+  }
+  // The SET wire uses recommended_policy_action; accept the advisory spec's
+  // recommended_action as the source field too (EMILIA-EYE-ADVISORY-SPEC §3.1).
+  const recommendedPolicyAction =
+    advisory.recommended_policy_action ?? advisory.recommended_action;
+  if (!isStr(recommendedPolicyAction)) {
+    throw new Error('buildEyeSet requires advisory.recommended_policy_action (or recommended_action)');
+  }
+  if (!isStr(advisory.advisory_hash)) {
+    throw new Error('buildEyeSet requires advisory.advisory_hash');
+  }
+  if (!isStr(advisory.expires_at)) {
+    throw new Error('buildEyeSet requires advisory.expires_at');
+  }
+
+  const header = {
+    alg: 'EdDSA',
+    typ: EYE_SET_TYP,
+    kid: signer.kid,
+  };
+
+  const payload = {
+    iss: isStr(signer.iss) ? signer.iss : signer.kid,
+    iat: isEpochSeconds(iat) ? iat : Math.floor(Date.now() / 1000),
+    jti: isStr(jti) ? jti : crypto.randomUUID(),
+    // sub_id is the re-derivable scope_binding_hash — NEVER a raw identifier.
+    sub_id: scopeBindingHash,
+    events: {
+      [EYE_ADVISORY_EVENT_URI]: {
+        status,
+        reason_codes: [...reasonCodes],
+        recommended_policy_action: recommendedPolicyAction,
+        advisory_hash: advisory.advisory_hash,
+        expires_at: advisory.expires_at,
+        // The in-band invariant, re-checked by verifyEyeSet. An Eye SET INFORMS;
+        // it is never the sole gate and never authorizes.
+        never_sole_gate: true,
+      },
+    },
+  };
+  if (isStr(audience)) payload.aud = audience;
+  if (isEpochSeconds(exp)) payload.exp = exp;
+
+  // JWS-COMPACT signing input: b64u(header) + '.' + b64u(payload) (RFC 7515 §5.1).
+  // canonicalize() (frozen, sorted-key JSON) is used for the serialized segments
+  // so the bytes are deterministic and re-derivable by the verifier.
+  const headerSeg = b64uEncode(Buffer.from(canonicalize(header), 'utf8'));
+  const payloadSeg = b64uEncode(Buffer.from(canonicalize(payload), 'utf8'));
+  const signingInput = `${headerSeg}.${payloadSeg}`;
+
+  const signatureB64u = hasSignCb
+    ? signer.sign(signingInput)
+    : crypto.sign(null, Buffer.from(signingInput, 'ascii'), signer.privateKey).toString('base64url');
+
+  return `${signingInput}.${signatureB64u}`;
+}
+
+// ── verification (relying-party side) — FAIL CLOSED ───────────────────────────
+
+/**
+ * verifyEyeSet — FAIL-CLOSED verification of an Eye SET. NEVER returns allow/deny
+ * and NEVER authorizes: on valid:true it returns the advisory POSTURE for a
+ * relying party to combine TIGHTEN-ONLY with its own base decision (Eye spec §7.4).
+ *
+ * Steps (each fail-closed; the alg gate runs FIRST so an unsecured token is never
+ * treated as signed):
+ *   1. parse + alg gate     — REJECT any alg != 'EdDSA' (incl. 'none')   alg_is_eddsa
+ *   2. typ gate             — typ MUST be 'secevent+jwt'                  typ_ok
+ *   3. pin the emitter key  — resolve from opts.pinnedKeys (kid/iss);
+ *                             an unpinned/self-asserted kid is rejected   emitter_key_pinned
+ *   4. verify JWS signature — recompute the signing input from the
+ *                             PRESENTED header.payload and verify under the
+ *                             PINNED key only (forge/substitute/tamper fail) jws_signature_valid
+ *   5. required claims       — iss, iat, jti, aud, sub_id + exactly one
+ *                              event member with the required fields        claims_present
+ *   6. audience              — payload.aud == opts.audience when set        audience_match
+ *   7. freshness             — exp/expires_at not past AND iat not older
+ *                              than maxAgeSec, when required                fresh
+ *   8. actionable status     — status in {caution,elevated,review_required} status_is_actionable
+ *   9. never-sole-gate       — event member carries never_sole_gate:true    never_sole_gate_present
+ *
+ * @param {string} setCompact - the compact SET `header.payload.signature`.
+ * @param {object} [opts]
+ * @param {Record<string,{public_key:string}|string>} opts.pinnedKeys - REQUIRED.
+ *   Map from (kid and/or iss) -> the pinned Ed25519 public key (base64url SPKI-DER,
+ *   as { public_key } or a bare string). An emitter absent here is UNPINNED and
+ *   rejected — a self-asserted kid confers nothing.
+ * @param {string} [opts.audience] - when set, payload.aud MUST equal it; when
+ *   unset, audience is not gated.
+ * @param {boolean} [opts.requireFresh] - when set, iat/exp freshness is enforced.
+ * @param {number} [opts.maxAgeSec] - maximum iat age (seconds) when fresh is required.
+ * @param {number} [opts.now] - injectable clock (seconds) for deterministic tests.
+ * @returns {{ valid:boolean, checks:object, errors:string[], posture:object|null }}
+ *   `posture` is present ONLY on valid:true and is NEVER allow/deny.
+ */
+export function verifyEyeSet(setCompact, opts = {}) {
+  const checks = {
+    alg_is_eddsa: false,
+    typ_ok: false,
+    emitter_key_pinned: false,
+    jws_signature_valid: false,
+    claims_present: false,
+    audience_match: true, // vacuously true until/unless opts.audience is set
+    fresh: true,          // vacuously true until/unless freshness is required
+    status_is_actionable: false,
+    never_sole_gate_present: false,
+  };
+  const errors = [];
+  const fail = (key, msg) => { checks[key] = false; errors.push(msg); };
+  const done = () => ({ valid: false, checks, errors, posture: null });
+
+  // ── parse the compact serialization ──────────────────────────────────────
+  if (typeof setCompact !== 'string' || setCompact.length === 0) {
+    fail('alg_is_eddsa', 'SET is not a non-empty compact string');
+    return done();
+  }
+  const parts = setCompact.split('.');
+  if (parts.length !== 3) {
+    fail('alg_is_eddsa', `compact SET must have exactly 3 segments, got ${parts.length}`);
+    return done();
+  }
+  const [headerSeg, payloadSeg, signatureSeg] = parts;
+  const header = decodeJsonSegment(headerSeg);
+  const payload = decodeJsonSegment(payloadSeg);
+  if (!header) {
+    fail('alg_is_eddsa', 'JOSE header is not decodable JSON');
+    return done();
+  }
+
+  // ── 1. alg gate (FIRST — never treat an unsecured token as signed) ────────
+  // REJECT any alg other than EdDSA, including 'none' and any non-EdDSA value,
+  // BEFORE any verification. A verifier that branched on the attacker-controlled
+  // alg would accept an unsigned token (vector d_alg_none_confusion).
+  if (header.alg !== 'EdDSA') {
+    fail('alg_is_eddsa', `alg "${header.alg}" is not the pinned EdDSA (unsecured/confusion rejected)`);
+    return done();
+  }
+  checks.alg_is_eddsa = true;
+
+  // ── 2. typ gate ──────────────────────────────────────────────────────────
+  if (header.typ !== EYE_SET_TYP) {
+    fail('typ_ok', `typ "${header.typ}" is not "${EYE_SET_TYP}"`);
+    return done();
+  }
+  checks.typ_ok = true;
+
+  // The payload must decode before we can pin on iss / verify / read claims.
+  if (!payload) {
+    fail('claims_present', 'SET payload is not decodable JSON');
+    return done();
+  }
+
+  // ── 3. pin the emitter key (self-asserted kid confers nothing) ────────────
+  const pinnedKey = resolvePinnedKey(opts.pinnedKeys, header.kid, payload.iss);
+  if (!pinnedKey) {
+    fail('emitter_key_pinned',
+      `no pinned key for emitter kid "${header.kid}" / iss "${payload.iss}" (unpinned — fail closed)`);
+    return done();
+  }
+  checks.emitter_key_pinned = true;
+
+  // ── 4. verify the JWS signature under the PINNED key ──────────────────────
+  // Recompute the signing input from the PRESENTED header.payload segments and
+  // verify ONLY under the pinned key (never a producer-supplied key). A forged
+  // signature, a substituted key, or a payload tampered after signing (e.g. a
+  // status downgrade) all fail here (vectors a / c / e).
+  const signingInput = `${headerSeg}.${payloadSeg}`;
+  if (!verifyEd25519(signingInput, pinnedKey, signatureSeg)) {
+    fail('jws_signature_valid',
+      'JWS signature does not verify under the pinned emitter key over the presented signing input');
+    return done();
+  }
+  checks.jws_signature_valid = true;
+
+  // ── 5. required claims ────────────────────────────────────────────────────
+  const event = singleEvent(payload);
+  const claimProblems = [];
+  if (!isStr(payload.iss)) claimProblems.push('iss');
+  if (!isEpochSeconds(payload.iat)) claimProblems.push('iat');
+  if (!isStr(payload.jti)) claimProblems.push('jti');
+  if (!isStr(payload.aud)) claimProblems.push('aud');
+  if (!isStr(payload.sub_id)) claimProblems.push('sub_id');
+  if (!event) {
+    claimProblems.push('events (exactly one advisory event member required)');
+  } else {
+    if (!isStr(event.status)) claimProblems.push('events.status');
+    if (!isStrArray(event.reason_codes)) claimProblems.push('events.reason_codes');
+    if (!isStr(event.recommended_policy_action)) claimProblems.push('events.recommended_policy_action');
+    if (!isStr(event.advisory_hash)) claimProblems.push('events.advisory_hash');
+    if (!isStr(event.expires_at)) claimProblems.push('events.expires_at');
+  }
+  if (claimProblems.length > 0) {
+    fail('claims_present', `missing/ill-typed required claims: ${claimProblems.join(', ')}`);
+    return done();
+  }
+  checks.claims_present = true;
+
+  // ── 6. audience (gated only when opts.audience is set) ────────────────────
+  if (isStr(opts.audience)) {
+    if (payload.aud !== opts.audience) {
+      fail('audience_match', `aud "${payload.aud}" != expected audience "${opts.audience}"`);
+    }
+  }
+
+  // ── 7. freshness (enforced only when required) ────────────────────────────
+  // A stale SET is rejected, never used to tighten OR relax. Freshness is
+  // enforced on BOTH exp/expires_at and iat age (vectors g / h).
+  if (opts.requireFresh === true) {
+    const now = isEpochSeconds(opts.now)
+      ? opts.now
+      : Math.floor(Date.now() / 1000);
+
+    // exp: prefer the JWT exp if present; always also enforce the event expires_at.
+    if (isEpochSeconds(payload.exp) && payload.exp <= now) {
+      fail('fresh', `SET exp ${payload.exp} is not after now ${now} (expired)`);
+    }
+    const expiresAtMs = Date.parse(event.expires_at);
+    if (Number.isNaN(expiresAtMs)) {
+      fail('fresh', `events.expires_at "${event.expires_at}" is not a parseable timestamp`);
+    } else if (Math.floor(expiresAtMs / 1000) <= now) {
+      fail('fresh', `events.expires_at "${event.expires_at}" is in the past (stale)`);
+    }
+
+    // iat age: an ancient issuance is stale even if exp parsing alone might pass.
+    if (isEpochSeconds(opts.maxAgeSec)) {
+      const age = now - payload.iat;
+      if (age > opts.maxAgeSec) {
+        fail('fresh', `iat age ${age}s exceeds maxAgeSec ${opts.maxAgeSec}s (stale issuance)`);
+      }
+    }
+  }
+
+  // ── 8. actionable status (a signed 'clear' event is REJECTED) ─────────────
+  // 'clear' is the default-path no-change posture (Eye spec §6); permitting a
+  // signed 'clear' event would let a replayed/forged 'clear' be read as an
+  // affirmative "authorized" signal (vector j_clear_status_emitted_as_event).
+  if (ACTIONABLE_STATUSES.includes(event.status)) {
+    checks.status_is_actionable = true;
+  } else {
+    fail('status_is_actionable',
+      `event status "${event.status}" is not an actionable posture-change status `
+      + `(a 'clear' or unknown status is not a posture event)`);
+  }
+
+  // ── 9. never-sole-gate marker (load-bearing, in-band) ─────────────────────
+  // The in-band invariant is load-bearing: a posture-change event that does not
+  // carry never_sole_gate:true is malformed for this profile and MUST be rejected
+  // (vector i_missing_never_sole_gate_marker).
+  if (event.never_sole_gate === true) {
+    checks.never_sole_gate_present = true;
+  } else {
+    fail('never_sole_gate_present',
+      'event member does not carry never_sole_gate:true (the in-band invariant is required)');
+  }
+
+  const valid = Object.values(checks).every(Boolean);
+
+  // The returned POSTURE is advice, not a command, and is NEVER allow/deny. The
+  // relying party MUST recompute scope_binding_hash against the action it is
+  // gating (Eye spec §7.3) and apply the posture TIGHTEN-ONLY. There is no
+  // decision vocabulary here by construction.
+  const posture = valid
+    ? {
+        status: event.status,
+        reason_codes: [...event.reason_codes],
+        recommended_policy_action: event.recommended_policy_action,
+        scope_binding_hash: payload.sub_id,
+        advisory_hash: event.advisory_hash,
+        expires_at: event.expires_at,
+        never_sole_gate: true,
+      }
+    : null;
+
+  return { valid, checks, errors, posture };
+}
+
+const eyeSet = {
+  buildEyeSet,
+  verifyEyeSet,
+  EYE_SET_VERSION,
+  EYE_SET_TYP,
+  EYE_ADVISORY_EVENT_URI,
+};
+export default eyeSet;

--- a/lib/revocation/revocation.js
+++ b/lib/revocation/revocation.js
@@ -1,0 +1,404 @@
+/**
+ * EMILIA Protocol — Portable, offline-verifiable revocation statement
+ * (EP-REVOCATION-v1)
+ *
+ * @license Apache-2.0
+ *
+ * REFERENCE IMPLEMENTATION of an ADDITIVE signed claim + fail-closed verifier
+ * check over EP-RECEIPT-v1. Spec: docs/EP-REVOCATION-SPEC.md. Conformance
+ * vectors: conformance/vectors/revocation.v1.json. EXPERIMENTAL — governed by an
+ * Extension PIP; not a production or customer claim; reports no metrics.
+ *
+ *   target the relying party HOLDS { target_type, target_id, action_hash }
+ *     -> a SIGNED revocation statement that BINDS that exact (target_id, action_hash)
+ *       -> verify under the key the verifier PINNED for revoker_id (not self-asserted)
+ *         -> fail closed on any: version / binding / pin / freshness / signature gap
+ *
+ * THE GAP THIS FILLS. Revocation in EP today is SERVER-STATE only:
+ * revokeCommit() (lib/commit.js) flips a commit to status:'revoked', and
+ * revokeAttestation()/revokeChallenge() (lib/signoff/revoke.js) do the same for
+ * signoff records — all live datastore queries. There is NO portable artifact a
+ * relying party can be HANDED to prove, offline and with no call back to the
+ * issuer, that a previously-valid authorization is now revoked. This profile
+ * defines that artifact: a detached, signed revocation statement over a target,
+ * carrying revoker_id + revoked_at + reason, and a verifier that accepts it only
+ * when it is AUTHENTIC and BINDS the exact target.
+ *
+ * NO NEW TRUST BEYOND ONE SIGNATURE. The only added trust input is the REVOKER's
+ * attested signature. The revoker is a party EP IDENTIFIES BUT NEVER TRUSTS: its
+ * signature ATTRIBUTES the revocation claim to a named, PINNED key — a self-
+ * asserted, unpinned key confers NOTHING (anyone can mint a keypair and sign "X
+ * is revoked"). This mirrors executor_key_pinned (lib/execution/integrity.js) and
+ * signer_key_unpinned (lib/wysiwys/render.js).
+ *
+ * FROZEN CORE (PIP-001). This file does NOT modify the EP-RECEIPT-v1 wire
+ * format, canonicalization, or signature, and it does NOT touch packages/verify
+ * or packages/issue, nor the existing server-state revocation. It imports the
+ * frozen canonicalize() as the single canonicalization source of truth (same
+ * relative-import convention as lib/provenance/chain.js, lib/execution/integrity.js,
+ * and lib/wysiwys/render.js) and re-implements nothing of Core's receipt path.
+ *
+ * FAIL CLOSED: verifyRevocation() returns { valid:false } whenever the @version
+ * is wrong, whenever the statement does not bind the EXACT (target_type,
+ * target_id, action_hash) the verifier holds (revoking A must never revoke B),
+ * whenever revoker_id is unpinned or the proof key differs from the pinned key,
+ * whenever revoked_at is absent/malformed, whenever the proof is forged or signs
+ * bytes other than the verifier-recomputed SIGNED_FIELDS, and (when required)
+ * whenever revoked_at is older than the freshness window.
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ * HONEST BOUNDARY — READ THIS. Offline verification proves the revocation
+ * statement is AUTHENTIC and BINDS the target. It does NOT prove you hold the
+ * LATEST revocation state. "Has this authorization been revoked by a statement I
+ * do NOT hold?" is a freshness / liveness / transparency problem — exactly the
+ * gap OCSP and CRLs exist to fill — and is OUT OF SCOPE of this offline check. A
+ * relying party that needs liveness MUST consult a revocation feed / transparency
+ * log, or rely on a short receipt TTL; the offline artifact answers "is THIS
+ * revocation real and for THIS target", NOT "is the absence of a revocation
+ * trustworthy". Treating absence-of-statement as proof-of-not-revoked is a
+ * relying-party error this profile CANNOT prevent. The opts freshness window
+ * bounds how stale a PRESENTED statement may be; it does nothing about a
+ * revocation that was never handed to the verifier.
+ * ──────────────────────────────────────────────────────────────────────────
+ */
+
+import crypto from 'node:crypto';
+
+// Compose the FROZEN v1 issuer's canonicalizer as the single source of
+// canonicalization truth. Relative import to the in-repo package source mirrors
+// lib/provenance/chain.js and lib/execution/integrity.js, so the signed bytes
+// are identical to the published @emilia-protocol/issue by construction.
+import { canonicalize } from '../../packages/issue/index.js';
+
+export const REVOCATION_VERSION = 'EP-REVOCATION-v1';
+
+// The set of target_type values this profile recognizes.
+const TARGET_TYPES = Object.freeze(['receipt', 'commit', 'delegation']);
+
+// ── small helpers ────────────────────────────────────────────────────────────
+
+/** Normalize a "sha256:<hex>" or bare-hex hash to lowercase bare hex. */
+const hexOf = (h) => String(h ?? '').replace(/^sha256:/, '').toLowerCase();
+
+/** Well-formed RFC 3339 instant => epoch ms, else null (never throws). */
+function instantMs(s) {
+  if (typeof s !== 'string' || s.length === 0) return null;
+  const t = Date.parse(s);
+  return Number.isNaN(t) ? null : t;
+}
+
+/**
+ * The canonical bytes the REVOKER signature is bound to — the fixed SIGNED_FIELDS
+ * set. The verifier INDEPENDENTLY recomputes these from the PRESENTED statement
+ * fields, so a producer cannot present one set of fields while claiming a
+ * signature over another (revoked_at / reason / target cannot be swapped after
+ * signing). Field order is irrelevant — canonicalize() sorts keys.
+ *
+ * Mirrors EP-REVOCATION-SPEC §3.3: canonicalize({ @version, target_type,
+ * target_id, action_hash, revoker_id, revoked_at, reason }).
+ */
+function revocationSignedPayload(stmt) {
+  return Buffer.from(
+    canonicalize({
+      '@version': REVOCATION_VERSION,
+      action_hash: stmt.action_hash ?? null,
+      reason: stmt.reason ?? null,
+      revoked_at: stmt.revoked_at ?? null,
+      revoker_id: stmt.revoker_id ?? null,
+      target_id: stmt.target_id ?? null,
+      target_type: stmt.target_type ?? null,
+    }),
+    'utf8',
+  );
+}
+
+/**
+ * Verify a detached Ed25519 signature over `bytes` under a base64url SPKI-DER
+ * public key. Returns true/false; never throws. This is the ONLY signature
+ * primitive added here, and it grants NO trust by itself — the caller gates on it
+ * AND on the key being pinned (identified-but-not-trusted).
+ */
+function verifyEd25519(bytes, publicKeyB64u, signatureB64u) {
+  try {
+    if (!bytes || !publicKeyB64u || !signatureB64u) return false;
+    const key = crypto.createPublicKey({
+      key: Buffer.from(publicKeyB64u, 'base64url'),
+      format: 'der',
+      type: 'spki',
+    });
+    return crypto.verify(null, bytes, key, Buffer.from(signatureB64u, 'base64url'));
+  } catch {
+    return false;
+  }
+}
+
+/** A base64url string that decodes to a plausible Ed25519 signature length (64 bytes). */
+function isWellFormedSignature(sigB64u) {
+  try { return Buffer.from(String(sigB64u ?? ''), 'base64url').length === 64; }
+  catch { return false; }
+}
+
+// ── assembly (revoker / issuer side) ──────────────────────────────────────────
+
+/**
+ * buildRevocation — produce an EP-REVOCATION-v1 statement binding the exact
+ * target, signed by the revoker (detached `proof` block keyed by revoker_key_id).
+ *
+ * HONESTY GATE: this refuses to mint a statement that does not bind a COMPLETE
+ * target (target_type + target_id + action_hash) or that lacks a revoked_at
+ * anchor. A signed claim asserts a fact that was structurally well-formed at
+ * signing time. (Negative tests bypass this gate by re-signing tampered/partial
+ * bytes directly, to exercise the verifier's independent fail-closed checks.)
+ *
+ * @param {object} args
+ * @param {{ target_type:string, target_id:string, action_hash:string }} args.target
+ *   - the thing being revoked; both target_id AND action_hash are part of the binding.
+ * @param {string} args.revoker_id - the party asserting the revocation (pinned by the verifier).
+ * @param {string} [args.revoked_at] - RFC 3339 instant the revocation took effect (defaults to now).
+ * @param {string} [args.reason] - human-readable cause (covered by the signature).
+ * @param {{ revoker_key_id?:string, privateKey:import('crypto').KeyObject,
+ *           publicKeyB64u:string, algorithm?:string }} args.signer - the revoker's signer.
+ * @returns {object} an EP-REVOCATION-v1 statement (with a `proof` block).
+ */
+export function buildRevocation({
+  target,
+  revoker_id: revokerId,
+  revoked_at: revokedAt = new Date().toISOString(),
+  reason,
+  signer,
+} = {}) {
+  if (!target || typeof target !== 'object') {
+    throw new Error('buildRevocation requires target {target_type,target_id,action_hash}');
+  }
+  if (!target.target_type || !target.target_id || !target.action_hash) {
+    throw new Error('buildRevocation: target must bind target_type, target_id, and action_hash (fail-closed honesty gate)');
+  }
+  if (!revokerId) throw new Error('buildRevocation requires revoker_id');
+  if (!revokedAt) throw new Error('buildRevocation requires a revoked_at anchor');
+  if (!signer || !signer.privateKey || !signer.publicKeyB64u) {
+    throw new Error('buildRevocation requires signer.{privateKey,publicKeyB64u}');
+  }
+
+  const stmt = {
+    '@version': REVOCATION_VERSION,
+    target_type: target.target_type,
+    target_id: target.target_id,
+    action_hash: target.action_hash,
+    revoker_id: revokerId,
+    revoked_at: revokedAt,
+    reason: reason ?? null,
+  };
+
+  const payload = revocationSignedPayload(stmt);
+  stmt.proof = {
+    algorithm: signer.algorithm || 'Ed25519',
+    revoker_key_id: signer.revoker_key_id || revokerId,
+    signed_payload_b64u: payload.toString('base64url'),
+    signature_b64u: crypto.sign(null, payload, signer.privateKey).toString('base64url'),
+    public_key: signer.publicKeyB64u,
+  };
+  // EVIDENCE that a named revoker attested this; never proof you hold the LATEST
+  // revocation state. See the HONEST BOUNDARY block above and SPEC §7.
+  stmt.scope_note =
+    'Revoker is identified but not trusted: this attributes the revocation claim to a named, pinned key. '
+    + 'Offline verification proves THIS revocation is real and binds THIS target; it does NOT prove the '
+    + 'absence of a revocation is trustworthy (freshness/transparency is a layer above — SPEC §7).';
+  return stmt;
+}
+
+// ── verification (verifier side) ──────────────────────────────────────────────
+
+/**
+ * verifyRevocation(target, statement, opts) — FAIL-CLOSED revocation check.
+ *
+ * Given the TARGET the relying party HOLDS (derived from the receipt/commit it
+ * has, never from the statement) and a candidate statement, evaluates the gating
+ * checks below. Any one false ⇒ valid:false. valid = AND(all gating checks).
+ *
+ * Rejects (valid:false) on ANY of:
+ *   - version: @version is not EP-REVOCATION-v1 (vector f);
+ *   - target_bound: the statement does not bind the EXACT (target_type,
+ *     target_id, action_hash) the verifier holds — a statement for a different
+ *     target_id (vector d) or a different action_hash (vector e, revoke-A-for-B)
+ *     is rejected; revoking A must never revoke B;
+ *   - revoker_key_pinned: revoker_id is not pinned by the verifier (vector b,
+ *     self-asserted key), or the proof key differs from the pinned key (vector c,
+ *     key substitution) — never falls back to the proof's own public_key;
+ *   - revoked_at_present: revoked_at is absent or malformed (vector h);
+ *   - revoker_signature_valid + signature_binds_statement: the proof is forged
+ *     (vector a) or signs bytes other than the verifier-recomputed SIGNED_FIELDS
+ *     (vector g, tampered-after-signing);
+ *   - freshness: (only when opts.maxAgeSeconds is set) revoked_at is older than
+ *     opts.maxAgeSeconds relative to opts.now (vector i).
+ *
+ * @param {{ target_type:string, target_id:string, action_hash:string }} target
+ *   - the thing the relying party is reasoning about (NOT taken from the statement).
+ * @param {object|null} statement - an EP-REVOCATION-v1 statement, or null/absent.
+ * @param {object} [opts]
+ * @param {Record<string,{public_key:string}>} [opts.revokerKeys] - pinned key per
+ *   revoker_id. A revoker with no pin, or a proof whose key differs, is rejected.
+ * @param {number} [opts.maxAgeSeconds] - when set, the max age of a PRESENTED
+ *   statement's revoked_at relative to opts.now (freshness bound, NOT completeness).
+ * @param {number|string|Date} [opts.now] - reference time for freshness (default: now).
+ * @returns {{ valid:boolean, checks:object, errors:string[] }}
+ */
+export function verifyRevocation(target, statement, opts = {}) {
+  const revokerKeys = opts.revokerKeys || {};
+
+  const checks = {
+    version: true,                  // @version matches
+    target_bound: true,             // binds the EXACT (target_type, target_id, action_hash)
+    revoker_key_pinned: true,       // revoker_id maps to a pinned key == the proof key
+    revoked_at_present: true,       // revoked_at present and well-formed
+    revoker_signature_valid: true,  // signature verifies under the pinned key
+    signature_binds_statement: true,// signature is over the recomputed presented bytes
+    freshness: true,                // (vacuous unless opts.maxAgeSeconds is set)
+  };
+  const errors = [];
+  const fail = (key, msg) => { checks[key] = false; errors.push(msg); };
+
+  // A missing statement confers nothing — fail closed (an absent statement is not
+  // proof of anything; it is the relying party's job to obtain one).
+  if (!statement || typeof statement !== 'object') {
+    fail('signature_binds_statement', 'no revocation statement presented (fail-closed)');
+    fail('revoker_signature_valid', 'no revocation statement presented (fail-closed)');
+    return { valid: false, checks, errors };
+  }
+
+  // ── 1. version ────────────────────────────────────────────────────────────
+  if (statement['@version'] !== REVOCATION_VERSION) {
+    fail('version', `unsupported version: ${statement['@version']}`);
+  }
+
+  // ── 2. target binding (BOTH target_id AND action_hash; never just an id) ────
+  if (!target || typeof target !== 'object') {
+    fail('target_bound', 'no target handed to the verifier (fail-closed)');
+  } else {
+    if (target.target_type && !TARGET_TYPES.includes(target.target_type)) {
+      fail('target_bound', `unknown target_type "${target.target_type}"`);
+    }
+    if (statement.target_type !== target.target_type) {
+      fail('target_bound',
+        `statement target_type "${statement.target_type}" != handed target_type "${target.target_type}"`);
+    }
+    if (statement.target_id !== target.target_id) {
+      fail('target_bound',
+        `statement target_id "${statement.target_id}" != handed target_id "${target.target_id}"`);
+    } else if (hexOf(statement.action_hash) !== hexOf(target.action_hash)) {
+      // target_id matched but action_hash did not — the revoke-A-presented-for-B
+      // case (vector e). Revoking A must never revoke B.
+      fail('target_bound',
+        `statement action_hash ${hexOf(statement.action_hash)} != handed action_hash ${hexOf(target.action_hash)} `
+        + '(revoke-A-presented-for-B)');
+    }
+  }
+
+  // ── 3. revoker key pinned (identified-but-not-trusted) ─────────────────────
+  // revoker_id MUST resolve to a key the verifier PINNED, and the proof's key
+  // MUST equal that pinned key. No pin ⇒ reject (vector b). Different key ⇒
+  // reject (vector c). NEVER fall back to the proof's self-asserted public_key.
+  const proof = statement.proof || null;
+  const revokerId = statement.revoker_id;
+  const pinned = revokerKeys[revokerId]?.public_key;
+  const presentedKey = proof?.public_key ?? null;
+  if (!pinned) {
+    fail('revoker_key_pinned',
+      `no pinned key for revoker "${revokerId}" (identified but not trusted)`);
+  } else if (presentedKey && pinned !== presentedKey) {
+    fail('revoker_key_pinned',
+      `presented revoker key does not match the pinned key for "${revokerId}" (key substitution)`);
+  }
+
+  // ── 4. revoked_at present + well-formed (the freshness/replay anchor) ───────
+  const revokedAtMs = instantMs(statement.revoked_at);
+  if (revokedAtMs === null) {
+    fail('revoked_at_present', 'revoked_at is absent or not a well-formed RFC 3339 instant');
+  }
+
+  // ── 5. signature: valid AND bound to the recomputed presented bytes ────────
+  // Verify under the PINNED key (never a producer-supplied key), over bytes the
+  // verifier recomputes from the presented statement fields. FAIL CLOSED, never
+  // throw: a non-canonicalizable field yields null bytes, against which no
+  // signature can verify.
+  let recomputedBytes = null;
+  try {
+    recomputedBytes = revocationSignedPayload(statement);
+  } catch {
+    recomputedBytes = null;
+  }
+  const signatureB64u = proof?.signature_b64u ?? null;
+  const sigBindsPinned = pinned && recomputedBytes && verifyEd25519(recomputedBytes, pinned, signatureB64u);
+  if (!sigBindsPinned) {
+    // Diagnose against whichever key we have so the forensic cause is precise,
+    // but the VERDICT only ever honors the pinned key (set in check 3 above).
+    const verifyKey = pinned || presentedKey;
+    const sigOverRecomputed = verifyKey && recomputedBytes && verifyEd25519(recomputedBytes, verifyKey, signatureB64u);
+    if (!signatureB64u || !verifyKey) {
+      fail('revoker_signature_valid', 'revocation proof signature or key missing');
+    } else if (!sigOverRecomputed && isWellFormedSignature(signatureB64u)) {
+      // Well-formed signature that does not verify over the recomputed bytes:
+      // either forged (verifies nowhere — vector a) or valid over OTHER (tampered)
+      // bytes (vector g). Without the original bytes we cannot tell which, so we
+      // flag BOTH the math and the binding to keep fail-closed and forensic.
+      fail('signature_binds_statement',
+        'revoker signature does not bind the presented statement bytes (recomputed payload mismatch)');
+      fail('revoker_signature_valid',
+        'revoker signature does not verify under the pinned revoker key over the recomputed bytes');
+    } else if (!sigOverRecomputed) {
+      fail('revoker_signature_valid',
+        'revoker signature does not verify under the pinned revoker key');
+    }
+    // (If sigOverRecomputed is true here, the only reason sigBindsPinned was
+    // false is that no key is pinned — already failed in check 3, fail-closed.)
+  }
+
+  // ── 6. freshness (optional — bounds staleness of a PRESENTED statement) ────
+  // This bounds how stale a PRESENTED statement may be. It does NOTHING about a
+  // revocation that was never handed to the verifier — see the HONEST BOUNDARY
+  // block above and SPEC §7. When opts.maxAgeSeconds is unset, freshness is
+  // vacuously true.
+  if (typeof opts.maxAgeSeconds === 'number' && revokedAtMs !== null) {
+    const nowMs = opts.now === undefined ? Date.now() : new Date(opts.now).getTime();
+    if (!Number.isNaN(nowMs)) {
+      const ageSeconds = (nowMs - revokedAtMs) / 1000;
+      if (ageSeconds > opts.maxAgeSeconds) {
+        fail('freshness',
+          `revoked_at is ${Math.round(ageSeconds)}s old, beyond the ${opts.maxAgeSeconds}s freshness window `
+          + '(NOTE: this bounds a PRESENTED statement only; it does not close the absence-of-statement gap)');
+      }
+    }
+  }
+
+  const valid = Object.values(checks).every(Boolean);
+  return { valid, checks, errors };
+}
+
+/**
+ * isRevoked(target, statements, opts) — aggregate convenience over a BAG of
+ * statements a relying party may have collected. Returns true IFF at least one
+ * statement returns valid:true from verifyRevocation(target, statement, opts).
+ *
+ * It does NOT require the matching statement to be first or alone (vector z2):
+ * a valid binding statement sitting among unrelated (validly-signed-but-for-
+ * other-targets) statements still yields true, and the unrelated ones are
+ * ignored. It is NOT a completeness oracle: a `false` means "no VALID binding
+ * statement is present IN THIS BAG", never "this target was never revoked
+ * anywhere" — the absence-of-statement gap (SPEC §7) is out of scope.
+ *
+ * @param {{ target_type:string, target_id:string, action_hash:string }} target
+ * @param {Array<object>} statements
+ * @param {object} [opts] - same opts as verifyRevocation.
+ * @returns {boolean}
+ */
+export function isRevoked(target, statements, opts = {}) {
+  if (!Array.isArray(statements)) return false;
+  return statements.some((s) => verifyRevocation(target, s, opts).valid);
+}
+
+const revocation = {
+  buildRevocation,
+  verifyRevocation,
+  isRevoked,
+  REVOCATION_VERSION,
+};
+export default revocation;

--- a/tests/eye-set.test.js
+++ b/tests/eye-set.test.js
@@ -1,0 +1,630 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect } from 'vitest';
+import crypto from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import {
+  buildEyeSet,
+  verifyEyeSet,
+  EYE_SET_VERSION,
+  EYE_SET_TYP,
+  EYE_ADVISORY_EVENT_URI,
+} from '../lib/eye/eye-set.js';
+
+import {
+  canonicalize,
+  generateEd25519KeyPair,
+} from '../packages/issue/index.js';
+
+/**
+ * EP-EYE-SET-v1 — live-crypto adversarial conformance suite.
+ *
+ * For each attack catalogued in conformance/vectors/eye-set.v1.json we build a
+ * SET that MUST verify { valid:false } on the catalogued failing_check, plus the
+ * two well-formed positives that MUST verify { valid:true }. Every keypair and
+ * every signature is minted LIVE (real Ed25519 over the real JWS signing input)
+ * so each negative is a genuine forgery / tamper / confusion attempt, not
+ * hand-edited JSON that would have failed for some unrelated reason.
+ *
+ * The EP-EYE-SET emission is ADDITIVE over Eye's advisory path: it composes the
+ * frozen canonicalize() and adds exactly one new primitive — a detached EdDSA/JWS
+ * over node:crypto. An Eye SET INFORMS; verifyEyeSet returns a POSTURE, never
+ * allow/deny, and never authorizes. FAIL CLOSED on alg confusion, an unpinned or
+ * substituted emitter key, a forged/tampered signature, a missing claim, an
+ * audience mismatch, staleness, a non-actionable status, or a missing
+ * never-sole-gate marker.
+ */
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const VECTORS = JSON.parse(
+  readFileSync(path.join(__dirname, '..', 'conformance', 'vectors', 'eye-set.v1.json'), 'utf8'),
+);
+const byId = (list, id) => list.find((v) => v.id === id);
+
+// ── reference material ─────────────────────────────────────────────────────────
+
+const EMITTER_KID = 'ep:eye:emitter#1';
+const EMITTER_ISS = 'ep:eye:emitter#1';
+const AUDIENCE = 'rp:bank-a';
+
+const emitterKp = generateEd25519KeyPair();
+
+/** Pinned-key map a verifier trusts (identified-AND-pinned). */
+function pinnedKeys(kp = emitterKp, kid = EMITTER_KID) {
+  return { [kid]: { public_key: kp.publicKeyB64u } };
+}
+
+/** signer for buildEyeSet using a raw private KeyObject. */
+function signer(kp = emitterKp, kid = EMITTER_KID, iss = EMITTER_ISS) {
+  return { kid, iss, privateKey: kp.privateKey };
+}
+
+/** A fresh, well-formed actionable advisory (elevated). */
+function elevatedAdvisory() {
+  return {
+    status: 'elevated',
+    reason_codes: ['device_fingerprint_changed', 'high_severity_signal_active'],
+    recommended_policy_action: 'step_up_auth',
+    scope_binding_hash: 'sha256:' + 'a'.repeat(64),
+    advisory_hash: 'sha256:' + 'b'.repeat(64),
+    expires_at: new Date(Date.now() + 3600_000).toISOString(),
+  };
+}
+
+/** A fresh, well-formed review_required advisory (most-tightening). */
+function reviewRequiredAdvisory() {
+  return {
+    status: 'review_required',
+    reason_codes: ['critical_signal_active'],
+    recommended_policy_action: 'require_signoff',
+    scope_binding_hash: 'sha256:' + 'c'.repeat(64),
+    advisory_hash: 'sha256:' + 'd'.repeat(64),
+    expires_at: new Date(Date.now() + 3600_000).toISOString(),
+  };
+}
+
+const NOW_SEC = Math.floor(Date.now() / 1000);
+
+// base64url helpers mirroring the lib (kept local so the test does not import lib internals).
+const b64u = (buf) => Buffer.from(buf).toString('base64url');
+const encodeSeg = (obj) => b64u(Buffer.from(canonicalize(obj), 'utf8'));
+
+/** Split a compact SET into [header, payload, signature] objects/segments. */
+function parts(compact) {
+  const [h, p, s] = compact.split('.');
+  return {
+    headerSeg: h,
+    payloadSeg: p,
+    signatureSeg: s,
+    header: JSON.parse(Buffer.from(h, 'base64url').toString('utf8')),
+    payload: JSON.parse(Buffer.from(p, 'base64url').toString('utf8')),
+  };
+}
+
+/** Re-encode a header.payload pair and sign it live under kp (a genuine signature). */
+function mint(header, payload, kp = emitterKp) {
+  const headerSeg = encodeSeg(header);
+  const payloadSeg = encodeSeg(payload);
+  const signingInput = `${headerSeg}.${payloadSeg}`;
+  const sig = crypto.sign(null, Buffer.from(signingInput, 'ascii'), kp.privateKey).toString('base64url');
+  return `${signingInput}.${sig}`;
+}
+
+// ── version + assembly ──────────────────────────────────────────────────────────
+
+describe('EP-EYE-SET-v1 — version + assembly', () => {
+  it('exposes the wire version, typ, and event URI', () => {
+    expect(EYE_SET_VERSION).toBe('EP-EYE-SET-v1');
+    expect(EYE_SET_TYP).toBe('secevent+jwt');
+    expect(EYE_ADVISORY_EVENT_URI).toBe('https://schemas.emiliaprotocol.ai/secevent/eye-advisory');
+  });
+
+  it('buildEyeSet emits a 3-segment secevent+jwt with the redacted, scope-bound shape', () => {
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    const { header, payload } = parts(compact);
+    expect(compact.split('.')).toHaveLength(3);
+    expect(header).toMatchObject({ alg: 'EdDSA', typ: 'secevent+jwt', kid: EMITTER_KID });
+    // sub_id is the scope_binding_hash, NOT a raw identifier.
+    expect(payload.sub_id).toBe(adv.scope_binding_hash);
+    expect(payload).toMatchObject({ iss: EMITTER_ISS, aud: AUDIENCE });
+    expect(typeof payload.iat).toBe('number');
+    expect(typeof payload.jti).toBe('string');
+    const event = payload.events[EYE_ADVISORY_EVENT_URI];
+    expect(event).toMatchObject({
+      status: 'elevated',
+      recommended_policy_action: 'step_up_auth',
+      advisory_hash: adv.advisory_hash,
+      expires_at: adv.expires_at,
+      never_sole_gate: true,
+    });
+    // NO raw subject/actor/target/issuer refs anywhere in the wire bytes.
+    const wire = JSON.stringify(payload);
+    expect(wire).not.toMatch(/subject_ref|actor_ref|target_ref|issuer_ref/);
+  });
+
+  it('buildEyeSet accepts the advisory-spec recommended_action as the source field', () => {
+    const adv = { ...elevatedAdvisory(), recommended_policy_action: undefined, recommended_action: 'escalate' };
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    const { payload } = parts(compact);
+    expect(payload.events[EYE_ADVISORY_EVENT_URI].recommended_policy_action).toBe('escalate');
+  });
+
+  it('buildEyeSet refuses to emit a clear status (build-time, §3.4)', () => {
+    const adv = { ...elevatedAdvisory(), status: 'clear', reason_codes: [] };
+    expect(() => buildEyeSet(adv, { signer: signer(), audience: AUDIENCE })).toThrow(/clear/i);
+  });
+
+  it('buildEyeSet refuses an unknown / non-actionable status', () => {
+    const adv = { ...elevatedAdvisory(), status: 'banana' };
+    expect(() => buildEyeSet(adv, { signer: signer(), audience: AUDIENCE })).toThrow(/actionable/i);
+  });
+
+  it('buildEyeSet validates required arguments and advisory fields', () => {
+    expect(() => buildEyeSet(null, { signer: signer() })).toThrow(/advisory object/i);
+    expect(() => buildEyeSet(elevatedAdvisory(), {})).toThrow(/signer/i);
+    expect(() => buildEyeSet(elevatedAdvisory(), { signer: { kid: EMITTER_KID } })).toThrow(/privateKey|sign/i);
+    expect(() => buildEyeSet({ ...elevatedAdvisory(), scope_binding_hash: undefined }, { signer: signer() }))
+      .toThrow(/scope_binding_hash/i);
+    expect(() => buildEyeSet({ ...elevatedAdvisory(), reason_codes: [] }, { signer: signer() }))
+      .toThrow(/reason_codes/i);
+    expect(() => buildEyeSet({ ...elevatedAdvisory(), recommended_policy_action: undefined, recommended_action: undefined }, { signer: signer() }))
+      .toThrow(/recommended_policy_action/i);
+    expect(() => buildEyeSet({ ...elevatedAdvisory(), advisory_hash: undefined }, { signer: signer() }))
+      .toThrow(/advisory_hash/i);
+    expect(() => buildEyeSet({ ...elevatedAdvisory(), expires_at: undefined }, { signer: signer() }))
+      .toThrow(/expires_at/i);
+  });
+
+  it('buildEyeSet supports a sign(callback) so EP need not hold the key', () => {
+    const adv = elevatedAdvisory();
+    const cbSigner = {
+      kid: EMITTER_KID,
+      iss: EMITTER_ISS,
+      sign: (input) => crypto.sign(null, Buffer.from(input, 'ascii'), emitterKp.privateKey).toString('base64url'),
+    };
+    const compact = buildEyeSet(adv, { signer: cbSigner, audience: AUDIENCE });
+    const r = verifyEyeSet(compact, { pinnedKeys: pinnedKeys(), audience: AUDIENCE, requireFresh: true });
+    expect(r.valid).toBe(true);
+  });
+});
+
+// ── must_reject vectors (each MUST verify valid:false on its failing_check) ──────
+
+describe('EP-EYE-SET-v1 — must_reject vectors', () => {
+  it('a_forged_jws_signature — signature over UNRELATED bytes', () => {
+    const compact = buildEyeSet(elevatedAdvisory(), { signer: signer(), audience: AUDIENCE });
+    const { headerSeg, payloadSeg } = parts(compact);
+    // A genuine Ed25519 signature, but over unrelated bytes (not the signing input).
+    const forged = crypto.sign(null, Buffer.from('unrelated-bytes', 'ascii'), emitterKp.privateKey)
+      .toString('base64url');
+    const tampered = `${headerSeg}.${payloadSeg}.${forged}`;
+    const r = verifyEyeSet(tampered, { pinnedKeys: pinnedKeys(), audience: AUDIENCE, requireFresh: true });
+    expect(r.valid).toBe(false);
+    expect(r.checks.jws_signature_valid).toBe(false);
+    expect(byId(VECTORS.must_reject, 'a_forged_jws_signature').expected.failing_check)
+      .toBe('jws_signature_valid');
+  });
+
+  it('b_unpinned_emitter_kid — signature verifies under the producer key, but kid is UNPINNED', () => {
+    // Genuinely valid SET signed by a freshly minted keypair whose kid is not pinned.
+    const otherKp = generateEd25519KeyPair();
+    const compact = buildEyeSet(elevatedAdvisory(), {
+      signer: signer(otherKp, 'ep:eye:rogue#1', 'ep:eye:rogue#1'),
+      audience: AUDIENCE,
+    });
+    // The verifier pins only the legitimate emitter — the rogue kid confers nothing.
+    const r = verifyEyeSet(compact, { pinnedKeys: pinnedKeys(), audience: AUDIENCE, requireFresh: true });
+    expect(r.valid).toBe(false);
+    expect(r.checks.emitter_key_pinned).toBe(false);
+    expect(byId(VECTORS.must_reject, 'b_unpinned_emitter_kid').expected.failing_check)
+      .toBe('emitter_key_pinned');
+  });
+
+  it('c_wrong_pinned_key_substitution — kid is pinned, but signed by a DIFFERENT key', () => {
+    const wrongKp = generateEd25519KeyPair();
+    // Sign with the wrong key under the legitimate kid; verify under the PINNED key.
+    const compact = buildEyeSet(elevatedAdvisory(), {
+      signer: signer(wrongKp, EMITTER_KID, EMITTER_ISS),
+      audience: AUDIENCE,
+    });
+    const r = verifyEyeSet(compact, { pinnedKeys: pinnedKeys(emitterKp), audience: AUDIENCE, requireFresh: true });
+    expect(r.valid).toBe(false);
+    expect(r.checks.emitter_key_pinned).toBe(true); // the kid IS pinned…
+    expect(r.checks.jws_signature_valid).toBe(false); // …but the substituted key fails the math.
+    expect(byId(VECTORS.must_reject, 'c_wrong_pinned_key_substitution').expected.failing_check)
+      .toBe('jws_signature_valid');
+  });
+
+  it("d_alg_none_confusion — alg:'none' is rejected BEFORE any verification", () => {
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    const { payload } = parts(compact);
+    // Forge an unsecured token: alg 'none', empty signature segment.
+    const header = { alg: 'none', typ: EYE_SET_TYP, kid: EMITTER_KID };
+    const unsecured = `${encodeSeg(header)}.${encodeSeg(payload)}.`;
+    const r = verifyEyeSet(unsecured, { pinnedKeys: pinnedKeys(), audience: AUDIENCE, requireFresh: true });
+    expect(r.valid).toBe(false);
+    expect(r.checks.alg_is_eddsa).toBe(false);
+    expect(byId(VECTORS.must_reject, 'd_alg_none_confusion').expected.failing_check)
+      .toBe('alg_is_eddsa');
+
+    // Also a non-EdDSA alg (algorithm confusion) is rejected on the same gate.
+    const hs256 = { alg: 'HS256', typ: EYE_SET_TYP, kid: EMITTER_KID };
+    const confused = mint(hs256, payload, emitterKp);
+    const r2 = verifyEyeSet(confused, { pinnedKeys: pinnedKeys(), audience: AUDIENCE, requireFresh: true });
+    expect(r2.valid).toBe(false);
+    expect(r2.checks.alg_is_eddsa).toBe(false);
+  });
+
+  it('e_tampered_payload_status_downgrade — status downgraded AFTER signing', () => {
+    const compact = buildEyeSet(elevatedAdvisory(), { signer: signer(), audience: AUDIENCE });
+    const { header, payload, signatureSeg } = parts(compact);
+    // Downgrade the posture in the payload, but keep the ORIGINAL signature.
+    const downgraded = JSON.parse(JSON.stringify(payload));
+    downgraded.events[EYE_ADVISORY_EVENT_URI].status = 'caution';
+    const tampered = `${encodeSeg(header)}.${encodeSeg(downgraded)}.${signatureSeg}`;
+    const r = verifyEyeSet(tampered, { pinnedKeys: pinnedKeys(), audience: AUDIENCE, requireFresh: true });
+    expect(r.valid).toBe(false);
+    expect(r.checks.jws_signature_valid).toBe(false);
+    expect(byId(VECTORS.must_reject, 'e_tampered_payload_status_downgrade').expected.failing_check)
+      .toBe('jws_signature_valid');
+  });
+
+  it('f_audience_mismatch — aud != opts.audience when an audience is pinned', () => {
+    // Minted for bank-a; presented to a verifier pinning bank-b.
+    const compact = buildEyeSet(elevatedAdvisory(), { signer: signer(), audience: 'rp:bank-a' });
+    const r = verifyEyeSet(compact, { pinnedKeys: pinnedKeys(), audience: 'rp:bank-b', requireFresh: true });
+    expect(r.valid).toBe(false);
+    expect(r.checks.audience_match).toBe(false);
+    expect(byId(VECTORS.must_reject, 'f_audience_mismatch').expected.failing_check)
+      .toBe('audience_match');
+  });
+
+  it('g_expired_set_exp_past — expires_at in the past when freshness required', () => {
+    const adv = { ...elevatedAdvisory(), expires_at: new Date(Date.now() - 3600_000).toISOString() };
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    const r = verifyEyeSet(compact, { pinnedKeys: pinnedKeys(), audience: AUDIENCE, requireFresh: true, now: NOW_SEC });
+    expect(r.valid).toBe(false);
+    expect(r.checks.fresh).toBe(false);
+    expect(byId(VECTORS.must_reject, 'g_expired_set_exp_past').expected.failing_check).toBe('fresh');
+  });
+
+  it('h_iat_too_old — iat older than maxAgeSec when freshness required', () => {
+    const oldIat = NOW_SEC - 10_000;
+    // expires_at still in the future so ONLY the iat-age check trips.
+    const adv = { ...elevatedAdvisory(), expires_at: new Date((NOW_SEC + 3600) * 1000).toISOString() };
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE, iat: oldIat });
+    const r = verifyEyeSet(compact, {
+      pinnedKeys: pinnedKeys(), audience: AUDIENCE, requireFresh: true, maxAgeSec: 300, now: NOW_SEC,
+    });
+    expect(r.valid).toBe(false);
+    expect(r.checks.fresh).toBe(false);
+    expect(byId(VECTORS.must_reject, 'h_iat_too_old').expected.failing_check).toBe('fresh');
+  });
+
+  it('i_missing_never_sole_gate_marker — marker omitted / not true', () => {
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    const { header, payload } = parts(compact);
+    // Strip the in-band marker and RE-SIGN live, so this fails ONLY on the marker
+    // check, not on the signature (a genuine, correctly signed SET that is
+    // malformed for this profile).
+    const stripped = JSON.parse(JSON.stringify(payload));
+    delete stripped.events[EYE_ADVISORY_EVENT_URI].never_sole_gate;
+    const reSigned = mint(header, stripped, emitterKp);
+    const r = verifyEyeSet(reSigned, { pinnedKeys: pinnedKeys(), audience: AUDIENCE, requireFresh: true });
+    expect(r.valid).toBe(false);
+    expect(r.checks.jws_signature_valid).toBe(true); // genuinely signed…
+    expect(r.checks.never_sole_gate_present).toBe(false); // …but missing the marker.
+    expect(byId(VECTORS.must_reject, 'i_missing_never_sole_gate_marker').expected.failing_check)
+      .toBe('never_sole_gate_present');
+
+    // A non-true marker is equally rejected.
+    const nonTrue = JSON.parse(JSON.stringify(payload));
+    nonTrue.events[EYE_ADVISORY_EVENT_URI].never_sole_gate = 'yes';
+    const reSigned2 = mint(header, nonTrue, emitterKp);
+    const r2 = verifyEyeSet(reSigned2, { pinnedKeys: pinnedKeys(), audience: AUDIENCE, requireFresh: true });
+    expect(r2.valid).toBe(false);
+    expect(r2.checks.never_sole_gate_present).toBe(false);
+  });
+
+  it('j_clear_status_emitted_as_event — a signed clear event is rejected by the verifier', () => {
+    // buildEyeSet refuses clear, so forge a correctly-signed clear SET directly to
+    // exercise the verifier's independent status_is_actionable gate.
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    const { header, payload } = parts(compact);
+    const cleared = JSON.parse(JSON.stringify(payload));
+    cleared.events[EYE_ADVISORY_EVENT_URI].status = 'clear';
+    const reSigned = mint(header, cleared, emitterKp);
+    const r = verifyEyeSet(reSigned, { pinnedKeys: pinnedKeys(), audience: AUDIENCE, requireFresh: true });
+    expect(r.valid).toBe(false);
+    expect(r.checks.jws_signature_valid).toBe(true); // genuinely signed…
+    expect(r.checks.status_is_actionable).toBe(false); // …but 'clear' is not a posture event.
+    expect(byId(VECTORS.must_reject, 'j_clear_status_emitted_as_event').expected.failing_check)
+      .toBe('status_is_actionable');
+  });
+});
+
+// ── must_accept vectors (each MUST verify valid:true; posture, never allow/deny) ──
+
+describe('EP-EYE-SET-v1 — must_accept vectors', () => {
+  it('z_well_formed_elevated_set_pinned_fresh — verifies and returns the posture', () => {
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    const r = verifyEyeSet(compact, { pinnedKeys: pinnedKeys(), audience: AUDIENCE, requireFresh: true, maxAgeSec: 3600 });
+    expect(r.errors, JSON.stringify(r, null, 2)).toEqual([]);
+    expect(r.valid).toBe(true);
+    for (const [k, v] of Object.entries(r.checks)) {
+      expect(v, `check ${k} should pass`).toBe(true);
+    }
+    // The verifier returns a POSTURE — never allow/deny, no decision vocabulary.
+    expect(r.posture).toMatchObject({
+      status: 'elevated',
+      recommended_policy_action: 'step_up_auth',
+      scope_binding_hash: adv.scope_binding_hash,
+      advisory_hash: adv.advisory_hash,
+      never_sole_gate: true,
+    });
+    expect(r.posture).not.toHaveProperty('allow');
+    expect(r.posture).not.toHaveProperty('deny');
+    expect(r.posture).not.toHaveProperty('decision');
+    expect(byId(VECTORS.must_accept, 'z_well_formed_elevated_set_pinned_fresh').expected.valid).toBe(true);
+  });
+
+  it('z2_well_formed_review_required_no_audience_pin — accepted with no audience pin', () => {
+    const adv = reviewRequiredAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    // opts.audience UNSET — audience is not gated; everything else still fails closed.
+    const r = verifyEyeSet(compact, { pinnedKeys: pinnedKeys(), requireFresh: true, maxAgeSec: 3600 });
+    expect(r.errors, JSON.stringify(r, null, 2)).toEqual([]);
+    expect(r.valid).toBe(true);
+    expect(r.checks.audience_match).toBe(true); // vacuously true when unset
+    expect(r.posture.status).toBe('review_required');
+    expect(r.posture.recommended_policy_action).toBe('require_signoff');
+    expect(byId(VECTORS.must_accept, 'z2_well_formed_review_required_no_audience_pin').expected.valid).toBe(true);
+  });
+
+  it('accepts a fresh SET resolved by iss when the kid is not the pinned map key', () => {
+    // Pin under iss instead of kid: resolvePinnedKey falls back to iss.
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: { kid: 'kid-not-in-map', iss: EMITTER_ISS, privateKey: emitterKp.privateKey }, audience: AUDIENCE });
+    const r = verifyEyeSet(compact, { pinnedKeys: { [EMITTER_ISS]: { public_key: emitterKp.publicKeyB64u } }, audience: AUDIENCE, requireFresh: true });
+    expect(r.valid).toBe(true);
+  });
+
+  it('accepts a bare-string pinned key entry', () => {
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    const r = verifyEyeSet(compact, { pinnedKeys: { [EMITTER_KID]: emitterKp.publicKeyB64u }, audience: AUDIENCE, requireFresh: true });
+    expect(r.valid).toBe(true);
+  });
+
+  it('skips freshness gating when requireFresh is not set (stale SET still parses)', () => {
+    const adv = { ...elevatedAdvisory(), expires_at: new Date(Date.now() - 3600_000).toISOString() };
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    const r = verifyEyeSet(compact, { pinnedKeys: pinnedKeys(), audience: AUDIENCE });
+    // No freshness required → fresh stays vacuously true; the rest still pass.
+    expect(r.valid).toBe(true);
+    expect(r.checks.fresh).toBe(true);
+  });
+});
+
+// ── malformed-input fail-closed (defensive parsing branches) ────────────────────
+
+describe('EP-EYE-SET-v1 — malformed input fails closed (never throws)', () => {
+  it('rejects a non-string / empty compact SET', () => {
+    for (const bad of [null, undefined, 123, '', {}]) {
+      const r = verifyEyeSet(bad, { pinnedKeys: pinnedKeys() });
+      expect(r.valid).toBe(false);
+      expect(r.posture).toBeNull();
+    }
+  });
+
+  it('rejects the wrong number of segments', () => {
+    const r = verifyEyeSet('only.two', { pinnedKeys: pinnedKeys() });
+    expect(r.valid).toBe(false);
+    expect(r.checks.alg_is_eddsa).toBe(false);
+  });
+
+  it('rejects an undecodable header / payload', () => {
+    const r1 = verifyEyeSet('!!!.also-bad.sig', { pinnedKeys: pinnedKeys() });
+    expect(r1.valid).toBe(false);
+    expect(r1.checks.alg_is_eddsa).toBe(false);
+
+    // Good header, junk payload: alg+typ pass, payload decode fails.
+    const goodHeader = encodeSeg({ alg: 'EdDSA', typ: EYE_SET_TYP, kid: EMITTER_KID });
+    const r2 = verifyEyeSet(`${goodHeader}.@@@.sig`, { pinnedKeys: pinnedKeys() });
+    expect(r2.valid).toBe(false);
+    expect(r2.checks.claims_present).toBe(false);
+  });
+
+  it('rejects a missing pinnedKeys map (no key resolvable → unpinned)', () => {
+    const compact = buildEyeSet(elevatedAdvisory(), { signer: signer(), audience: AUDIENCE });
+    const r = verifyEyeSet(compact, {});
+    expect(r.valid).toBe(false);
+    expect(r.checks.emitter_key_pinned).toBe(false);
+  });
+
+  it('rejects a SET missing required claims (no aud) — re-signed so signature is genuine', () => {
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer() }); // no audience → no aud
+    const r = verifyEyeSet(compact, { pinnedKeys: pinnedKeys() });
+    expect(r.valid).toBe(false);
+    expect(r.checks.jws_signature_valid).toBe(true);
+    expect(r.checks.claims_present).toBe(false);
+    expect(r.errors.some((e) => /aud/.test(e))).toBe(true);
+  });
+
+  it('rejects an events map that is not exactly one expected-URI member', () => {
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    const { header, payload } = parts(compact);
+    // Two event members → not exactly one.
+    const twoEvents = JSON.parse(JSON.stringify(payload));
+    twoEvents.events['https://example.com/other'] = { foo: 'bar' };
+    const r = verifyEyeSet(mint(header, twoEvents), { pinnedKeys: pinnedKeys(), audience: AUDIENCE });
+    expect(r.valid).toBe(false);
+    expect(r.checks.claims_present).toBe(false);
+
+    // Wrong URI key → rejected.
+    const wrongUri = { ...payload, events: { 'https://example.com/wrong': payload.events[EYE_ADVISORY_EVENT_URI] } };
+    const r2 = verifyEyeSet(mint(header, wrongUri), { pinnedKeys: pinnedKeys(), audience: AUDIENCE });
+    expect(r2.valid).toBe(false);
+    expect(r2.checks.claims_present).toBe(false);
+  });
+
+  it('rejects an unparseable expires_at when freshness is required', () => {
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    const { header, payload } = parts(compact);
+    const bad = JSON.parse(JSON.stringify(payload));
+    bad.events[EYE_ADVISORY_EVENT_URI].expires_at = 'not-a-date';
+    const r = verifyEyeSet(mint(header, bad), { pinnedKeys: pinnedKeys(), audience: AUDIENCE, requireFresh: true });
+    expect(r.valid).toBe(false);
+    expect(r.checks.fresh).toBe(false);
+  });
+
+  it('enforces a top-level JWT exp when present and freshness required', () => {
+    const adv = elevatedAdvisory();
+    // exp in the past, but event expires_at in the future: the exp gate must trip.
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE, exp: NOW_SEC - 100 });
+    const r = verifyEyeSet(compact, { pinnedKeys: pinnedKeys(), audience: AUDIENCE, requireFresh: true, now: NOW_SEC });
+    expect(r.valid).toBe(false);
+    expect(r.checks.fresh).toBe(false);
+  });
+
+  it('accepts a future top-level JWT exp when freshness required (exp gate passes)', () => {
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE, exp: NOW_SEC + 3600 });
+    const r = verifyEyeSet(compact, { pinnedKeys: pinnedKeys(), audience: AUDIENCE, requireFresh: true, now: NOW_SEC, maxAgeSec: 3600 });
+    expect(r.valid).toBe(true);
+    expect(r.checks.fresh).toBe(true);
+  });
+
+  it('rejects a wrong typ on the typ gate', () => {
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    const { payload } = parts(compact);
+    const wrongTyp = mint({ alg: 'EdDSA', typ: 'JWT', kid: EMITTER_KID }, payload);
+    const r = verifyEyeSet(wrongTyp, { pinnedKeys: pinnedKeys(), audience: AUDIENCE });
+    expect(r.valid).toBe(false);
+    expect(r.checks.typ_ok).toBe(false);
+  });
+
+  it('fails closed when the pinned key bytes are not a valid public key (createPublicKey throws)', () => {
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    // A pinned entry whose bytes are not a decodable SPKI key → verifyEd25519
+    // catches the createPublicKey throw and returns false (fail closed).
+    const r = verifyEyeSet(compact, {
+      pinnedKeys: { [EMITTER_KID]: { public_key: 'AAAA' } },
+      audience: AUDIENCE,
+    });
+    expect(r.valid).toBe(false);
+    expect(r.checks.emitter_key_pinned).toBe(true); // an entry WAS resolved…
+    expect(r.checks.jws_signature_valid).toBe(false); // …but it is not a usable key.
+  });
+
+  it('rejects an events member that is not an object', () => {
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    const { header, payload } = parts(compact);
+    const badMember = { ...payload, events: { [EYE_ADVISORY_EVENT_URI]: 'not-an-object' } };
+    const r = verifyEyeSet(mint(header, badMember), { pinnedKeys: pinnedKeys(), audience: AUDIENCE });
+    expect(r.valid).toBe(false);
+    expect(r.checks.claims_present).toBe(false);
+  });
+
+  it('rejects an events value that is an array (not a map)', () => {
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    const { header, payload } = parts(compact);
+    const arrEvents = { ...payload, events: [payload.events[EYE_ADVISORY_EVENT_URI]] };
+    const r = verifyEyeSet(mint(header, arrEvents), { pinnedKeys: pinnedKeys(), audience: AUDIENCE });
+    expect(r.valid).toBe(false);
+    expect(r.checks.claims_present).toBe(false);
+  });
+
+  it('rejects a non-integer iat as a missing claim', () => {
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    const { header, payload } = parts(compact);
+    const badIat = { ...payload, iat: 'soon' };
+    const r = verifyEyeSet(mint(header, badIat), { pinnedKeys: pinnedKeys(), audience: AUDIENCE });
+    expect(r.valid).toBe(false);
+    expect(r.checks.claims_present).toBe(false);
+    expect(r.errors.some((e) => /iat/.test(e))).toBe(true);
+  });
+
+  it('ignores a non-integer opts.maxAgeSec (iat age not gated) and a non-integer opts.now (uses wall clock)', () => {
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    // maxAgeSec not an integer → iat-age branch skipped; now not an integer → wall clock.
+    const r = verifyEyeSet(compact, {
+      pinnedKeys: pinnedKeys(), audience: AUDIENCE, requireFresh: true, maxAgeSec: 'lots', now: 'whenever',
+    });
+    expect(r.valid).toBe(true);
+    expect(r.checks.fresh).toBe(true);
+  });
+
+  it('treats an empty / null pinned entry as unpinned', () => {
+    const adv = elevatedAdvisory();
+    const compact = buildEyeSet(adv, { signer: signer(), audience: AUDIENCE });
+    expect(verifyEyeSet(compact, { pinnedKeys: { [EMITTER_KID]: '' } }).checks.emitter_key_pinned).toBe(false);
+    expect(verifyEyeSet(compact, { pinnedKeys: { [EMITTER_KID]: { public_key: 123 } } }).checks.emitter_key_pinned).toBe(false);
+    expect(verifyEyeSet(compact, { pinnedKeys: 'not-a-map' }).checks.emitter_key_pinned).toBe(false);
+  });
+});
+
+// ── catalogue parity (every vector id is asserted by name) ───────────────────────
+
+describe('EP-EYE-SET-v1 — vectors catalogue parity', () => {
+  it('catalogue is the expected wire tag and lengths', () => {
+    expect(VECTORS.wire_tag).toBe('EP-EYE-SET-v1');
+    expect(VECTORS.must_reject).toHaveLength(10);
+    expect(VECTORS.must_accept).toHaveLength(2);
+  });
+
+  it('every catalogued vector id is asserted by name in this suite', () => {
+    // The set of ids this suite explicitly drives (matches the it() titles above).
+    const asserted = new Set([
+      'a_forged_jws_signature',
+      'b_unpinned_emitter_kid',
+      'c_wrong_pinned_key_substitution',
+      'd_alg_none_confusion',
+      'e_tampered_payload_status_downgrade',
+      'f_audience_mismatch',
+      'g_expired_set_exp_past',
+      'h_iat_too_old',
+      'i_missing_never_sole_gate_marker',
+      'j_clear_status_emitted_as_event',
+      'z_well_formed_elevated_set_pinned_fresh',
+      'z2_well_formed_review_required_no_audience_pin',
+    ]);
+    const catalogued = [
+      ...VECTORS.must_reject.map((v) => v.id),
+      ...VECTORS.must_accept.map((v) => v.id),
+    ];
+    for (const id of catalogued) {
+      expect(asserted.has(id), `vector ${id} must be asserted by name`).toBe(true);
+    }
+    // And no asserted id is stale (not in the catalogue).
+    for (const id of asserted) {
+      expect(catalogued.includes(id), `asserted id ${id} must exist in the catalogue`).toBe(true);
+    }
+    expect(catalogued).toHaveLength(asserted.size);
+  });
+
+  it('each must_reject vector names a failing_check the verifier exposes', () => {
+    const exposed = new Set(Object.keys(
+      verifyEyeSet('x.y.z', { pinnedKeys: pinnedKeys() }).checks,
+    ));
+    for (const v of VECTORS.must_reject) {
+      expect(exposed.has(v.expected.failing_check), `${v.id} → ${v.expected.failing_check}`).toBe(true);
+    }
+  });
+});

--- a/tests/revocation.test.js
+++ b/tests/revocation.test.js
@@ -1,0 +1,542 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect } from "vitest";
+import crypto from "node:crypto";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import {
+  buildRevocation,
+  verifyRevocation,
+  isRevoked,
+  REVOCATION_VERSION,
+} from "../lib/revocation/revocation.js";
+
+import {
+  canonicalize,
+  generateEd25519KeyPair,
+} from "../packages/issue/index.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const VECTORS = JSON.parse(
+  readFileSync(
+    path.join(__dirname, "..", "conformance", "vectors", "revocation.v1.json"),
+    "utf8",
+  ),
+);
+
+const byId = (list, id) => list.find((v) => v.id === id);
+
+// ── reference material ───────────────────────────────────────────────────────
+// The target the relying party HOLDS (action A). Both target_id AND action_hash
+// are part of the binding; a statement for action B must never revoke action A.
+const TARGET_A = {
+  target_type: "receipt",
+  target_id: "rcpt_01J_A",
+  action_hash: "sha256:" + "a".repeat(64),
+};
+
+// A DIFFERENT authorization (same type) — used for "bound to a different target".
+const TARGET_B = {
+  target_type: "receipt",
+  target_id: "rcpt_01J_B",
+  action_hash: "sha256:" + "b".repeat(64),
+};
+
+// Same target_id as A but a DIFFERENT action_hash — the revoke-A-presented-for-B
+// case: a re-issued authorization with the same id but a different action.
+const TARGET_A_OTHER_ACTION = {
+  target_type: "receipt",
+  target_id: "rcpt_01J_A",
+  action_hash: "sha256:" + "c".repeat(64),
+};
+
+const REVOKER_ID = "ep:key:revoker#1";
+const revokerKp = generateEd25519KeyPair();
+
+/** The revoker signer: signs the canonical statement bytes with its own key. */
+function revokerSigner(kp = revokerKp, revokerKeyId = REVOKER_ID) {
+  return {
+    revoker_key_id: revokerKeyId,
+    privateKey: kp.privateKey,
+    publicKeyB64u: kp.publicKeyB64u,
+  };
+}
+
+/** Pinned revoker-key map the verifier trusts (identified-AND-pinned). */
+function pinnedKeys(kp = revokerKp, revokerId = REVOKER_ID) {
+  return { [revokerId]: { public_key: kp.publicKeyB64u } };
+}
+
+const REVOKED_AT = "2026-06-14T20:41:00.000Z";
+
+/** A well-formed, validly-signed binding revocation for a given target. */
+function freshStatement(target = TARGET_A, overrides = {}) {
+  return buildRevocation({
+    target,
+    revoker_id: REVOKER_ID,
+    revoked_at: REVOKED_AT,
+    reason: "policy change — key compromise suspected",
+    signer: revokerSigner(),
+    ...overrides,
+  });
+}
+
+/**
+ * Re-sign a (possibly tampered/partial) statement over its OWN canonical bytes,
+ * mirroring lib/revocation/revocation.js's revocationSignedPayload() EXACTLY, so
+ * a negative exercises the INTENDED check rather than an incidental signature
+ * break. Used by negatives that need a genuine signature over the bytes as
+ * presented (e.g. unpinned/substituted key, missing revoked_at).
+ */
+function reSign(stmt, kp) {
+  const payload = canonicalize({
+    "@version": REVOCATION_VERSION,
+    action_hash: stmt.action_hash ?? null,
+    reason: stmt.reason ?? null,
+    revoked_at: stmt.revoked_at ?? null,
+    revoker_id: stmt.revoker_id ?? null,
+    target_id: stmt.target_id ?? null,
+    target_type: stmt.target_type ?? null,
+  });
+  const bytes = Buffer.from(payload, "utf8");
+  const sig = crypto.sign(null, bytes, kp.privateKey).toString("base64url");
+  return {
+    ...stmt,
+    proof: {
+      ...(stmt.proof || {}),
+      algorithm: "Ed25519",
+      revoker_key_id: stmt.proof?.revoker_key_id ?? stmt.revoker_id ?? REVOKER_ID,
+      signed_payload_b64u: bytes.toString("base64url"),
+      signature_b64u: sig,
+      public_key: kp.publicKeyB64u,
+    },
+  };
+}
+
+// ── version + assembly ───────────────────────────────────────────────────────
+
+describe("EP-REVOCATION-v1 — version + assembly", () => {
+  it("exposes the wire version", () => {
+    expect(REVOCATION_VERSION).toBe("EP-REVOCATION-v1");
+    expect(VECTORS.wire_tag).toBe("EP-REVOCATION-v1");
+  });
+
+  it("buildRevocation mints a complete, self-verifying binding statement", () => {
+    const stmt = freshStatement();
+    expect(stmt["@version"]).toBe("EP-REVOCATION-v1");
+    expect(stmt.target_type).toBe(TARGET_A.target_type);
+    expect(stmt.target_id).toBe(TARGET_A.target_id);
+    expect(stmt.action_hash).toBe(TARGET_A.action_hash);
+    expect(stmt.revoker_id).toBe(REVOKER_ID);
+    expect(stmt.revoked_at).toBe(REVOKED_AT);
+    expect(stmt.proof.algorithm).toBe("Ed25519");
+    expect(typeof stmt.proof.signature_b64u).toBe("string");
+    // round-trips through the verifier
+    const r = verifyRevocation(TARGET_A, stmt, { revokerKeys: pinnedKeys() });
+    expect(r.valid).toBe(true);
+  });
+
+  it("buildRevocation honesty gate refuses an incomplete target or missing inputs", () => {
+    expect(() => buildRevocation({})).toThrow();
+    expect(() =>
+      buildRevocation({
+        target: { target_type: "receipt", target_id: "x" }, // no action_hash
+        revoker_id: REVOKER_ID,
+        signer: revokerSigner(),
+      }),
+    ).toThrow();
+    expect(() =>
+      buildRevocation({ target: TARGET_A, signer: revokerSigner() }),
+    ).toThrow(); // no revoker_id
+    expect(() =>
+      buildRevocation({ target: TARGET_A, revoker_id: REVOKER_ID }),
+    ).toThrow(); // no signer
+  });
+
+  it("uses a custom revoker_key_id when supplied to the signer", () => {
+    const stmt = buildRevocation({
+      target: TARGET_A,
+      revoker_id: REVOKER_ID,
+      revoked_at: REVOKED_AT,
+      signer: revokerSigner(revokerKp, "ep:key:revoker#custom"),
+    });
+    expect(stmt.proof.revoker_key_id).toBe("ep:key:revoker#custom");
+  });
+
+  it("buildRevocation defaults revoked_at to now when omitted", () => {
+    const before = Date.now();
+    const stmt = buildRevocation({
+      target: TARGET_A,
+      revoker_id: REVOKER_ID,
+      signer: revokerSigner(),
+    });
+    const after = Date.now();
+    const t = Date.parse(stmt.revoked_at);
+    expect(t).toBeGreaterThanOrEqual(before);
+    expect(t).toBeLessThanOrEqual(after);
+  });
+});
+
+// ── must_reject vectors (each asserted by id) ────────────────────────────────
+
+describe("EP-REVOCATION-v1 — must_reject vectors", () => {
+  it("a_forged_signature -> revoker_signature_valid:false", () => {
+    const v = byId(VECTORS.must_reject, "a_forged_signature");
+    expect(v.expected.failing_check).toBe("revoker_signature_valid");
+
+    // Genuine binding statement, then flip a byte in the signature -> a real
+    // forgery (well-formed length, verifies nowhere) under the PINNED key.
+    const stmt = freshStatement();
+    const sigBuf = Buffer.from(stmt.proof.signature_b64u, "base64url");
+    sigBuf[0] ^= 0xff;
+    const forged = {
+      ...stmt,
+      proof: { ...stmt.proof, signature_b64u: sigBuf.toString("base64url") },
+    };
+
+    const r = verifyRevocation(TARGET_A, forged, { revokerKeys: pinnedKeys() });
+    expect(r.valid).toBe(false);
+    expect(r.checks[v.expected.failing_check]).toBe(false);
+  });
+
+  it("b_unpinned_revoker_key -> revoker_key_pinned:false", () => {
+    const v = byId(VECTORS.must_reject, "b_unpinned_revoker_key");
+    expect(v.expected.failing_check).toBe("revoker_key_pinned");
+
+    // A structurally valid, validly-signed statement whose key is self-asserted:
+    // the proof verifies under its OWN public_key, but revoker_id is NOT pinned.
+    const stmt = freshStatement();
+
+    // No registry at all.
+    const r0 = verifyRevocation(TARGET_A, stmt, {});
+    expect(r0.valid).toBe(false);
+    expect(r0.checks.revoker_key_pinned).toBe(false);
+
+    // Registry present but missing THIS revoker.
+    const r1 = verifyRevocation(TARGET_A, stmt, {
+      revokerKeys: { "ep:key:someone-else": { public_key: stmt.proof.public_key } },
+    });
+    expect(r1.valid).toBe(false);
+    expect(r1.checks.revoker_key_pinned).toBe(false);
+    // Never falls back to the self-asserted public_key.
+  });
+
+  it("c_wrong_pinned_key_substitution -> revoker_key_pinned:false", () => {
+    const v = byId(VECTORS.must_reject, "c_wrong_pinned_key_substitution");
+    expect(v.expected.failing_check).toBe("revoker_key_pinned");
+
+    // revoker_id IS pinned, and the signature verifies under the key in the proof
+    // — but that proof key is an ATTACKER key, not the one pinned for revoker_id.
+    const attackerKp = generateEd25519KeyPair();
+    const stmt = reSign(freshStatement(), attackerKp); // signed by attacker, key in proof
+
+    const r = verifyRevocation(TARGET_A, stmt, {
+      revokerKeys: pinnedKeys(), // pins the GENUINE revoker key, != attacker key
+    });
+    expect(r.valid).toBe(false);
+    expect(r.checks.revoker_key_pinned).toBe(false);
+  });
+
+  it("d_bound_to_different_target_id -> target_bound:false", () => {
+    const v = byId(VECTORS.must_reject, "d_bound_to_different_target_id");
+    expect(v.expected.failing_check).toBe("target_bound");
+
+    // A genuine, validly-signed revocation for TARGET_B, presented against the
+    // target the verifier holds (TARGET_A). Replay/staple onto another auth.
+    const stmtForB = freshStatement(TARGET_B);
+    const r = verifyRevocation(TARGET_A, stmtForB, { revokerKeys: pinnedKeys() });
+    expect(r.valid).toBe(false);
+    expect(r.checks.target_bound).toBe(false);
+  });
+
+  it("e_bound_to_different_action_hash -> target_bound:false", () => {
+    const v = byId(VECTORS.must_reject, "e_bound_to_different_action_hash");
+    expect(v.expected.failing_check).toBe("target_bound");
+
+    // target_id MATCHES, but action_hash binds action A' (a re-issued auth with
+    // the same id, different action). Revoking that must not revoke TARGET_A.
+    const stmtOther = freshStatement(TARGET_A_OTHER_ACTION);
+    const r = verifyRevocation(TARGET_A, stmtOther, { revokerKeys: pinnedKeys() });
+    expect(r.valid).toBe(false);
+    expect(r.checks.target_bound).toBe(false);
+  });
+
+  it("f_wrong_version -> version:false", () => {
+    const v = byId(VECTORS.must_reject, "f_wrong_version");
+    expect(v.expected.failing_check).toBe("version");
+
+    // Validly signed, exact binding — but a future/forked @version tag. We sign
+    // the WRONG-version object's own SIGNED_FIELDS (which still pin @version to
+    // the canonical tag via revocationSignedPayload), then mutate the top-level
+    // @version, so this fails ONLY on the version gate.
+    const stmt = freshStatement();
+    const forked = { ...stmt, "@version": "EP-REVOCATION-v2" };
+    const r = verifyRevocation(TARGET_A, forked, { revokerKeys: pinnedKeys() });
+    expect(r.valid).toBe(false);
+    expect(r.checks.version).toBe(false);
+  });
+
+  it("g_tampered_fields_after_signing -> signature_binds_statement:false", () => {
+    const v = byId(VECTORS.must_reject, "g_tampered_fields_after_signing");
+    expect(v.expected.failing_check).toBe("signature_binds_statement");
+
+    // Genuine statement, then edit revoked_at AND reason in the presented object
+    // WITHOUT re-signing. The proof now signs DIFFERENT bytes than the verifier
+    // recomputes from the presented fields.
+    const stmt = freshStatement();
+    const tampered = {
+      ...stmt,
+      revoked_at: "2099-01-01T00:00:00.000Z",
+      reason: "attacker-edited reason",
+    };
+    const r = verifyRevocation(TARGET_A, tampered, { revokerKeys: pinnedKeys() });
+    expect(r.valid).toBe(false);
+    expect(r.checks.signature_binds_statement).toBe(false);
+  });
+
+  it("h_missing_revoked_at -> revoked_at_present:false", () => {
+    const v = byId(VECTORS.must_reject, "h_missing_revoked_at");
+    expect(v.expected.failing_check).toBe("revoked_at_present");
+
+    // Build a statement with revoked_at omitted, then sign over its OWN bytes
+    // (revoked_at:null) so the ONLY failure is the missing anchor — not a
+    // signature break.
+    const base = {
+      "@version": REVOCATION_VERSION,
+      target_type: TARGET_A.target_type,
+      target_id: TARGET_A.target_id,
+      action_hash: TARGET_A.action_hash,
+      revoker_id: REVOKER_ID,
+      reason: "no anchor",
+      // revoked_at intentionally absent
+    };
+    const stmt = reSign(base, revokerKp);
+    const r = verifyRevocation(TARGET_A, stmt, { revokerKeys: pinnedKeys() });
+    expect(r.valid).toBe(false);
+    expect(r.checks.revoked_at_present).toBe(false);
+    // The signature itself is genuine over the presented (revoked_at-less) bytes:
+    expect(r.checks.revoker_signature_valid).toBe(true);
+    expect(r.checks.signature_binds_statement).toBe(true);
+  });
+
+  it("i_stale_beyond_freshness_window -> freshness:false (only with opts.maxAgeSeconds)", () => {
+    const v = byId(VECTORS.must_reject, "i_stale_beyond_freshness_window");
+    expect(v.expected.failing_check).toBe("freshness");
+
+    // Genuine, validly-signed, exactly-bound statement whose revoked_at is older
+    // than the demanded window relative to opts.now.
+    const stmt = freshStatement();
+    const r = verifyRevocation(TARGET_A, stmt, {
+      revokerKeys: pinnedKeys(),
+      maxAgeSeconds: 3600,
+      now: "2026-06-15T20:41:00.000Z", // 24h after revoked_at
+    });
+    expect(r.valid).toBe(false);
+    expect(r.checks.freshness).toBe(false);
+    // Every OTHER gating check passed — the rejection is freshness alone.
+    for (const [k, val] of Object.entries(r.checks)) {
+      if (k !== "freshness") expect(val, `check ${k}`).toBe(true);
+    }
+
+    // The SAME statement is accepted when no window is demanded (freshness vacuous).
+    const rNoWindow = verifyRevocation(TARGET_A, stmt, { revokerKeys: pinnedKeys() });
+    expect(rNoWindow.valid).toBe(true);
+  });
+});
+
+// ── must_accept vectors (each asserted by id) ────────────────────────────────
+
+describe("EP-REVOCATION-v1 — must_accept vectors", () => {
+  it("z_well_formed_binding_revocation -> valid:true (and isRevoked true)", () => {
+    const v = byId(VECTORS.must_accept, "z_well_formed_binding_revocation");
+    expect(v.expected.valid).toBe(true);
+
+    const stmt = freshStatement();
+    const r = verifyRevocation(TARGET_A, stmt, { revokerKeys: pinnedKeys() });
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+    for (const [k, val] of Object.entries(r.checks)) {
+      expect(val, `check ${k}`).toBe(true);
+    }
+    expect(isRevoked(TARGET_A, [stmt], { revokerKeys: pinnedKeys() })).toBe(true);
+
+    // Within a generous freshness window it is still accepted.
+    const rFresh = verifyRevocation(TARGET_A, stmt, {
+      revokerKeys: pinnedKeys(),
+      maxAgeSeconds: 86_400 * 7,
+      now: "2026-06-15T20:41:00.000Z",
+    });
+    expect(rFresh.valid).toBe(true);
+  });
+
+  it("z2_is_revoked_true_among_unrelated -> valid:true among unrelated statements", () => {
+    const v = byId(VECTORS.must_accept, "z2_is_revoked_true_among_unrelated");
+    expect(v.expected.valid).toBe(true);
+
+    const matching = freshStatement(TARGET_A);
+    const unrelatedById = freshStatement(TARGET_B); // valid, different target_id
+    const unrelatedByAction = freshStatement(TARGET_A_OTHER_ACTION); // valid, different action_hash
+
+    // The matching statement is NOT first and NOT alone.
+    const bag = [unrelatedById, unrelatedByAction, matching];
+    expect(isRevoked(TARGET_A, bag, { revokerKeys: pinnedKeys() })).toBe(true);
+
+    // Each unrelated statement on its own does NOT revoke TARGET_A.
+    expect(isRevoked(TARGET_A, [unrelatedById], { revokerKeys: pinnedKeys() })).toBe(false);
+    expect(isRevoked(TARGET_A, [unrelatedByAction], { revokerKeys: pinnedKeys() })).toBe(false);
+
+    // But each DOES revoke its own target (sanity: they are genuinely valid).
+    expect(isRevoked(TARGET_B, [unrelatedById], { revokerKeys: pinnedKeys() })).toBe(true);
+    expect(isRevoked(TARGET_A_OTHER_ACTION, [unrelatedByAction], { revokerKeys: pinnedKeys() })).toBe(true);
+  });
+});
+
+// ── isRevoked aggregate edge cases ───────────────────────────────────────────
+
+describe("EP-REVOCATION-v1 — isRevoked aggregate", () => {
+  it("false for a non-array, empty bag, or all-invalid bag", () => {
+    expect(isRevoked(TARGET_A, undefined, { revokerKeys: pinnedKeys() })).toBe(false);
+    expect(isRevoked(TARGET_A, null, { revokerKeys: pinnedKeys() })).toBe(false);
+    expect(isRevoked(TARGET_A, [], { revokerKeys: pinnedKeys() })).toBe(false);
+    // One unpinned + one wrong-target: neither valid -> false.
+    const unpinned = freshStatement(TARGET_A); // valid sig but no pin supplied
+    const wrongTarget = freshStatement(TARGET_B);
+    expect(isRevoked(TARGET_A, [unpinned, wrongTarget], {})).toBe(false);
+  });
+});
+
+// ── fail-closed robustness (no throws on hostile input) ──────────────────────
+
+describe("EP-REVOCATION-v1 — fail-closed robustness", () => {
+  it("rejects a null/absent statement without throwing", () => {
+    const r = verifyRevocation(TARGET_A, null, { revokerKeys: pinnedKeys() });
+    expect(r.valid).toBe(false);
+    expect(r.checks.revoker_signature_valid).toBe(false);
+  });
+
+  it("rejects when no target is handed to the verifier", () => {
+    const stmt = freshStatement();
+    const r = verifyRevocation(null, stmt, { revokerKeys: pinnedKeys() });
+    expect(r.valid).toBe(false);
+    expect(r.checks.target_bound).toBe(false);
+  });
+
+  it("rejects an unknown target_type", () => {
+    const weird = { target_type: "policy", target_id: "x", action_hash: TARGET_A.action_hash };
+    const stmt = reSign(
+      { ...freshStatement(), target_type: "policy", target_id: "x" },
+      revokerKp,
+    );
+    const r = verifyRevocation(weird, stmt, { revokerKeys: pinnedKeys() });
+    expect(r.valid).toBe(false);
+    expect(r.checks.target_bound).toBe(false);
+  });
+
+  it("rejects a statement with no proof block (missing signature/key)", () => {
+    const stmt = freshStatement();
+    const { proof, ...noProof } = stmt;
+    void proof;
+    const r = verifyRevocation(TARGET_A, noProof, { revokerKeys: pinnedKeys() });
+    expect(r.valid).toBe(false);
+    expect(r.checks.revoker_signature_valid).toBe(false);
+  });
+
+  it("does not throw on a non-canonicalizable signed field (BigInt) — fails closed", () => {
+    const stmt = freshStatement();
+    // A BigInt cannot be JSON-serialized by canonicalize(); recomputed bytes go
+    // null and no signature can verify. Must fail closed, not crash.
+    const hostile = { ...stmt, reason: 10n };
+    let r;
+    expect(() => {
+      r = verifyRevocation(TARGET_A, hostile, { revokerKeys: pinnedKeys() });
+    }).not.toThrow();
+    expect(r.valid).toBe(false);
+  });
+
+  it("malformed revoked_at (not RFC 3339) fails revoked_at_present", () => {
+    const base = { ...freshStatement(), revoked_at: "not-a-date" };
+    const stmt = reSign(base, revokerKp);
+    const r = verifyRevocation(TARGET_A, stmt, { revokerKeys: pinnedKeys() });
+    expect(r.valid).toBe(false);
+    expect(r.checks.revoked_at_present).toBe(false);
+  });
+
+  it("freshness is vacuous when maxAgeSeconds is unset, and honors default now", () => {
+    // A statement freshly minted at NOW passes a tight window using the default
+    // wall-clock now (opts.now omitted).
+    const stmt = buildRevocation({
+      target: TARGET_A,
+      revoker_id: REVOKER_ID,
+      signer: revokerSigner(),
+    });
+    const r = verifyRevocation(TARGET_A, stmt, {
+      revokerKeys: pinnedKeys(),
+      maxAgeSeconds: 3600, // now defaults to Date.now()
+    });
+    expect(r.valid).toBe(true);
+  });
+
+  it("accepts a Date object as opts.now", () => {
+    const stmt = freshStatement();
+    const r = verifyRevocation(TARGET_A, stmt, {
+      revokerKeys: pinnedKeys(),
+      maxAgeSeconds: 86_400 * 7,
+      now: new Date("2026-06-15T20:41:00.000Z"),
+    });
+    expect(r.valid).toBe(true);
+  });
+});
+
+// ── catalogue parity: EVERY vector id is asserted by name ─────────────────────
+
+describe("EP-REVOCATION-v1 — catalogue parity", () => {
+  // The set of ids this suite asserts by name above. Keep in lockstep with the
+  // it() blocks; the parity test below proves it covers the whole catalogue.
+  const ASSERTED = new Set([
+    "a_forged_signature",
+    "b_unpinned_revoker_key",
+    "c_wrong_pinned_key_substitution",
+    "d_bound_to_different_target_id",
+    "e_bound_to_different_action_hash",
+    "f_wrong_version",
+    "g_tampered_fields_after_signing",
+    "h_missing_revoked_at",
+    "i_stale_beyond_freshness_window",
+    "z_well_formed_binding_revocation",
+    "z2_is_revoked_true_among_unrelated",
+  ]);
+
+  it("every must_reject + must_accept vector id is asserted by name", () => {
+    const catalogue = [
+      ...VECTORS.must_reject.map((v) => v.id),
+      ...VECTORS.must_accept.map((v) => v.id),
+    ];
+    for (const id of catalogue) {
+      expect(ASSERTED.has(id), `vector "${id}" must be asserted by name`).toBe(true);
+    }
+    // And the suite asserts no phantom ids that are not in the catalogue.
+    for (const id of ASSERTED) {
+      expect(catalogue.includes(id), `asserted id "${id}" must exist in the catalogue`).toBe(true);
+    }
+    expect(catalogue.length).toBe(ASSERTED.size);
+  });
+
+  it("the catalogue matches the documented vector ids exactly", () => {
+    expect(VECTORS.must_reject.map((v) => v.id)).toEqual([
+      "a_forged_signature",
+      "b_unpinned_revoker_key",
+      "c_wrong_pinned_key_substitution",
+      "d_bound_to_different_target_id",
+      "e_bound_to_different_action_hash",
+      "f_wrong_version",
+      "g_tampered_fields_after_signing",
+      "h_missing_revoked_at",
+      "i_stale_beyond_freshness_window",
+    ]);
+    expect(VECTORS.must_accept.map((v) => v.id)).toEqual([
+      "z_well_formed_binding_revocation",
+      "z2_is_revoked_true_among_unrelated",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
Track 3 of the agentic-trust layer — two **additive** profiles over the **frozen** `EP-RECEIPT-v1` (no wire/canonicalization/signature change; `packages/issue`+`packages/verify` byte-identical). Together they close the revocation + continuous-eval loop the roadmap names: *Eye detects a posture drop → emits a signed SET → a relying party issues a revocation → verifiers consulting revocation fail closed.*

### `EP-REVOCATION-v1` — portable, offline-verifiable revocation
- `lib/revocation/revocation.js` — a **signed revocation statement** binding a pinned revoker key to an exact target `{target_type,target_id,action_hash}`. Today EP revokes only via server-state; this is the artifact a relying party can be *handed* and check **offline**.
- `verifyRevocation` / `isRevoked` fail closed on: unpinned revoker (no self-asserted fallback), wrong key, **revoke-A-presented-for-B** (id *or* action_hash), tampered fields, missing statement.
- **Honest boundary (CRL/OCSP-style):** offline proves a revocation is *authentic and binds its target* — not that you hold the *latest* state. Freshness/completeness is a transparency layer above, explicitly out of scope.

### `EP-EYE-SET-v1` — Eye continuous-eval as an RFC 8417 SET
- `lib/eye/eye-set.js` — an Eye advisory emitted as a **Security Event Token** (JWS-compact, EdDSA) carrying a CAEP-style posture-change event: scope-bound (`sub_id` = `scope_binding_hash`, never a raw ref), pinned-key verified, `never_sole_gate: true` in-band.
- `verifyEyeSet` fails closed on: non-EdDSA `alg` (incl. **`none`/confusion**, checked first), wrong `typ`, unpinned/substituted emitter key, forged or tampered payload (verified over the **presented** segments), missing claims, audience mismatch, staleness, a `clear` status, or a missing `never_sole_gate` marker.
- **Never a gate:** returns a posture for the relying party to act on, never `allow`/`deny`. SSF/CAEP/SET are prior art; the only contribution is the verifiable, scope-bound, in-band-invariant SET.

## Governance & docs
- **PIP-011** (Draft, additive) — `PIPs/PIP-011-revocation-continuous-eval.md`
- Specs: `docs/EP-REVOCATION-SPEC.md`, `docs/EP-EYE-SET-SPEC.md`
- Conformance vectors: `conformance/vectors/{revocation,eye-set}.v1.json`

## Verification (beyond the build's own tests)
An **independent adversarial harness** drove 22 attacks through the real code — `alg:none` + algorithm confusion, both unpinned paths (verify *and* `isRevoked`), wrong key, attacker-self-sign, payload tamper, audience, expiry, revoke-A-for-B on both `target_id` and `action_hash`, tampered fields, null statement — **22/22 fail closed, 0 fail-open.**

- Full suite: **4083 passed / 0 failed**
- Coverage: **95.15 line / 89.41 branch / 93.34 stmt / 94.79 func** (above the ratcheted gate); eye-set 90% branch, revocation 91% branch
- Lint clean; protocol/write/docs-secrets discipline clean; language-governance green
- **Frozen core untouched** (`packages/issue`, `packages/verify` byte-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)