### PR TITLE
feat: /try/multi-party — two-person-rule demo (show, not tell)

### DIFF
--- a/app/try/multi-party/layout.js
+++ b/app/try/multi-party/layout.js
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Metadata for /try/multi-party — the multi-party (two-person rule) demo. Built
+// as a layout so the page itself can stay a client component.
+
+export const metadata = {
+  title: 'The two-person rule for AI actions — multi-party approval demo — EMILIA Protocol',
+  description:
+    'A $40M release that needs an ordered quorum of three named humans — Program Officer, Authorizing Official, Inspector General — each binding to the exact action. Verify the quorum live in your browser; watch separation-of-duties reject a duplicate signer. Nothing uploaded.',
+  alternates: { canonical: '/try/multi-party' },
+  openGraph: {
+    title: 'The two-person rule, cryptographically enforced — multi-party approval',
+    description:
+      'An ordered quorum of named humans, each bound to the exact action, verified offline in your browser with EP-QUORUM-v1.',
+    url: 'https://www.emiliaprotocol.ai/try/multi-party',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'The two-person rule, cryptographically enforced',
+    description: 'An ordered quorum of named humans, each bound to the exact action — verified live in your browser.',
+  },
+};
+
+export default function MultiPartyLayout({ children }) {
+  return children;
+}

