### PR TITLE
feat: multi-party quorum orchestration core (trail of signatories)

### DIFF
--- a/lib/signoff/quorum-session.js
+++ b/lib/signoff/quorum-session.js
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * EP multi-party signoff orchestration — the "trail of signatories" engine.
+ *
+ * Pure, stateless logic over the attestations collected for a quorum-gated
+ * action. Two responsibilities:
+ *
+ *   canAccept()  — incremental, server-side enforcement: when a new approver
+ *                  attests, decide whether to ACCEPT it into the trail. Rejects
+ *                  a wrong action, an ineligible role, a duplicate human, an
+ *                  out-of-order signer (ordered mode), a stale signature
+ *                  (outside the window), or a bad signature — *at attest time*,
+ *                  so a bad signer never enters the trail.
+ *   quorumGate() — is the accumulated trail a SATISFIED quorum? Composes the
+ *                  frozen, cross-language-verified verifyQuorum (the same
+ *                  fail-closed predicate JS/Python/Go agree on). An action may
+ *                  only consume the signoff once this returns satisfied:true.
+ *
+ * This is the deployment-agnostic core. The fielded flow (persist the quorum
+ * policy on a challenge; store each accepted attestation; gate consume on
+ * quorumGate) wires DB + API routes to these functions — that layer is the
+ * next increment; this module is what it enforces with.
+ */
+import { verifyQuorum, verifyWebAuthnSignoff } from '../../packages/verify/index.js';
+
+const ctxOf = (m) => m?.signoff?.context ?? {};
+const slotKey = (role, approver) => `${role} ${approver}`;
+
+/**
+ * Should an incoming attestation be admitted into the trail?
+ * @returns {{ ok: boolean, reason?: string }}
+ */
+export function canAccept(policy, actionHash, existing, incoming, opts = {}) {
+  if (!policy || typeof actionHash !== 'string' || !actionHash) return { ok: false, reason: 'no_policy' };
+  const eligible = Array.isArray(policy.approvers) ? policy.approvers : [];
+  if (eligible.length === 0) return { ok: false, reason: 'no_eligible_approvers' };
+  const distinctHumans = policy.distinct_humans !== false;
+  const windowSec = Number.isFinite(policy.window_sec) ? policy.window_sec : 900;
+  const ordered = policy.mode === 'ordered';
+  const cx = ctxOf(incoming);
+
+  // 1. Action binding — must be signing the exact action this quorum authorizes.
+  if (cx.action_hash !== actionHash) return { ok: false, reason: 'action_mismatch' };
+
+  // 2. Role eligibility — (role, approver) must be a slot on the roster.
+  const eligibleSet = new Set(eligible.map((e) => slotKey(e.role, e.approver)));
+  if (!eligibleSet.has(slotKey(incoming?.role, cx.approver))) return { ok: false, reason: 'ineligible_role' };
+
+  // 3. Separation of duties — no human fills two slots.
+  if (distinctHumans && existing.some((m) => ctxOf(m).approver === cx.approver)) {
+    return { ok: false, reason: 'duplicate_human' };
+  }
+
+  // 4. Order — in ordered mode the next signer must be the next roster slot.
+  if (ordered) {
+    const expected = eligible[existing.length];
+    if (!expected || incoming?.role !== expected.role || cx.approver !== expected.approver) {
+      return { ok: false, reason: 'out_of_order' };
+    }
+  }
+
+  // 5. Window — within window_sec of the first accepted signature.
+  if (existing.length > 0) {
+    const t0 = Date.parse(ctxOf(existing[0]).issued_at ?? '');
+    const ti = Date.parse(cx.issued_at ?? '');
+    if (Number.isNaN(t0) || Number.isNaN(ti) || Math.abs(ti - t0) > windowSec * 1000) {
+      return { ok: false, reason: 'window_exceeded' };
+    }
+    if (ordered && !(ti > Date.parse(ctxOf(existing[existing.length - 1]).issued_at ?? ''))) {
+      return { ok: false, reason: 'non_increasing_time' };
+    }
+  }
+
+  // 6. Signature — the device assertion must actually verify.
+  if (!verifyWebAuthnSignoff(incoming?.signoff, incoming?.approver_public_key, opts).valid) {
+    return { ok: false, reason: 'invalid_signature' };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Is the accumulated trail a satisfied quorum? Composes verifyQuorum (the
+ * frozen, tri-language-verified predicate). An action may consume only when
+ * satisfied === true.
+ * @returns {{ satisfied: boolean, checks: object, members: Array }}
+ */
+export function quorumGate(policy, actionHash, members, opts = {}) {
+  const r = verifyQuorum({ '@type': 'ep.quorum', action_hash: actionHash, policy, members }, opts);
+  return { satisfied: r.valid, checks: r.checks, members: r.members };
+}
+
+/**
+ * Convenience: fold a stream of candidate attestations through canAccept, then
+ * gate. Returns the accepted trail, any rejections (with reasons), and whether
+ * the quorum is satisfied. Pure — does no I/O.
+ */
+export function evaluateTrail(policy, actionHash, candidates, opts = {}) {
+  const accepted = [];
+  const rejected = [];
+  for (const c of candidates || []) {
+    const r = canAccept(policy, actionHash, accepted, c, opts);
+    if (r.ok) accepted.push(c);
+    else rejected.push({ approver: ctxOf(c).approver ?? null, role: c?.role ?? null, reason: r.reason });
+  }
+  const gate = quorumGate(policy, actionHash, accepted, opts);
+  return { accepted, rejected, ...gate };
+}

--- a/tests/quorum-session.test.js
+++ b/tests/quorum-session.test.js
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tests for lib/signoff/quorum-session.js — the multi-party signoff
+// orchestration brain. Mints real ECDSA P-256 attestations (Web Crypto) and
+// asserts incremental enforcement: canAccept() admits a valid next signer and
+// rejects each adversarial case (wrong action, ineligible role, duplicate
+// human, out-of-order, window, bad signature); evaluateTrail() satisfies a
+// genuine ordered trail and never satisfies a tampered one.
+import { describe, it, expect } from 'vitest';
+import { canAccept, quorumGate, evaluateTrail } from '../lib/signoff/quorum-session.js';
+
+const HOST = 'emiliaprotocol.ai';
+const utf8 = (s) => new TextEncoder().encode(s);
+const b64u = (b) => Buffer.from(b).toString('base64url');
+const canon = (v) => v === null || typeof v !== 'object' ? JSON.stringify(v)
+  : Array.isArray(v) ? `[${v.map(canon).join(',')}]`
+    : `{${Object.keys(v).sort().map((k) => JSON.stringify(k) + ':' + canon(v[k])).join(',')}}`;
+const sha = async (b) => new Uint8Array(await crypto.subtle.digest('SHA-256', b));
+function rawToDer(raw) {
+  const e = (v) => { let i = 0; while (i < v.length - 1 && v[i] === 0) i++; let b = v.subarray(i); if (b[0] & 0x80) { const t = new Uint8Array(b.length + 1); t.set(b, 1); b = t; } return b; };
+  const r = e(raw.subarray(0, 32)); const s = e(raw.subarray(32, 64)); const L = 2 + r.length + 2 + s.length;
+  const o = new Uint8Array(2 + L); let p = 0; o[p++] = 0x30; o[p++] = L; o[p++] = 2; o[p++] = r.length; o.set(r, p); p += r.length; o[p++] = 2; o[p++] = s.length; o.set(s, p); return o;
+}
+async function mkMember(role, approver, i, { actionHash, wrongKey } = {}) {
+  const pair = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']);
+  const ver = wrongKey ? (await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify'])).publicKey : pair.publicKey;
+  const ctx = { action_hash: actionHash ?? ACTION, policy: 'p', role, approver, nonce: b64u(crypto.getRandomValues(new Uint8Array(16))), issued_at: new Date(Date.UTC(2026, 5, 11, 0, i)).toISOString() };
+  const ch = b64u(await sha(utf8(canon(ctx))));
+  const cd = utf8(JSON.stringify({ type: 'webauthn.get', challenge: ch, origin: `https://${HOST}`, crossOrigin: false }));
+  const ad = new Uint8Array(37); ad.set(await sha(utf8(HOST)), 0); ad[32] = 0x05;
+  const signed = new Uint8Array(ad.length + 32); signed.set(ad, 0); signed.set(await sha(cd), ad.length);
+  const sig = new Uint8Array(await crypto.subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, pair.privateKey, signed));
+  return { role, approver_public_key: b64u(new Uint8Array(await crypto.subtle.exportKey('spki', ver))), signoff: { '@type': 'ep.signoff', context: ctx, webauthn: { authenticator_data: b64u(ad), client_data_json: b64u(cd), signature: b64u(rawToDer(sig)) } } };
+}
+
+const PO = ['program_officer', 'ep:po'], AO = ['authorizing_official', 'ep:ao'], IG = ['inspector_general', 'ep:ig'];
+const POLICY = { mode: 'ordered', required: 3, approvers: [PO, AO, IG].map(([role, approver]) => ({ role, approver })), distinct_humans: true, window_sec: 900 };
+let ACTION;
+const OPTS = { rpId: HOST };
+
+describe('lib/signoff/quorum-session.js — trail-of-signatories enforcement', () => {
+  it('accepts a valid ordered trail and gates satisfied', async () => {
+    ACTION = Array.from(await sha(utf8(canon({ a: 'release' }))), (x) => x.toString(16).padStart(2, '0')).join('');
+    const m0 = await mkMember(...PO, 1), m1 = await mkMember(...AO, 2), m2 = await mkMember(...IG, 3);
+    expect(canAccept(POLICY, ACTION, [], m0, OPTS).ok).toBe(true);
+    expect(canAccept(POLICY, ACTION, [m0], m1, OPTS).ok).toBe(true);
+    expect(canAccept(POLICY, ACTION, [m0, m1], m2, OPTS).ok).toBe(true);
+    expect(quorumGate(POLICY, ACTION, [m0, m1, m2], OPTS).satisfied).toBe(true);
+  });
+
+  // Threshold roster (any M-of-N) — where the same valid human resubmitting is
+  // the duplicate-human case (in an ordered 1:1 roster that's caught earlier as
+  // ineligible_role, since a human is only ever eligible for their own slot).
+  const TPOL = { mode: 'threshold', required: 2, approvers: [PO, AO, IG].map(([role, approver]) => ({ role, approver })), distinct_humans: true, window_sec: 900 };
+
+  it('rejects a duplicate human at attest time (threshold)', async () => {
+    const m0 = await mkMember(...PO, 1);
+    const again = await mkMember(...PO, 2); // same valid approver, second time
+    expect(canAccept(TPOL, ACTION, [m0], again, OPTS)).toMatchObject({ ok: false, reason: 'duplicate_human' });
+  });
+
+  it('rejects a same-human-wrong-slot as ineligible (ordered 1:1 roster)', async () => {
+    const m0 = await mkMember(...PO, 1);
+    const wrong = await mkMember('inspector_general', 'ep:po', 2); // PO claiming IG slot
+    expect(canAccept(POLICY, ACTION, [m0], wrong, OPTS)).toMatchObject({ ok: false, reason: 'ineligible_role' });
+  });
+
+  it('rejects an out-of-order signer (ordered mode)', async () => {
+    const m0 = await mkMember(...PO, 1);
+    const ig = await mkMember(...IG, 2); // IG before AO
+    expect(canAccept(POLICY, ACTION, [m0], ig, OPTS)).toMatchObject({ ok: false, reason: 'out_of_order' });
+  });
+
+  it('rejects an ineligible role', async () => {
+    const x = await mkMember('intern', 'ep:nobody', 1);
+    expect(canAccept(POLICY, ACTION, [], x, OPTS)).toMatchObject({ ok: false, reason: 'ineligible_role' });
+  });
+
+  it('rejects a different action', async () => {
+    const x = await mkMember(...PO, 1, { actionHash: 'f'.repeat(64) });
+    expect(canAccept(POLICY, ACTION, [], x, OPTS)).toMatchObject({ ok: false, reason: 'action_mismatch' });
+  });
+
+  it('rejects a stale signature outside the window', async () => {
+    const m0 = await mkMember(...PO, 0);
+    const late = await mkMember(...AO, 30); // 30 min later, window 900s
+    expect(canAccept(POLICY, ACTION, [m0], late, OPTS)).toMatchObject({ ok: false, reason: 'window_exceeded' });
+  });
+
+  it('rejects a bad signature', async () => {
+    const bad = await mkMember(...PO, 1, { wrongKey: true });
+    expect(canAccept(POLICY, ACTION, [], bad, OPTS)).toMatchObject({ ok: false, reason: 'invalid_signature' });
+  });
+
+  it('evaluateTrail folds candidates: keeps valid, rejects bad, gates satisfied', async () => {
+    const m0 = await mkMember(...PO, 1), m1 = await mkMember(...AO, 2), m2 = await mkMember(...IG, 3);
+    const dup = await mkMember(...PO, 4); // same valid approver again → duplicate_human (threshold)
+    const r = evaluateTrail(TPOL, ACTION, [m0, m1, dup, m2], OPTS);
+    expect(r.accepted.length).toBe(3);
+    expect(r.rejected).toEqual([{ approver: 'ep:po', role: 'program_officer', reason: 'duplicate_human' }]);
+    expect(r.satisfied).toBe(true);
+  });
+
+  it('fails closed on malformed input', () => {
+    expect(canAccept(null, ACTION, [], {}, OPTS).ok).toBe(false);
+    expect(quorumGate(POLICY, ACTION, [], OPTS).satisfied).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
The server-side **enforcement brain** for double / N-party signoff — moving multi-party from "verifier + demo" toward a fielded flow. Composes the frozen, tri-language-verified `verifyQuorum` (no new trust).

- **`canAccept()`** — incremental, fail-closed admission: rejects wrong action, ineligible role, duplicate human, out-of-order, stale (window), or bad signature **at attest time**, so a bad signer never enters the trail.
- **`quorumGate()`** — is the accumulated trail a *satisfied* quorum (the consume gate).
- **`evaluateTrail()`** — folds candidates → `{accepted, rejected[reasons], satisfied}`.

Pure/stateless. The fielded flow (persist the quorum policy on a challenge, store accepted attestations, gate consume on `quorumGate`) wires DB + API to these — next increment.

## Verification
`tests/quorum-session.test.js` — 10 Web-Crypto tests: valid ordered trail, every reject reason (duplicate/out-of-order/ineligible/action-mismatch/window/bad-sig), threshold mode, malformed fail-closed. Frozen verifier reused; core unchanged. (Test ships with the new lib/** file — per the coverage-gate lesson.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)