### PR TITLE
feat: wire EP-QUORUM-v1 into the live Class-A authorization path (review + E2E before merge)

### DIFF
--- a/app/api/v1/signoffs/[signoffId]/approve-webauthn/route.js
+++ b/app/api/v1/signoffs/[signoffId]/approve-webauthn/route.js
@@ -23,6 +23,8 @@ import {
   SIGNOFF_ID_PATTERN,
 } from '@/lib/webauthn';
 import { loadSignoffForSigning } from '@/lib/webauthn-signoff';
+import { canAccept } from '@/lib/signoff/quorum-session.js';
+import { decisionToMember, decisionsToMembers } from '@/lib/signoff/attestation-members.js';
 
 export async function POST(request, { params }) {
   try {
@@ -139,6 +141,54 @@ export async function POST(request, { params }) {
     }
     if (!verification.verified) {
       return epProblem(400, 'assertion_invalid', 'Assertion did not verify');
+    }
+
+    // ── EP-QUORUM-v1 early gate (defense-in-depth) ─────────────────────────
+    // If this receipt carries a multi-party quorum policy, reject a signer who
+    // cannot be admitted to the trail (ineligible / duplicate human / out of
+    // order / outside the window) BEFORE recording their approval — early,
+    // actionable feedback. The consume gate re-verifies the full quorum through
+    // the same predicate regardless, so this is not the security boundary.
+    if (decision === 'approved') {
+      const { data: rcEvents } = await supabase
+        .from('audit_events')
+        .select('event_type, after_state, created_at')
+        .eq('target_type', 'trust_receipt')
+        .eq('target_id', loaded.receiptId)
+        .order('created_at', { ascending: true });
+      const createdEv = (rcEvents || []).find((e) => e.event_type === 'guard.trust_receipt.created');
+      const quorumPolicy = createdEv && createdEv.after_state && createdEv.after_state.quorum_policy;
+      if (quorumPolicy) {
+        const priorApproved = (rcEvents || [])
+          .filter((e) => e.event_type === 'guard.signoff.approved')
+          .map((e) => e.after_state)
+          .filter(Boolean);
+        const credMap = { [credential.credential_id]: { public_key_spki: credential.public_key_spki } };
+        const priorCredIds = priorApproved.map((d) => d.webauthn && d.webauthn.credential_id).filter(Boolean);
+        if (priorCredIds.length > 0) {
+          const { data: pc } = await supabase
+            .from('approver_credentials')
+            .select('credential_id, public_key_spki')
+            .in('credential_id', priorCredIds);
+          for (const c of pc || []) credMap[c.credential_id] = c;
+        }
+        const existingMembers = decisionsToMembers(quorumPolicy, priorApproved, credMap);
+        const roster = quorumPolicy.approvers || [];
+        const incoming = decisionToMember({
+          role: (roster.find((a) => a.approver === body.approver_id) || {}).role || null,
+          approver_public_key: credential.public_key_spki,
+          context: challengeRow.context,
+          webauthn: {
+            authenticator_data: body.assertion.response.authenticatorData,
+            client_data_json: body.assertion.response.clientDataJSON,
+            signature: body.assertion.response.signature,
+          },
+        });
+        const verdict = canAccept(quorumPolicy, loaded.actionHash, existingMembers, incoming, { rpId: rpID });
+        if (!verdict.ok) {
+          return epProblem(409, 'quorum_signer_rejected', `Signer cannot be admitted to the quorum: ${verdict.reason}`);
+        }
+      }
     }
 
     // ── Record the decision (race-safe via the decided-once unique index).

--- a/app/api/v1/trust-receipts/[receiptId]/consume/route.js
+++ b/app/api/v1/trust-receipts/[receiptId]/consume/route.js
@@ -16,6 +16,9 @@ import { authenticateRequest, authEntityId } from '@/lib/supabase';
 import { getGuardedClient } from '@/lib/write-guard';
 import { epProblem } from '@/lib/errors';
 import { logger } from '@/lib/logger.js';
+import { quorumGate } from '@/lib/signoff/quorum-session.js';
+import { decisionsToMembers } from '@/lib/signoff/attestation-members.js';
+import { getRpConfig } from '@/lib/webauthn.js';
 
 export async function POST(request, { params }) {
   try {
@@ -74,14 +77,59 @@ export async function POST(request, { params }) {
       );
     }
 
-    if (base.signoff_required) {
-      const approved = events.some((e) => e.event_type === 'guard.signoff.approved');
-      if (!approved) {
-        return epProblem(403, 'signoff_required', 'Receipt requires signoff before consume');
-      }
+    // A quorum policy always implies a signoff is required, even if the policy
+    // decision didn't set signoff_required.
+    if (base.signoff_required || base.quorum_policy) {
       const rejected = events.some((e) => e.event_type === 'guard.signoff.rejected');
       if (rejected) {
         return epProblem(403, 'signoff_rejected', 'Receipt signoff was rejected');
+      }
+
+      if (base.quorum_policy) {
+        // ── Multi-party (EP-QUORUM-v1): require a SATISFIED quorum ──────────
+        // Re-verify ALL approvals through the same fail-closed predicate the
+        // cross-language conformance suite covers (distinct humans, roles,
+        // order, window, action-binding, signatures). The approve route already
+        // recorded each assertion; we reconstitute members and gate on them.
+        const approvedDecisions = events
+          .filter((e) => e.event_type === 'guard.signoff.approved')
+          .map((e) => e.after_state)
+          .filter(Boolean);
+        const credentialIds = approvedDecisions
+          .map((d) => d.webauthn && d.webauthn.credential_id)
+          .filter(Boolean);
+        let credsByCredentialId = {};
+        if (credentialIds.length > 0) {
+          const { data: creds, error: credErr } = await supabase
+            .from('approver_credentials')
+            .select('credential_id, public_key_spki')
+            .in('credential_id', credentialIds);
+          if (credErr) {
+            logger.error('[guard] consume: credential load failed:', credErr);
+            return epProblem(500, 'internal_error', 'Failed to load approver credentials');
+          }
+          credsByCredentialId = Object.fromEntries(
+            (creds || []).map((c) => [c.credential_id, c]),
+          );
+        }
+        const members = decisionsToMembers(base.quorum_policy, approvedDecisions, credsByCredentialId);
+        const { rpID } = getRpConfig();
+        const gate = quorumGate(base.quorum_policy, base.action_hash, members, { rpId: rpID });
+        if (!gate.satisfied) {
+          const failed = Object.entries(gate.checks || {})
+            .filter(([, v]) => v === false)
+            .map(([k]) => k);
+          return epProblem(
+            403,
+            'quorum_not_satisfied',
+            `Receipt requires a satisfied multi-party quorum before consume${failed.length ? ` (failing: ${failed.join(', ')})` : ''}`,
+          );
+        }
+      } else {
+        const approved = events.some((e) => e.event_type === 'guard.signoff.approved');
+        if (!approved) {
+          return epProblem(403, 'signoff_required', 'Receipt requires signoff before consume');
+        }
       }
     }
 

--- a/app/api/v1/trust-receipts/route.js
+++ b/app/api/v1/trust-receipts/route.js
@@ -157,6 +157,11 @@ export async function POST(request) {
           decision: decision.decision,
           enforcement_mode: mode,
           signoff_required: decision.signoffRequired,
+          // EP-QUORUM-v1: an optional multi-party policy. When present, consume
+          // requires a SATISFIED quorum of Class-A signoffs (not just one
+          // approval). NULL = single-signoff, unchanged. The quorum implies a
+          // signoff is required regardless of the policy decision.
+          quorum_policy: body.quorum_policy || null,
           receipt_status,
           action_hash: actionHash,
           before_state_hash: beforeHash,

--- a/lib/signoff/attestation-members.js
+++ b/lib/signoff/attestation-members.js
@@ -55,3 +55,38 @@ export function attestationsToMembers(decisions) {
     .filter((d) => d && d.context && d.webauthn && d.approver_public_key)
     .map(decisionToMember);
 }
+
+/**
+ * Build quorum members from raw `guard.signoff.approved` audit-event payloads.
+ *
+ * Each approved decision's `after_state` carries `{ context, webauthn:{...},
+ * approver_id }` but NOT the approver's role or public key. The role comes from
+ * the quorum policy roster (by approver id); the SPKI key comes from
+ * `approver_credentials` (by credential id). This joins them. Fail-safe: any
+ * decision we can't fully resolve (unknown approver, missing key, incomplete
+ * assertion) is dropped — it cannot count toward the quorum.
+ *
+ * @param {object} policy                 EP-QUORUM-v1 policy (for the role roster)
+ * @param {Array<object>} decisions        guard.signoff.approved after_state payloads
+ * @param {Object<string,object>} credsByCredentialId  credential_id → { public_key_spki }
+ * @returns {Array<object>} EP-QUORUM-v1 members
+ */
+export function decisionsToMembers(policy, decisions, credsByCredentialId = {}) {
+  const roleByApprover = Object.fromEntries(
+    ((policy && policy.approvers) || []).map((a) => [a.approver, a.role]),
+  );
+  return (decisions || [])
+    .map((d) => {
+      const credId = d && d.webauthn && d.webauthn.credential_id;
+      const cred = credId ? credsByCredentialId[credId] : null;
+      const approver = (d && d.approver_id) || (d && d.context && d.context.approver);
+      return {
+        role: roleByApprover[approver] ?? null,
+        approver_public_key: cred ? cred.public_key_spki : null,
+        context: d && d.context,
+        webauthn: d && d.webauthn,
+      };
+    })
+    .filter((m) => m.role && m.approver_public_key && m.context && m.webauthn)
+    .map(decisionToMember);
+}

--- a/tests/attestation-members.test.js
+++ b/tests/attestation-members.test.js
@@ -7,7 +7,7 @@
 // it back via attestationsToMembers, and confirm quorumGate ACCEPTS the result
 // — i.e. the gate verifies exactly what was stored, through the real verifier.
 import { describe, it, expect } from 'vitest';
-import { attestationsToMembers, decisionToMember } from '../lib/signoff/attestation-members.js';
+import { attestationsToMembers, decisionToMember, decisionsToMembers } from '../lib/signoff/attestation-members.js';
 import { quorumGate } from '../lib/signoff/quorum-session.js';
 
 const HOST = 'emiliaprotocol.ai';
@@ -69,5 +69,29 @@ describe('lib/signoff/attestation-members.js — stored evidence → verifiable 
     const d = await mkDecision(...AO, 5, 'b'.repeat(64));
     const m = decisionToMember(d);
     expect(Object.keys(m.signoff.webauthn).sort()).toEqual(['authenticator_data', 'client_data_json', 'signature']);
+  });
+
+  // decisionsToMembers joins raw guard.signoff.approved payloads (which carry
+  // approver_id + credential_id but NOT role/key) with the policy roster and the
+  // approver_credentials key map — the exact join the consume gate performs.
+  it('decisionsToMembers joins audit-event payloads + creds → members quorumGate accepts', async () => {
+    const action = Array.from(await sha(utf8(canon({ a: 'wire' }))), (x) => x.toString(16).padStart(2, '0')).join('');
+    const raw = [await mkDecision(...PO, 1, action), await mkDecision(...AO, 2, action), await mkDecision(...IG, 3, action)];
+    // Reshape into the audit-event after_state shape: approver_id + credential_id, key lives in creds.
+    const credsByCredentialId = {};
+    const decisions = raw.map((d) => {
+      credsByCredentialId[d.webauthn.credential_id] = { public_key_spki: d.approver_public_key };
+      return { context: d.context, approver_id: d.context.approver, webauthn: d.webauthn };
+    });
+    const members = decisionsToMembers(POLICY, decisions, credsByCredentialId);
+    expect(members).toHaveLength(3);
+    expect(quorumGate(POLICY, action, members, OPTS).satisfied).toBe(true);
+  });
+
+  it('decisionsToMembers drops a decision whose approver is not on the roster', async () => {
+    const action = 'c'.repeat(64);
+    const d = await mkDecision('program_officer', 'ep:stranger', 1, action); // not in POLICY roster
+    const decisions = [{ context: d.context, approver_id: 'ep:stranger', webauthn: d.webauthn }];
+    expect(decisionsToMembers(POLICY, decisions, { [d.webauthn.credential_id]: { public_key_spki: d.approver_public_key } })).toHaveLength(0);
   });
 });


### PR DESCRIPTION
**Draft — needs review + live multi-device E2E before merge.** This is the final fielding of multi-party quorum, on the **correct** subsystem (Class-A `audit_events` / trust-receipt consume, per #155's correction).

## Changes (all guarded — no `quorum_policy` ⇒ byte-identical behavior)
- **Issuance** (`trust-receipts/route.js`): persist optional `quorum_policy` on the receipt-creation event.
- **Consume gate** (`trust-receipts/[receiptId]/consume`): when a `quorum_policy` is present, require `quorumGate()` **satisfied** over all `guard.signoff.approved` decisions — re-verified through the same fail-closed, cross-language-conformant predicate (distinct humans, roles, order, window, action-binding, signatures) — instead of "any one approved". The gate is the authoritative security boundary.
- **Early gate** (`approve-webauthn`): `canAccept()` rejects an inadmissible signer before recording — early feedback only.
- **`decisionsToMembers()`**: joins raw audit-event payloads + policy roster + `approver_credentials` keys → members.

## Verification done
- `decisionsToMembers` round-trips audit-event shape → `quorumGate` accepts (new tests).
- **32 existing** consume/issuer/handshake tests still green — single-signoff path untouched.
- eslint clean on all touched routes.

## NOT done (why this is a draft)
- **No live E2E**: needs real multi-device WebAuthn ceremonies against EP's running app — I can't perform those.
- **Migration 094 not applied to EP prod** (the connected Supabase MCP is a *different* project — RexRuby, not EP). Apply to EP's actual Supabase before relying on the bearer-subsystem column; note this path stores the policy on the receipt event, so 094 is not strictly required for the Class-A path.

Recommend: review, then drive one ordered PO→AO→IG quorum through staging (mirror `/try/multi-party`) and confirm consume is blocked until satisfied, before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)