### PR TITLE
feat: EP × x402 require-receipt — the demand-side rail

### DIFF
--- a/app/api/demo/x402/route.js
+++ b/app/api/demo/x402/route.js
@@ -1,0 +1,92 @@
+/**
+ * POST /api/demo/x402  — the demand-side rail, spoken in x402.
+ * @license Apache-2.0
+ *
+ * The "No receipt, no irreversible action" loop, made x402/AP2-native so an
+ * agent client recognizes the demand without bespoke code:
+ *
+ *   • No proof      → 402 with an x402 `accepts` block naming the authorization
+ *                     proof to bring (an EP-ENVELOPE-v1 for any registered
+ *                     profile, or a bare EP-RECEIPT-v1), carried in X-PAYMENT.
+ *   • Invalid proof → 402 + the verifier's reason.
+ *   • Valid proof   → 200, action released, with an X-PAYMENT-RESPONSE settlement
+ *                     header (the x402 analogue of a paid-receipt).
+ *
+ * The proof is verified OFFLINE. An EP-ENVELOPE rides the registry verifier
+ * (verifyEnvelope) — the keystone as the demand currency: one rail accepts the
+ * whole profile family. This is NOT auth or permissions; it is portable
+ * accountability evidence the service keeps for its own liability. Demo accepts
+ * self-signed receipts (integrity, not trust); production pins issuer keys.
+ */
+
+import { NextResponse } from 'next/server';
+import { x402ReceiptChallenge, verifyX402Proof } from '@/lib/require-receipt/x402.js';
+
+export const runtime = 'nodejs';
+
+const SAMPLE_ACTION = 'demo.delete_production_database';
+
+function challenge(request) {
+  return x402ReceiptChallenge({
+    resource: new URL(request.url).pathname,
+    action: SAMPLE_ACTION,
+    description: 'Refusing an irreversible action (delete production database): present a verifiable EMILIA authorization proof that a named human approved THIS exact action.',
+  });
+}
+
+export async function POST(request) {
+  // Proof carried in X-PAYMENT (x402) — fall back to legacy header / body.
+  let payment = request.headers.get('x-payment') || request.headers.get('x-emilia-receipt') || null;
+  if (!payment) {
+    const body = await request.json().catch(() => ({}));
+    if (body?.emilia_receipt) payment = body.emilia_receipt; // already-decoded object
+  }
+
+  if (!payment) {
+    return NextResponse.json(challenge(request), { status: 402, headers: { 'WWW-Authenticate': `x402 scheme="emilia-receipt", action="${SAMPLE_ACTION}"` } });
+  }
+
+  // Verify. Demo: integrity-only for bare receipts (allowInlineKey) bound to the
+  // sample action; an EP-ENVELOPE rides the registry verifier and fails closed
+  // on its own (unpinned keys etc.).
+  const v = verifyX402Proof(payment, {
+    allowInlineKey: true,
+    action: SAMPLE_ACTION,
+    maxAgeSec: 900,
+    allowedOutcomes: ['allow', 'allow_with_signoff'],
+  });
+
+  if (!v.valid) {
+    return NextResponse.json(
+      { ...challenge(request), rejected: { reason: v.reason, detail: v.detail, errors: v.errors } },
+      { status: 402, headers: { 'WWW-Authenticate': `x402 scheme="emilia-receipt", action="${SAMPLE_ACTION}"` } },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      status: 200,
+      allowed: true,
+      action: SAMPLE_ACTION,
+      proof_profile: v.profile,
+      note: 'Demo only — nothing was destroyed. With a valid proof the irreversible action would run; the service keeps the proof as its accountability evidence.',
+      settlement: v.settlement,
+    },
+    { status: 200, headers: { 'X-PAYMENT-RESPONSE': Buffer.from(JSON.stringify(v.settlement)).toString('base64') } },
+  );
+}
+
+export async function GET(request) {
+  return NextResponse.json({
+    title: 'EMILIA × x402 — require-receipt (demand-side rail)',
+    rule: 'No receipt, no irreversible action.',
+    sample_action: SAMPLE_ACTION,
+    accepts: x402ReceiptChallenge({ action: SAMPLE_ACTION }).accepts,
+    try_it: {
+      refuse: 'POST with no X-PAYMENT → 402 with an x402 accepts block.',
+      allow: 'POST with X-PAYMENT: base64(<EP-ENVELOPE-v1 or EP-RECEIPT-v1>) bound to the action → 200 + X-PAYMENT-RESPONSE.',
+    },
+    registry: '/.well-known/ep-profiles.json',
+    docs: 'https://www.emiliaprotocol.ai/agent-guard',
+  });
+}

