### PR TITLE
chore(mcp): add smithery.yaml + fix server.json version for registry listing

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.emiliaprotocol/mcp-server",
+  "title": "Emilia Protocol",
   "description": "Trust & human sign-off for AI agents: approval required before irreversible agent actions",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "repository": {
     "url": "https://github.com/emiliaprotocol/emilia-protocol",
     "source": "github"
@@ -13,10 +14,11 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@emilia-protocol/mcp-server",
-      "version": "1.0.0",
+      "version": "1.0.4",
       "transport": {
         "type": "stdio"
       },
+      "runtimeHint": "npx",
       "environmentVariables": [
         {
           "name": "EP_API_KEY",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,19 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+# Lists @emilia-protocol/mcp-server (npm, stdio) on smithery.ai.
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema for user-supplied config. EP_API_KEY is optional — public
+    # read tools work without it; it's only needed for authenticated writes.
+    type: object
+    required: []
+    properties:
+      EP_API_KEY:
+        type: string
+        description: "Optional Emilia Protocol API key for authenticated write operations (registering entities, submitting receipts)."
+  commandFunction:
+    # Produces the CLI command to start the MCP server over stdio.
+    |-
+    (config) => ({ command: 'npx', args: ['-y', '@emilia-protocol/mcp-server'], env: config.EP_API_KEY ? { EP_API_KEY: config.EP_API_KEY } : {} })
+exampleConfig: {}


### PR DESCRIPTION
Prep to list **@emilia-protocol/mcp-server** on the MCP registries (Glama / Smithery / official registry).

- **server.json**: version `1.0.0` → **`1.0.4`** to match the published npm package — the stale version would have failed `mcp-publisher publish` (the registry verifies the package version exists). Also bumped `$schema` to 2025-12-11 and added `title` + `runtimeHint: npx`.
- **smithery.yaml**: new — stdio launch via `npx -y @emilia-protocol/mcp-server`, optional `EP_API_KEY`.

`glama.json` (already committed) and the npm package (already published 1.0.4, `mcpName` set) are unchanged. Everything remaining is a human OAuth/CLI login (Glama claim, mcp-publisher login+publish, Smithery deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)