### PR TITLE
feat: quorum member bridge + correct the live Class-A target

### DIFF
--- a/docs/MULTI-PARTY-DEPLOYMENT.md
+++ b/docs/MULTI-PARTY-DEPLOYMENT.md
@@ -77,10 +77,43 @@ already-built core.
    that consume is blocked until the trail is satisfied. Mirror the `/try/multi-party`
    demo flow against the live API.
 
+## ⚠️ Corrected target: the LIVE Class-A path is the `audit_events` subsystem
+Tracing the deployed code (2026-06-20) surfaced that there are **two signoff
+subsystems**, and the one that matters for multi-party device approval is **not**
+the one this doc first assumed:
+
+| Subsystem | Storage | Verifier | Status |
+|---|---|---|---|
+| **Class-A WebAuthn** (the live, multi-party-relevant path; what `/try/multi-party` mirrors) | decisions in `audit_events.after_state` (`guard.signoff.approved`, with `context` + `webauthn` + `approved_action_hash`); approver keys in `approver_credentials` | `@simplewebauthn/server` at decision time | **this is where the quorum gate belongs** |
+| **Bearer attestation** (older) | `signoff_attestations` / `signoff_consumptions` (`lib/signoff/consume.js`) | n/a | migration 094 + the `consume.js` hook above target THIS — the wrong subsystem for Class-A |
+
+**So the correct fielding for the real path is:**
+1. **Persist the quorum policy at issuance** in the Class-A subsystem (on the
+   signoff request / receipt), *not* on `signoff_challenges`. (Migration 094's
+   column is harmless but aimed at the bearer subsystem.)
+2. **`canAccept()` hook** goes in `app/api/v1/signoffs/[signoffId]/approve-webauthn/route.js`
+   — before inserting the `guard.signoff.approved` decision, map the already-
+   recorded decisions for this receipt via `attestationsToMembers()` and reject
+   a bad/duplicate/out-of-order signer.
+3. **`quorumGate()` hook** goes in the Class-A authorization-before-action path —
+   **`app/api/v1/trust-receipts/[receiptId]/consume/route.js`** (which reads the
+   `guard.signoff` decisions from `audit_events`), not `lib/signoff/consume.js`.
+   Load all `guard.signoff.approved` decisions for the receipt →
+   `attestationsToMembers()` → `quorumGate()`; block consume unless satisfied.
+
+The **`attestationsToMembers()` bridge is built and tested**
+(`lib/signoff/attestation-members.js`) against this exact stored shape, and the
+round-trip test proves the mapped members pass the real `quorumGate`.
+
 ## Status (honest)
 - **Built + tested**: the enforcement core (`quorum-session.js`, `verifyQuorum`
-  in JS/Python/Go), the `/try/multi-party` demo, and migration 094 (additive).
-- **Remaining to field**: the `attestationsToMembers` helper + the two hooks in
-  `attest.js`/`consume.js`, applying migration 094 to prod, and live E2E. This
-  is a deliberate, reviewed step because `consume.js` gates real actions —
-  not a capability to claim as shipped until it is wired and verified end-to-end.
+  in JS/Python/Go), the `/try/multi-party` demo, the `attestationsToMembers`
+  bridge (round-trip-tested), and migration 094 (additive, but see the
+  correction above re subsystem).
+- **Remaining to field (Class-A path)**: persist the quorum policy at signoff
+  issuance; the `canAccept()` hook in `approve-webauthn`; the `quorumGate()` hook
+  in `trust-receipts/[receiptId]/consume`; and live multi-device E2E. These are
+  deliberate, reviewed changes to the live action-authorization path — not
+  claimed as shipped until wired against the correct subsystem and verified
+  end-to-end. The earlier `attest.js`/`consume.js` plan above is retained only as
+  the bearer-subsystem reference; the corrected target supersedes it.

