### PR TITLE
docs: reflect merged multi-party enforcement (honest scope)

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -58,9 +58,15 @@ independent interoperable implementations** — and it runs on every push (CI jo
 
 > **Scope, stated honestly.** Multi-party quorum is a *verifiable protocol
 > capability* with cross-language reference verifiers and a live in-browser demo
-> ([`/try/multi-party`](https://www.emiliaprotocol.ai/try/multi-party)) — not yet
-> a fielded N-party signoff product. The verifier proves a quorum is satisfiable
-> and checkable offline; production approval orchestration is on the roadmap.
+> ([`/try/multi-party`](https://www.emiliaprotocol.ai/try/multi-party)). The
+> server-side enforcement is now **wired into the live authorization path** — a
+> quorum-gated trust receipt cannot be consumed until a satisfied quorum is
+> re-verified through the same fail-closed predicate (distinct humans, roles,
+> order, window, action-binding, signatures), with an early-reject gate at
+> signoff time. What remains before calling it *fielded*: live multi-device
+> end-to-end validation in production and (for defense) an accredited
+> deployment. The orchestration is built and merged; the verifier proves a
+> quorum is satisfiable and checkable offline.
 
 ### The format, in one paragraph
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Eye observes. Handshake verifies. Signoff owns. Commit seals.
 |---|---|
 | **EP Eye** | Observes and classifies agent behavior (OBSERVE → SHADOW → ENFORCE) |
 | **EP Handshake** | Cryptographic consent ceremony with 7-property binding |
-| **EP Signoff** | Named human ownership — WebAuthn / passkey Class A, device-bound |
+| **EP Signoff** | Named human ownership — WebAuthn / passkey Class A, device-bound; **multi-party quorum** (M-of-N / ordered — the two-person rule) for the highest-stakes actions |
 | **EP Commit** | Atomic, immutable action close with Merkle-chained receipts |
 
 ---
@@ -138,6 +138,7 @@ Eye observes. Handshake verifies. Signoff owns. Commit seals.
 | Red-team cases cataloged | 85 — [RED_TEAM_CASES.md](docs/conformance/RED_TEAM_CASES.md) |
 | Security findings remediated | 31 |
 | Conformance (7/7) | `node conformance/ep-conformance-test.js https://www.emiliaprotocol.ai` |
+| Cross-language conformance | receipts · device signoffs · multi-party quorum — JS / Python / Go verifiers agree (`node conformance/run.mjs`) |
 | Handshake create p95 | 575ms at 50 VUs — [PERFORMANCE_PROOF.md](docs/operations/PERFORMANCE_PROOF.md) |
 
 ---


### PR DESCRIPTION
Brings the public docs in line with the now-merged server-side quorum enforcement (#156).

- **CONFORMANCE.md**: scope note upgraded — orchestration is wired into the live authorization path (quorum-gated receipts can't consume until a satisfied quorum re-verifies through the fail-closed predicate); remaining before *fielded* = live multi-device E2E + accredited deploy. No overclaim.
- **README**: EP Signoff row notes multi-party quorum; proof points add cross-language (JS/Python/Go) receipts·signoffs·quorum agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)