--- a/app/try/multi-party/page.js
+++ b/app/try/multi-party/page.js
@@ -1,0 +1,194 @@
+'use client';
+/**
+ * /try/multi-party — the two-person rule, shown not told.
+ * @license Apache-2.0
+ *
+ * A high-consequence action ($40M program release) requires an ORDERED quorum of
+ * three named humans — Program Officer -> Authorizing Official -> Inspector
+ * General. Each "signs" on a simulated secure element (ephemeral Web Crypto
+ * P-256, the same path as /try) bound to the EXACT action. The EP-QUORUM-v1
+ * verifier runs entirely in your browser (lib/quorum-web.js) — nothing uploaded.
+ * A "let one person sign twice" button shows the separation-of-duties rejection.
+ */
+import { useState } from 'react';
+import SiteNav from '@/components/SiteNav';
+import SiteFooter from '@/components/SiteFooter';
+import { color, font, styles } from '@/lib/tokens';
+import { verifyQuorum } from '@/lib/quorum-web.js';
+
+// ── minimal crypto helpers (mirror /try) ──────────────────────────────────────
+const utf8 = (s) => new TextEncoder().encode(s);
+const b64u = (bytes) => btoa(String.fromCharCode(...bytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+function canonicalize(v) {
+  if (v === null || typeof v !== 'object') return JSON.stringify(v);
+  if (Array.isArray(v)) return `[${v.map(canonicalize).join(',')}]`;
+  return `{${Object.keys(v).sort().map((k) => JSON.stringify(k) + ':' + canonicalize(v[k])).join(',')}}`;
+}
+const sha256 = async (bytes) => new Uint8Array(await crypto.subtle.digest('SHA-256', bytes));
+function rawP256ToDer(raw) {
+  const enc = (v) => { let i = 0; while (i < v.length - 1 && v[i] === 0) i++; let b = v.subarray(i); if (b[0] & 0x80) { const t = new Uint8Array(b.length + 1); t.set(b, 1); b = t; } return b; };
+  const rb = enc(raw.subarray(0, 32)); const sb = enc(raw.subarray(32, 64));
+  const seqLen = 2 + rb.length + 2 + sb.length; const out = new Uint8Array(2 + seqLen); let o = 0;
+  out[o++] = 0x30; out[o++] = seqLen; out[o++] = 0x02; out[o++] = rb.length; out.set(rb, o); o += rb.length;
+  out[o++] = 0x02; out[o++] = sb.length; out.set(sb, o); return out;
+}
+const HOST = 'emiliaprotocol.ai';
+async function signSim(context) {
+  const pair = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']);
+  const spki = new Uint8Array(await crypto.subtle.exportKey('spki', pair.publicKey));
+  const challengeB64u = b64u(await sha256(utf8(canonicalize(context))));
+  const clientDataBytes = utf8(JSON.stringify({ type: 'webauthn.get', challenge: challengeB64u, origin: `https://${HOST}`, crossOrigin: false }));
+  const authData = new Uint8Array(37);
+  authData.set(await sha256(utf8(HOST)), 0); authData[32] = 0x05; // UP | UV
+  const signedData = new Uint8Array(authData.length + 32);
+  signedData.set(authData, 0); signedData.set(await sha256(clientDataBytes), authData.length);
+  const rawSig = new Uint8Array(await crypto.subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, pair.privateKey, signedData));
+  return {
+    approver_public_key: b64u(spki),
+    signoff: { '@type': 'ep.signoff', context, webauthn: { authenticator_data: b64u(authData), client_data_json: b64u(clientDataBytes), signature: b64u(rawP256ToDer(rawSig)) } },
+  };
+}
+
+// ── the scenario ──────────────────────────────────────────────────────────────
+const ROSTER = [
+  { role: 'program_officer', approver: 'ep:approver:po_rivera', label: 'Program Officer', who: 'M. Rivera' },
+  { role: 'authorizing_official', approver: 'ep:approver:ao_chen', label: 'Authorizing Official', who: 'J. Chen' },
+  { role: 'inspector_general', approver: 'ep:approver:ig_okafor', label: 'Inspector General', who: 'A. Okafor' },
+];
+const ACTION_FIELDS = { action: 'program_funds.release', amount: '40000000.00', currency: 'USD', program: 'program/aegis-1', memo: 'FY26 milestone disbursement' };
+
+export default function MultiPartyDemo() {
+  const [actionHash, setActionHash] = useState(null);
+  const [members, setMembers] = useState([]); // signed, in order
+  const [result, setResult] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [cheated, setCheated] = useState(false);
+
+  async function ensureHash() {
+    if (actionHash) return actionHash;
+    const h = Array.from(await sha256(utf8(canonicalize(ACTION_FIELDS))), (x) => x.toString(16).padStart(2, '0')).join('');
+    setActionHash(h); return h;
+  }
+  const mkContext = (slot, h, idx) => ({
+    action_hash: h, policy: 'policy_aegis_quorum', role: slot.role, approver: slot.approver,
+    initiator: 'agent:program-ops/v2', nonce: b64u(crypto.getRandomValues(new Uint8Array(16))),
+    issued_at: new Date(Date.now() + idx * 60000).toISOString(),
+  });
+  const buildQuorum = (mem, h) => ({
+    '@type': 'ep.quorum', action_hash: h,
+    policy: { mode: 'ordered', required: 3, approvers: ROSTER.map((r) => ({ role: r.role, approver: r.approver })), distinct_humans: true, window_sec: 900 },
+    members: mem,
+  });
+
+  async function signNext() {
+    setBusy(true);
+    try {
+      const h = await ensureHash();
+      const idx = members.length;
+      const slot = ROSTER[idx];
+      const m = await signSim(mkContext(slot, h, idx));
+      const next = [...members, { ...m, role: slot.role }];
+      setMembers(next); setResult(null); setCheated(false);
+      if (next.length === ROSTER.length) setResult(await verifyQuorum(buildQuorum(next, h), { rpId: HOST }));
+    } finally { setBusy(false); }
+  }
+
+  // The cheat: the Program Officer (already signed) also signs the IG slot.
+  async function cheatDuplicate() {
+    setBusy(true);
+    try {
+      const h = await ensureHash();
+      const po = ROSTER[0];
+      const m0 = await signSim(mkContext(po, h, 0));
+      const m1 = await signSim(mkContext(ROSTER[1], h, 1));
+      // IG slot signed by the SAME human as the Program Officer:
+      const m2 = await signSim({ ...mkContext(ROSTER[2], h, 2), approver: po.approver });
+      const mem = [{ ...m0, role: po.role }, { ...m1, role: ROSTER[1].role }, { ...m2, role: ROSTER[2].role }];
+      setMembers(mem); setCheated(true);
+      setResult(await verifyQuorum(buildQuorum(mem, h), { rpId: HOST }));
+    } finally { setBusy(false); }
+  }
+
+  function reset() { setMembers([]); setResult(null); setCheated(false); }
+
+  const allSigned = members.length === ROSTER.length;
+  return (
+    <div style={styles.page}>
+      <SiteNav />
+      <main style={{ maxWidth: 880, margin: '0 auto', padding: '56px 24px 96px' }}>
+        <div style={styles.eyebrow}>EP-QUORUM-v1 · the two-person rule</div>
+        <h1 style={{ ...styles.h1, maxWidth: 760 }}>Some actions need more than one human.</h1>
+        <p style={{ ...styles.body, maxWidth: 720 }}>
+          A <strong>$40,000,000</strong> program release. Policy requires an <strong>ordered quorum</strong> — Program Officer, then Authorizing Official, then Inspector General — each approving the <em>exact</em> action on their own device, all within the window. No quorum, no release. Everything below runs in your browser; nothing is uploaded.
+        </p>
+
+        <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', margin: '28px 0' }}>
+          {ROSTER.map((r, i) => {
+            const signed = i < members.length && !cheated;
+            const isNext = i === members.length && !allSigned && !cheated;
+            return (
+              <div key={r.role} style={{
+                flex: '1 1 240px', border: `1px solid ${signed ? color.green : isNext ? color.blue : color.border}`,
+                borderRadius: 10, padding: '16px 18px', background: color.card,
+              }}>
+                <div style={{ fontFamily: font.mono, fontSize: 11, letterSpacing: 1.5, textTransform: 'uppercase', color: signed ? color.green : color.t3 }}>
+                  {i + 1} · {signed ? 'signed ✓' : isNext ? 'next' : 'waiting'}
+                </div>
+                <div style={{ fontSize: 17, fontWeight: 600, color: color.t1, marginTop: 6 }}>{r.label}</div>
+                <div style={{ fontSize: 13, color: color.t2 }}>{r.who}</div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+          {!allSigned && !cheated && (
+            <button onClick={signNext} disabled={busy} style={btn(color.blue)}>
+              {busy ? 'Signing…' : `Sign as ${ROSTER[members.length].label} (Face ID)`}
+            </button>
+          )}
+          <button onClick={cheatDuplicate} disabled={busy} style={btn(color.t2, true)}>Try to cheat: one person signs twice</button>
+          {(members.length > 0) && <button onClick={reset} disabled={busy} style={btn(color.t3, true)}>Reset</button>}
+        </div>
+
+        {result && (
+          <div style={{
+            marginTop: 30, border: `1px solid ${result.valid ? color.green : color.red}`,
+            borderRadius: 12, padding: '22px 24px', background: color.card,
+          }}>
+            <div style={{ fontSize: 22, fontWeight: 700, color: result.valid ? color.green : color.red }}>
+              {result.valid ? '✓ QUORUM SATISFIED — action authorized' : '✕ REJECTED — action NOT authorized'}
+            </div>
+            {cheated && !result.valid && (
+              <p style={{ ...styles.body, marginTop: 8 }}>The same human filled two slots. <strong>Separation of duties</strong> fails the quorum — exactly as the two-person rule requires.</p>
+            )}
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '6px 24px', marginTop: 16 }}>
+              {Object.entries(result.checks).map(([k, v]) => (
+                <div key={k} style={{ fontFamily: font.mono, fontSize: 13, color: v ? color.green : color.red }}>
+                  {v ? '✓' : '✕'} {k}
+                </div>
+              ))}
+            </div>
+            <p style={{ fontSize: 13, color: color.t3, marginTop: 16, lineHeight: 1.6 }}>
+              Verified in-browser by the EP-QUORUM-v1 verifier (same logic as <span style={{ fontFamily: font.mono }}>@emilia-protocol/verify</span>, 69/69 tests). Each signature is a real ECDSA P-256 assertion bound to the exact action; tamper any field, duplicate a signer, break the order, or miss the window and the quorum fails by construction.
+            </p>
+          </div>
+        )}
+
+        <p style={{ fontSize: 13, color: color.t3, marginTop: 36, lineHeight: 1.7, maxWidth: 720 }}>
+          Roles are illustrative chain-of-command, not real individuals. This is a simulated secure element for demonstration; in production each approver signs on their own enrolled device (Face ID · Touch ID · passkey).
+        </p>
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}
+
+function btn(c, ghost) {
+  return {
+    fontFamily: font.mono, fontSize: 13, letterSpacing: 1, textTransform: 'uppercase',
+    padding: '12px 20px', borderRadius: 8, cursor: 'pointer',
+    background: ghost ? 'transparent' : c, color: ghost ? c : '#fff',
+    border: `1px solid ${c}`, fontWeight: 600,
+  };
+}

--- a/lib/quorum-web.js
+++ b/lib/quorum-web.js
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * EP-QUORUM-v1 — in-browser (Web Crypto) multi-party approval verifier.
+ *
+ * The async mirror of packages/verify/quorum.js: it composes the in-browser
+ * verifyWebAuthnSignoff (lib/verify-web.js) once per member, then applies the
+ * SAME fail-closed quorum predicate. Used by the /try multi-party demo so the
+ * quorum verifies entirely client-side, nothing uploaded. Keep this in lockstep
+ * with packages/verify/quorum.js — same predicates, same fail-closed semantics.
+ */
+import { verifyWebAuthnSignoff } from './verify-web.js';
+
+export async function verifyQuorum(quorum, opts = {}) {
+  const checks = {
+    all_signatures_valid: false,
+    action_binding: false,
+    distinct_humans: false,
+    roles_admitted: false,
+    threshold_met: false,
+    order_satisfied: false,
+    within_window: false,
+  };
+  const members = Array.isArray(quorum?.members) ? quorum.members : null;
+  const memberResults = [];
+
+  try {
+    const policy = quorum?.policy;
+    const actionHash = quorum?.action_hash;
+    if (!policy || !members || members.length === 0 || typeof actionHash !== 'string' || !actionHash) {
+      return { valid: false, checks, members: memberResults };
+    }
+
+    const mode = policy.mode === 'ordered' ? 'ordered' : 'threshold';
+    const distinctHumans = policy.distinct_humans !== false;
+    const windowSec = Number.isFinite(policy.window_sec) ? policy.window_sec : 900;
+    const eligible = Array.isArray(policy.approvers) ? policy.approvers : [];
+    const required = mode === 'ordered'
+      ? eligible.length
+      : (Number.isInteger(policy.required) && policy.required > 0 ? policy.required : NaN);
+    if (!Number.isInteger(required) || required <= 0 || eligible.length === 0) {
+      return { valid: false, checks, members: memberResults };
+    }
+
+    let allSigsValid = true;
+    let allBound = true;
+    const issuedAts = [];
+    for (const m of members) {
+      const r = await verifyWebAuthnSignoff(m?.signoff, m?.approver_public_key, opts);
+      memberResults.push({ approver: m?.signoff?.context?.approver ?? null, role: m?.role ?? null, valid: !!r.valid });
+      if (!r.valid) allSigsValid = false;
+      if (m?.signoff?.context?.action_hash !== actionHash) allBound = false;
+      const t = Date.parse(m?.signoff?.context?.issued_at ?? '');
+      issuedAts.push(Number.isNaN(t) ? null : t);
+    }
+    checks.all_signatures_valid = allSigsValid;
+    checks.action_binding = allBound;
+
+    const counted = members
+      .map((m, i) => ({ m, i, ok: memberResults[i].valid && m?.signoff?.context?.action_hash === actionHash }))
+      .filter((x) => x.ok);
+
+    const countedApprovers = counted.map((x) => x.m?.signoff?.context?.approver);
+    checks.distinct_humans = distinctHumans
+      ? new Set(countedApprovers).size === countedApprovers.length
+      : true;
+
+    const eligibleSet = new Set(eligible.map((e) => `${e.role} ${e.approver}`));
+    checks.roles_admitted = counted.length > 0 && counted.every((x) =>
+      eligibleSet.has(`${x.m?.role} ${x.m?.signoff?.context?.approver}`));
+
+    const distinctEligible = new Set(
+      counted
+        .filter((x) => eligibleSet.has(`${x.m?.role} ${x.m?.signoff?.context?.approver}`))
+        .map((x) => x.m?.signoff?.context?.approver),
+    );
+    checks.threshold_met = distinctEligible.size >= required;
+
+    if (mode === 'ordered') {
+      const seqRolesOk = eligible.every((e, idx) => members[idx]?.role === e.role
+        && members[idx]?.signoff?.context?.approver === e.approver);
+      const times = issuedAts.slice(0, eligible.length);
+      const timesOk = times.every((t, idx) => t !== null && (idx === 0 || t > times[idx - 1]));
+      checks.order_satisfied = members.length >= eligible.length && seqRolesOk && timesOk;
+    } else {
+      checks.order_satisfied = true;
+    }
+
+    const ts = counted.map((x) => issuedAts[x.i]).filter((t) => t !== null);
+    checks.within_window = ts.length === counted.length && counted.length > 0
+      && (Math.max(...ts) - Math.min(...ts)) <= windowSec * 1000;
+  } catch {
+    return { valid: false, checks, members: memberResults };
+  }
+
+  const valid = checks.all_signatures_valid
+    && checks.action_binding
+    && checks.distinct_humans
+    && checks.roles_admitted
+    && checks.threshold_met
+    && checks.order_satisfied
+    && checks.within_window;
+  return { valid, checks, members: memberResults };
+}


### PR DESCRIPTION
## What
A live, in-browser **multi-party approval** demo at **/try/multi-party** — the gov/defense pitch centerpiece for EP-QUORUM-v1 (merged in #148).

A \$40M program release requires an **ordered quorum**: Program Officer → Authorizing Official → Inspector General. Each "signs" on a simulated secure element (Web Crypto P-256, the same path as `/try`), bound to the **exact** action. The quorum verifies **entirely client-side** — nothing uploaded. A "let one person sign twice" button demonstrates the **separation-of-duties** rejection.

## How
- `lib/quorum-web.js` — async Web Crypto mirror of the merged `packages/verify/quorum.js` (same fail-closed predicates). Kept as a separate file so it doesn't touch the verify-web drift-consistency pair.
- `app/try/multi-party/{page,layout}.js` — self-contained client demo + metadata.

## Verified
- eslint clean; language-governance pass.
- **Real Web Crypto run** (same path as the browser): happy quorum → `valid:true`, all 7 checks; duplicate-signer → `valid:false`, `distinct_humans:false`.
- CI `next build` + e2e are the route-compile check.

Neutral chain-of-command roles only — never named officials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)