--- a/lib/signoff/attestation-members.js
+++ b/lib/signoff/attestation-members.js
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Bridge: reconstruct EP-QUORUM-v1 members from stored Class-A signoff evidence.
+ *
+ * The Class-A WebAuthn approve path
+ * (app/api/v1/signoffs/[signoffId]/approve-webauthn/route.js) records, per
+ * approver decision, everything an offline verifier needs: the canonical
+ * authorization `context` and the WebAuthn assertion (authenticator_data /
+ * client_data_json / signature). Paired with the approver's enrolled SPKI
+ * public key (approver_credentials.public_key_spki), that reconstitutes the
+ * exact EP-SIGNOFF-v1 object that verifyQuorum / quorumGate consume.
+ *
+ * The point: the quorum gate then verifies the SAME bytes with the SAME
+ * fail-closed predicate that cross-language conformance (JS/Python/Go) covers —
+ * it does NOT introduce a second verifier. (The live approve route validates
+ * the assertion via @simplewebauthn at decision time; this re-derives the
+ * portable EP-SIGNOFF object for the offline quorum check, which is what makes
+ * the quorum independently checkable off any EP server.)
+ */
+
+/**
+ * One stored Class-A decision → one quorum member.
+ * @param {object} d
+ * @param {string} d.role               roster role (e.g. 'authorizing_official')
+ * @param {string} d.approver_public_key approver SPKI (base64url) from approver_credentials
+ * @param {object} d.context            canonical authorization context (incl. action_hash, approver, issued_at)
+ * @param {object} d.webauthn           { authenticator_data, client_data_json, signature } (base64url)
+ * @returns {object} EP-QUORUM-v1 member
+ */
+export function decisionToMember({ role, approver_public_key, context, webauthn }) {
+  return {
+    role,
+    approver_public_key,
+    signoff: {
+      '@type': 'ep.signoff',
+      context,
+      webauthn: {
+        authenticator_data: webauthn.authenticator_data,
+        client_data_json: webauthn.client_data_json,
+        signature: webauthn.signature,
+      },
+    },
+  };
+}
+
+/**
+ * Map a list of stored Class-A decisions → quorum members. Skips any decision
+ * missing its context or assertion (fail-safe: an incomplete record can never
+ * count toward a quorum).
+ * @param {Array<object>} decisions
+ * @returns {Array<object>}
+ */
+export function attestationsToMembers(decisions) {
+  return (decisions || [])
+    .filter((d) => d && d.context && d.webauthn && d.approver_public_key)
+    .map(decisionToMember);
+}