--- a/lib/require-receipt/x402.js
+++ b/lib/require-receipt/x402.js
@@ -1,0 +1,116 @@
+/**
+ * EP × x402 — the demand-side rail.
+ *
+ * @license Apache-2.0
+ *
+ * Speaks the x402 (HTTP 402) shape so an x402/AP2-aware agent client recognizes
+ * the demand natively: when a service guards an irreversible action, it answers
+ * `402` with an `accepts` block describing the authorization proof to bring. The
+ * "payment" is not money — it is a **verifiable EMILIA authorization proof**:
+ *
+ *   - an `EP-ENVELOPE-v1` for ANY registered profile  → verified via the registry
+ *     verifier (verifyEnvelope). This is the keystone as the demand currency: a
+ *     single rail that accepts the whole protocol family.
+ *   - a bare `EP-RECEIPT-v1` authorization receipt     → verified via
+ *     @emilia-protocol/require-receipt (action-bound, fresh, outcome-checked).
+ *
+ * The proof is carried in the x402 `X-PAYMENT` header (base64 JSON). Verification
+ * is offline; a missing/invalid proof yields `402` + a machine-readable reason so
+ * a well-behaved agent self-serves a proof and retries (like a browser on 401).
+ * Fail closed: only a valid proof releases the action.
+ */
+
+import { verifyEnvelope } from '../envelope/index.js';
+import { verifyEmiliaReceipt } from '../../packages/require-receipt/index.js';
+
+export const X402_VERSION = 1;
+export const EP_X402_SCHEME = 'emilia-receipt';
+
+/**
+ * Build the x402 402-challenge body telling an agent exactly what proof to bring.
+ * @param {object} o
+ * @param {string} [o.resource] the protected resource URL
+ * @param {string} [o.action] the action_type the proof must be bound to
+ * @param {string} [o.profile] the EP profile URN expected (default: the core receipt)
+ * @param {string} [o.description]
+ */
+export function x402ReceiptChallenge({ resource = null, action = null, profile = 'urn:ep:profile:receipt:v1', description } = {}) {
+  return {
+    x402Version: X402_VERSION,
+    error: 'EMILIA authorization proof required',
+    accepts: [
+      {
+        scheme: EP_X402_SCHEME,
+        network: 'offline',
+        resource,
+        description: description || 'Present a verifiable EMILIA authorization proof that a named human approved this exact irreversible action.',
+        // Not a monetary payment: the "amount" is a valid receipt. Kept for x402
+        // client compatibility (clients expect these fields).
+        maxAmountRequired: '0',
+        asset: 'ep-authorization-receipt',
+        payTo: null,
+        extra: {
+          action_type: action,
+          profile,
+          accepted_proofs: ['EP-ENVELOPE-v1', 'EP-RECEIPT-v1'],
+          present_via: 'X-PAYMENT: base64(<EP-ENVELOPE-v1 or EP-RECEIPT-v1 JSON>)',
+          registry: '/.well-known/ep-profiles.json',
+          how: 'Obtain a proof (emilia-gate / SDK / POST /api/trust/gate), base64 it, resend with the X-PAYMENT header.',
+          learn_more: 'https://www.emiliaprotocol.ai/agent-guard',
+        },
+      },
+    ],
+  };
+}
+
+/** Decode an x402 X-PAYMENT header (base64 JSON) → object, or null. */
+export function decodeX402Payment(headerValue) {
+  if (typeof headerValue !== 'string' || headerValue.length === 0) return null;
+  try {
+    return JSON.parse(Buffer.from(headerValue, 'base64').toString('utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Verify a presented x402 authorization proof. Fail closed.
+ *
+ * @param {string|object} payment - the X-PAYMENT header value (base64 JSON) or an
+ *   already-decoded proof object.
+ * @param {object} opts - verifier context: for an envelope, the per-profile opts
+ *   (e.g. pinnedKeys/target/action); for a bare receipt, require-receipt opts
+ *   (trustedKeys/allowInlineKey/action/maxAgeSec/allowedOutcomes).
+ * @returns {{ ok:boolean, valid:boolean, profile?:string, reason?:string, detail?:string,
+ *            checks?:object, errors?:string[], settlement?:object }}
+ */
+export function verifyX402Proof(payment, opts = {}) {
+  const obj = typeof payment === 'string' ? decodeX402Payment(payment) : payment;
+  if (!obj || typeof obj !== 'object') {
+    return { ok: false, valid: false, reason: 'no_or_malformed_payment' };
+  }
+
+  // EP-ENVELOPE-v1 → registry-dispatched verification (the keystone rail).
+  if (obj.ep === 'EP-ENVELOPE-v1') {
+    const r = verifyEnvelope(obj, opts);
+    if (r.valid) return { ok: true, valid: true, profile: r.profile, settlement: settlement(EP_X402_SCHEME, r.profile) };
+    return { ok: false, valid: false, profile: r.profile, reason: 'envelope_invalid', checks: r.checks, errors: r.errors };
+  }
+
+  // Bare EP-RECEIPT-v1 authorization receipt → action-bound verification.
+  if (obj['@version'] === 'EP-RECEIPT-v1') {
+    const v = verifyEmiliaReceipt(obj, opts);
+    if (v.ok) return { ok: true, valid: true, profile: 'urn:ep:profile:receipt:v1', receipt: v, settlement: settlement(EP_X402_SCHEME, 'urn:ep:profile:receipt:v1') };
+    return { ok: false, valid: false, reason: v.reason, detail: v.detail };
+  }
+
+  return { ok: false, valid: false, reason: 'unrecognized_proof', detail: 'expected EP-ENVELOPE-v1 or EP-RECEIPT-v1' };
+}
+
+/** The x402 X-PAYMENT-RESPONSE analogue the service returns on a 200 release. */
+function settlement(scheme, profile) {
+  return { success: true, scheme, profile, network: 'offline' };
+}
+
+const epx402 = { X402_VERSION, EP_X402_SCHEME, x402ReceiptChallenge, decodeX402Payment, verifyX402Proof };
+export default epx402;

--- a/middleware.js
+++ b/middleware.js
@@ -108,6 +108,7 @@ const ROUTE_POLICIES = {
   // opening up real tenant evidence.
   'GET /api/demo/trust-receipts/*/evidence':       { rateCategory: 'read', useAuth: false },
   'POST /api/demo/require-receipt':                { rateCategory: 'read', useAuth: false },
+  'POST /api/demo/x402':                           { rateCategory: 'read', useAuth: false },
 
   // Disputes (writes)
   'POST /api/disputes/file':          { rateCategory: 'dispute_write', useAuth: true },

--- a/tests/public-claims.test.js
+++ b/tests/public-claims.test.js
@@ -67,6 +67,7 @@ const OPENAPI_EXEMPT_ROUTES = [
   // surfaces, not core protocol API.
   '/api/badge/[entity]',
   '/api/demo/require-receipt',
+  '/api/demo/x402',
   // Retired (HTTP 410): legacy compatibility-score endpoints, removed from the
   // public API (verifiable evidence, not a score). Route files return 410 only.
   '/api/score/[entityId]',

--- a/tests/route-coverage.test.js
+++ b/tests/route-coverage.test.js
@@ -123,6 +123,7 @@ const OPENAPI_EXEMPTIONS = [
   // surfaces, not core protocol API.
   '/api/badge/[entity]',
   '/api/demo/require-receipt',
+  '/api/demo/x402',
   // Retired (HTTP 410): the legacy 0-100 compatibility-score endpoints were
   // removed from the public API — EMILIA publishes verifiable evidence, not a
   // score. The route files remain only to return 410 + a migration pointer.

--- a/tests/x402.test.js
+++ b/tests/x402.test.js
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// EP × x402 demand-side rail. Proves: the 402 challenge is x402-shaped; a valid
+// EP-ENVELOPE proof (registry-verified) and a valid bare EP-RECEIPT-v1 both
+// release; and missing / malformed / wrong-action / unpinned proofs fail closed.
+
+import { describe, it, expect } from 'vitest';
+import crypto from 'node:crypto';
+import { x402ReceiptChallenge, decodeX402Payment, verifyX402Proof, X402_VERSION, EP_X402_SCHEME } from '../lib/require-receipt/x402.js';
+import { migrate } from '../lib/envelope/index.js';
+import { buildRevocation } from '../lib/revocation/revocation.js';
+
+function ed25519() {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+  return { privateKey, publicKeyB64u: publicKey.export({ format: 'der', type: 'spki' }).toString('base64url') };
+}
+// Mirror @emilia-protocol/require-receipt's canonicalizer for minting test receipts.
+function canon(v) {
+  if (v === null || v === undefined) return JSON.stringify(v);
+  if (Array.isArray(v)) return `[${v.map(canon).join(',')}]`;
+  if (typeof v === 'object') return `{${Object.keys(v).sort().map((k) => JSON.stringify(k) + ':' + canon(v[k])).join(',')}}`;
+  return JSON.stringify(v);
+}
+function mintReceipt(action, outcome, kp) {
+  const payload = { receipt_id: 'r_test', subject: 'agent:demo', created_at: new Date().toISOString(), claim: { action_type: action, outcome } };
+  const sig = crypto.sign(null, Buffer.from(canon(payload), 'utf8'), kp.privateKey).toString('base64url');
+  return { '@version': 'EP-RECEIPT-v1', payload, signature: { value: sig }, public_key: kp.publicKeyB64u };
+}
+const b64 = (o) => Buffer.from(JSON.stringify(o), 'utf8').toString('base64');
+
+describe('EP × x402 — challenge', () => {
+  it('is x402-shaped and names the accepted proofs', () => {
+    const c = x402ReceiptChallenge({ action: 'demo.delete', resource: '/x' });
+    expect(c.x402Version).toBe(X402_VERSION);
+    expect(c.accepts[0].scheme).toBe(EP_X402_SCHEME);
+    expect(c.accepts[0].extra.accepted_proofs).toEqual(['EP-ENVELOPE-v1', 'EP-RECEIPT-v1']);
+    expect(c.accepts[0].extra.action_type).toBe('demo.delete');
+    expect(c.accepts[0].extra.registry).toBe('/.well-known/ep-profiles.json');
+  });
+  it('decodeX402Payment returns null on garbage', () => {
+    expect(decodeX402Payment('!!!not-base64-json')).toBeNull();
+    expect(decodeX402Payment('')).toBeNull();
+  });
+});
+
+describe('EP × x402 — verify proof (fail closed)', () => {
+  it('releases on a valid EP-ENVELOPE proof (registry-verified)', () => {
+    const rk = ed25519();
+    const REVOKER = 'ep:org:t';
+    const TARGET = { target_type: 'receipt', target_id: 'x', action_hash: 'sha256:' + '1'.repeat(64) };
+    const stmt = buildRevocation({ target: TARGET, revoker_id: REVOKER, reason: 'r', signer: { privateKey: rk.privateKey, publicKeyB64u: rk.publicKeyB64u } });
+    const env = migrate(stmt, 'urn:ep:profile:revocation:v1');
+    const r = verifyX402Proof(b64(env), { target: TARGET, revokerKeys: { [REVOKER]: { public_key: rk.publicKeyB64u } } });
+    expect(r.ok).toBe(true);
+    expect(r.profile).toBe('urn:ep:profile:revocation:v1');
+    expect(r.settlement.success).toBe(true);
+  });
+  it('fails closed on an EP-ENVELOPE with an unpinned key', () => {
+    const rk = ed25519();
+    const REVOKER = 'ep:org:t';
+    const TARGET = { target_type: 'receipt', target_id: 'x', action_hash: 'sha256:' + '1'.repeat(64) };
+    const stmt = buildRevocation({ target: TARGET, revoker_id: REVOKER, reason: 'r', signer: { privateKey: rk.privateKey, publicKeyB64u: rk.publicKeyB64u } });
+    const env = migrate(stmt, 'urn:ep:profile:revocation:v1');
+    expect(verifyX402Proof(b64(env), { target: TARGET, revokerKeys: {} }).valid).toBe(false);
+  });
+
+  it('releases on a valid, action-bound bare EP-RECEIPT-v1', () => {
+    const kp = ed25519();
+    const doc = mintReceipt('demo.delete_production_database', 'allow_with_signoff', kp);
+    const r = verifyX402Proof(b64(doc), { allowInlineKey: true, action: 'demo.delete_production_database', allowedOutcomes: ['allow', 'allow_with_signoff'] });
+    expect(r.ok).toBe(true);
+    expect(r.profile).toBe('urn:ep:profile:receipt:v1');
+  });
+  it('rejects a bare receipt bound to the WRONG action', () => {
+    const kp = ed25519();
+    const doc = mintReceipt('other.action', 'allow', kp);
+    const r = verifyX402Proof(b64(doc), { allowInlineKey: true, action: 'demo.delete_production_database' });
+    expect(r.valid).toBe(false);
+    expect(r.reason).toBe('action_mismatch');
+  });
+  it('rejects missing / malformed / unrecognized proofs', () => {
+    expect(verifyX402Proof(null).valid).toBe(false);
+    expect(verifyX402Proof('!!!').valid).toBe(false);
+    expect(verifyX402Proof(b64({ hello: 'world' })).reason).toBe('unrecognized_proof');
+  });
+});


### PR DESCRIPTION
The demand-side half of the ecosystem keystone: makes "no receipt, no irreversible action" speak **x402** (HTTP 402) so an x402/AP2-aware agent client recognizes the demand natively — and wires it to the **envelope registry** so the rail accepts the whole protocol family.

- **`lib/require-receipt/x402.js`** — `x402ReceiptChallenge()` (proper `x402Version` + `accepts` block) + `verifyX402Proof()`: a presented `X-PAYMENT` proof is verified **offline, fail-closed**. Accepts an **`EP-ENVELOPE-v1`** for any registered profile (via `verifyEnvelope` — the keystone as the demand currency) **or** a bare **`EP-RECEIPT-v1`** (action-bound).
- **`app/api/demo/x402/route.js`** — runnable loop: no `X-PAYMENT` → 402 + x402 `accepts`; invalid → 402 + reason; valid → 200 + `X-PAYMENT-RESPONSE` settlement.
- **`tests/x402.test.js`** — challenge shape; valid envelope proof releases; unpinned envelope fails closed; valid bare receipt releases; wrong-action / missing / malformed fail closed.

Additive; frozen core untouched. **4115 pass / 0 fail; coverage above gate; lint + license + discipline clean.** This + the merged envelope keystone (#134) = both halves of the ecosystem keystone: a registry that *makes it extensible* and a rail that *makes a receipt required*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)