### PR TITLE
chore(deps): clear mcp-server subpackage advisories + audit it in CI

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -23,5 +23,16 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
-      - name: Check for known vulnerabilities
+      - name: Check for known vulnerabilities (root)
         run: npm audit --audit-level=moderate
+      # mcp-server ships its own committed lockfile (a separate npm package with
+      # the MCP SDK + its transitive HTTP-transport deps), so its advisories are
+      # invisible to the root audit above. Audit it here so they can't silently
+      # regress. (sdks/typescript is intentionally NOT audited: its lockfile is
+      # gitignored and the package has zero runtime dependencies — vite is a
+      # dev-only transitive of vitest and is never shipped to consumers.)
+      - name: Check for known vulnerabilities (mcp-server)
+        working-directory: mcp-server
+        run: |
+          npm ci
+          npm audit --audit-level=moderate

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -971,12 +971,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -995,9 +995,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -1165,9 +1165,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1216,9 +1216,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1698,9 +1698,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -1786,9 +1786,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
## What

Follow-up to [#137](https://github.com/emiliaprotocol/emilia-protocol/pull/137) (which fixed the **root** lock). The `mcp-server/` subpackage ships its **own committed lockfile** that the root Security Scan job never audited. `cd mcp-server && npm audit` reported **7 advisories (5 moderate, 2 high)**.

## Findings

- All 7 are **transitive via `@modelcontextprotocol/sdk`** (`hono`, `@hono/node-server`, `fast-uri`, `path-to-regexp`, `qs`, `ip-address`) — the SDK's Streamable-HTTP transport stack.
- mcp-server's own source imports **none** of them directly (no `hono` import; `toSSG()` / JSX-SSR are unreachable), so the Hono path-traversal/HTML-injection exposure was theoretical.
- Every advisory had an **in-range** fix.

## How

- `cd mcp-server && npm audit fix` (non-breaking, **no** `--force`) → **0 vulnerabilities**. Only `mcp-server/package-lock.json` changed.
- **Hardened `security-scan.yml`**: it now runs `npm ci && npm audit --audit-level=moderate` in `mcp-server` too, so these can't silently regress.

## Verification

- ✅ `cd mcp-server && npm ci && npm audit --audit-level=moderate` → 0 vulnerabilities (exit 0) — exactly what the new CI step runs
- ✅ mcp-server tests (`vitest run`): **68 passed**
- ✅ workflow YAML validated (5 steps, single `audit` job — check name unchanged)

## Why `sdks/typescript` is not included

Its `package-lock.json` is **gitignored** (not a committed surface), and the package has **zero runtime dependencies** — its only audit hit (`vite`, pulled in by `vitest`) is dev-tooling that is **never shipped to consumers**. `npm audit fix` there touches only a local, uncommitted lock; there's nothing to commit and nothing for CI to audit deterministically (`npm ci` would fail with no committed lock). Documented inline in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)