--- a/tests/attestation-members.test.js
+++ b/tests/attestation-members.test.js
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tests for lib/signoff/attestation-members.js — the bridge that reconstitutes
+// EP-QUORUM-v1 members from stored Class-A signoff evidence. Proves the bridge
+// is faithful by round-tripping: mint a real ECDSA P-256 signoff, reduce it to
+// the shape the approve route stores (context + assertion + approver key), map
+// it back via attestationsToMembers, and confirm quorumGate ACCEPTS the result
+// — i.e. the gate verifies exactly what was stored, through the real verifier.
+import { describe, it, expect } from 'vitest';
+import { attestationsToMembers, decisionToMember } from '../lib/signoff/attestation-members.js';
+import { quorumGate } from '../lib/signoff/quorum-session.js';
+
+const HOST = 'emiliaprotocol.ai';
+const utf8 = (s) => new TextEncoder().encode(s);
+const b64u = (b) => Buffer.from(b).toString('base64url');
+const canon = (v) => v === null || typeof v !== 'object' ? JSON.stringify(v)
+  : Array.isArray(v) ? `[${v.map(canon).join(',')}]`
+    : `{${Object.keys(v).sort().map((k) => JSON.stringify(k) + ':' + canon(v[k])).join(',')}}`;
+const sha = async (b) => new Uint8Array(await crypto.subtle.digest('SHA-256', b));
+function rawToDer(raw) {
+  const e = (v) => { let i = 0; while (i < v.length - 1 && v[i] === 0) i++; let b = v.subarray(i); if (b[0] & 0x80) { const t = new Uint8Array(b.length + 1); t.set(b, 1); b = t; } return b; };
+  const r = e(raw.subarray(0, 32)); const s = e(raw.subarray(32, 64)); const L = 2 + r.length + 2 + s.length;
+  const o = new Uint8Array(2 + L); let p = 0; o[p++] = 0x30; o[p++] = L; o[p++] = 2; o[p++] = r.length; o.set(r, p); p += r.length; o[p++] = 2; o[p++] = s.length; o.set(s, p); return o;
+}
+// Mint a stored-decision record exactly as the approve route persists it.
+async function mkDecision(role, approver, i, action) {
+  const pair = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']);
+  const context = { action_hash: action, policy: 'p', role, approver, nonce: b64u(crypto.getRandomValues(new Uint8Array(16))), issued_at: new Date(Date.UTC(2026, 5, 11, 0, i)).toISOString() };
+  const ch = b64u(await sha(utf8(canon(context))));
+  const cd = utf8(JSON.stringify({ type: 'webauthn.get', challenge: ch, origin: `https://${HOST}`, crossOrigin: false }));
+  const ad = new Uint8Array(37); ad.set(await sha(utf8(HOST)), 0); ad[32] = 0x05;
+  const signed = new Uint8Array(ad.length + 32); signed.set(ad, 0); signed.set(await sha(cd), ad.length);
+  const sig = new Uint8Array(await crypto.subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, pair.privateKey, signed));
+  return {
+    role,
+    approver_public_key: b64u(new Uint8Array(await crypto.subtle.exportKey('spki', pair.publicKey))),
+    context,                                          // as stored in audit_events.after_state.context
+    webauthn: {                                       // as stored in after_state.webauthn
+      credential_id: 'cred-' + i,
+      authenticator_data: b64u(ad),
+      client_data_json: b64u(cd),
+      signature: b64u(rawToDer(sig)),
+    },
+  };
+}
+
+const PO = ['program_officer', 'ep:po'], AO = ['authorizing_official', 'ep:ao'], IG = ['inspector_general', 'ep:ig'];
+const POLICY = { mode: 'ordered', required: 3, approvers: [PO, AO, IG].map(([role, approver]) => ({ role, approver })), distinct_humans: true, window_sec: 900 };
+const OPTS = { rpId: HOST };
+
+describe('lib/signoff/attestation-members.js — stored evidence → verifiable members', () => {
+  it('round-trips: stored Class-A decisions map to members quorumGate accepts', async () => {
+    const action = Array.from(await sha(utf8(canon({ a: 'release' }))), (x) => x.toString(16).padStart(2, '0')).join('');
+    const decisions = [await mkDecision(...PO, 1, action), await mkDecision(...AO, 2, action), await mkDecision(...IG, 3, action)];
+    const members = attestationsToMembers(decisions);
+    expect(members).toHaveLength(3);
+    expect(members[0]).toMatchObject({ role: 'program_officer', signoff: { '@type': 'ep.signoff' } });
+    expect(quorumGate(POLICY, action, members, OPTS).satisfied).toBe(true);
+  });
+
+  it('drops incomplete records (missing context or assertion) — fail-safe', async () => {
+    const action = 'a'.repeat(64);
+    const good = await mkDecision(...PO, 1, action);
+    const members = attestationsToMembers([good, { role: 'x' }, null, { context: {}, webauthn: null, approver_public_key: 'k' }]);
+    expect(members).toHaveLength(1);
+  });
+
+  it('decisionToMember carries only the three assertion fields', async () => {
+    const d = await mkDecision(...AO, 5, 'b'.repeat(64));
+    const m = decisionToMember(d);
+    expect(Object.keys(m.signoff.webauthn).sort()).toEqual(['authenticator_data', 'client_data_json', 'signature']);
+  });
+});


### PR DESCRIPTION
## Two things
1. **`attestationsToMembers()`** — reconstitutes EP-QUORUM-v1 members from the Class-A evidence the approve route **already stores** (`context` + `webauthn` assertion) + the approver's `public_key_spki`. The quorum gate then verifies the **same bytes with the same fail-closed predicate** cross-language conformance covers — no second verifier. **Round-trip test** proves mapped members pass the real `quorumGate`.
2. **Corrected deployment target.** Tracing deployed code found **two signoff subsystems**; the live multi-party path is the **Class-A `audit_events`** one (gate belongs in `trust-receipts/[receiptId]/consume`), **not** the `signoff_attestations` subsystem migration 094 + the earlier `consume.js` hook targeted.

## Why it matters
Wiring the gate into `lib/signoff/consume.js` would have gated the *wrong subsystem* — security theater on real action authorization. This pins the correct target + ships the tested bridge it needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)