### PR TITLE
feat: EMILIA Quorum product page (multi-party as a distinct product + audience)

### DIFF
--- a/app/finguard/page.js
+++ b/app/finguard/page.js
@@ -55,6 +55,11 @@ export default function FinGuardPage() {
               cannot outlive its expiry, and cannot be consumed without the exact action it
               authorizes.
             </p>
+            <p style={{ ...styles.body, maxWidth: 720, marginTop: 12, fontSize: 15, color: color.t2 }}>
+              FinGuard binds each action to a single accountable approver. For the largest
+              transfers — where dual control is required — escalate to a multi-party quorum with{' '}
+              <a href="/quorum" style={{ color: color.t1, textDecoration: 'underline' }}>EMILIA Quorum</a>.
+            </p>
             <div style={{ display: 'flex', gap: 12, marginTop: 32, flexWrap: 'wrap' }}>
               <a href="#how-it-works" style={cta.primary}>How it works</a>
               <a href="#api" style={cta.secondary}>API reference</a>

--- a/app/govguard/page.js
+++ b/app/govguard/page.js
@@ -126,6 +126,11 @@ export default function GovGuardPage() {
             to you. The receipt proves it to everyone else - auditors, regulators,
             acquirers - without anyone having to trust your logs, your vendor, or EMILIA.
           </p>
+          <p style={{ ...styles.body, maxWidth: 740, marginTop: 8, fontSize: 15, color: color.t2 }}>
+            GovGuard binds each action to one accountable approver. Where statute or policy
+            requires dual approval — the two-person rule — escalate to a multi-party quorum
+            with <a href="/quorum" style={{ color: color.t1, textDecoration: 'underline' }}>EMILIA Quorum</a>.
+          </p>
           <div style={{ display: 'flex', gap: 12, marginTop: 30, flexWrap: 'wrap' }}>
             <a href="/pilot?v=gov" style={cta.primary}>Scope a 60-day observe-mode pilot</a>
             <a href="/pilot/sandbox" style={cta.secondary}>Run observe-mode sandbox</a>

--- a/app/quorum/layout.js
+++ b/app/quorum/layout.js
@@ -1,0 +1,31 @@
+export const metadata = {
+  title: 'EMILIA Quorum — The Two-Person Rule for AI Actions',
+  description:
+    'Multi-party approval for the highest-stakes irreversible actions: M-of-N '
+    + 'or ordered human signoff, each named approver bound to the exact action, '
+    + 'fail-closed and verifiable offline. For defense, national security, and '
+    + 'treasury dual-control.',
+  alternates: { canonical: '/quorum' },
+  openGraph: {
+    title: 'EMILIA Quorum — multi-party signoff',
+    description:
+      'The two-person rule, cryptographically enforced: an ordered or M-of-N '
+      + 'quorum of named humans, each bound to the exact action. Try it live.',
+    url: 'https://www.emiliaprotocol.ai/quorum',
+    type: 'article',
+  },
+  keywords: [
+    'two-person rule',
+    'multi-party approval',
+    'dual control authorization',
+    'M-of-N human approval',
+    'quorum authorization AI',
+    'defense AI authorization',
+    'treasury dual control',
+    'separation of duties AI agents',
+  ],
+};
+
+export default function QuorumLayout({ children }) {
+  return children;
+}

--- a/app/quorum/page.js
+++ b/app/quorum/page.js
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// EP Quorum — multi-party (two-person rule) signoff for the highest-stakes
+// irreversible actions. Landing page for the Quorum product. Sits alongside the
+// single-signoff products (FinGuard, GovGuard); this is the multi-party tier.
+
+import SiteNav from '@/components/SiteNav';
+import SiteFooter from '@/components/SiteFooter';
+import { styles, cta, color, font } from '@/lib/tokens';
+
+const AUDIENCES = [
+  ['Defense & national security', 'Actions that already mandate two-person control — release authority, taskings, weapons-adjacent decisions. The rule made cryptographic, with evidence an inspector general can verify offline.'],
+  ['Treasury & large-value payments', 'Dual control on the wire desk: the largest transfers and account changes require two distinct, named approvers — not a policy memo, a fail-closed predicate.'],
+  ['Government benefit integrity', 'Disbursement approvals and caseworker overrides that move public money require a quorum, so a single forged approval cannot redirect a payment.'],
+  ['Critical infrastructure & production', 'Irreversible deploys, infrastructure and IAM changes with real blast radius — held until the quorum signs.'],
+];
+
+const PREDICATE = [
+  ['Threshold or order', 'M-of-N (any two of three controllers) or a strict sequence (program officer → authorizing official → inspector general). The policy names which.'],
+  ['Each signer bound to the exact action', 'Every approval covers the same action hash — the same destination, amount, and parameters. No one signs a summary; everyone signs the bytes.'],
+  ['Distinct humans', 'Separation of duties is enforced, not assumed: one person cannot fill two seats, and the initiator cannot approve their own request.'],
+  ['Bounded window', 'Signatures must land close enough in time to describe one decision, not a stale collection.'],
+  ['Fail-closed', 'If any element is missing, mismatched, or unverifiable, the quorum is not satisfied — and the action does not proceed.'],
+];
+
+export default function QuorumPage() {
+  return (
+    <>
+      <SiteNav activePage="Quorum" />
+      <main style={styles.page}>
+        {/* Hero */}
+        <section style={{ ...styles.sectionWide, paddingTop: 80, paddingBottom: 56 }}>
+          <div style={styles.eyebrow}>EMILIA QUORUM</div>
+          <h1 style={{ ...styles.h1Large, maxWidth: 900 }}>
+            The two-person rule for AI actions.
+          </h1>
+          <p style={{ ...styles.body, maxWidth: 800, marginTop: 18, fontSize: 18 }}>
+            Some actions are too consequential for one signature. EMILIA Quorum holds a
+            high-stakes, irreversible action until a quorum of named humans — M-of-N or in
+            strict order, each bound to the exact action — has signed. The result is a
+            cryptographic, offline-verifiable proof that the rule held for this exact action.
+          </p>
+          <p style={{ ...styles.body, maxWidth: 760, marginTop: 8 }}>
+            It is additive over single signoff: where one accountable human is enough, use{' '}
+            <a href="/finguard" style={{ color: color.t1, textDecoration: 'underline' }}>FinGuard</a> or{' '}
+            <a href="/govguard" style={{ color: color.t1, textDecoration: 'underline' }}>GovGuard</a>.
+            Where the stakes demand more than one, require a quorum.
+          </p>
+          <div style={{ display: 'flex', gap: 12, marginTop: 30, flexWrap: 'wrap' }}>
+            <a href="/try/multi-party" style={cta.primary}>Try the live demo</a>
+            <a href="/partners" style={cta.secondary}>Scope a pilot</a>
+          </div>
+        </section>
+
+        {/* Who it's for */}
+        <section style={styles.sectionWide}>
+          <div style={styles.eyebrow}>WHO IT&rsquo;S FOR</div>
+          <h2 style={{ ...styles.h2, maxWidth: 760 }}>Where one approval is too small a target for the stakes.</h2>
+          <div style={{ marginTop: 28, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: 16 }}>
+            {AUDIENCES.map(([label, body]) => (
+              <div key={label} style={{ ...styles.card, padding: 24 }}>
+                <div style={{ ...styles.h3, fontSize: 20, marginBottom: 8 }}>{label}</div>
+                <div style={styles.cardBody}>{body}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* The predicate */}
+        <section style={styles.sectionWide}>
+          <div style={styles.eyebrow}>WHAT &ldquo;SATISFIED&rdquo; MEANS</div>
+          <h2 style={{ ...styles.h2, maxWidth: 760 }}>A quorum either holds or it doesn&rsquo;t.</h2>
+          <p style={{ ...styles.body, maxWidth: 720 }}>
+            A policy document that says &ldquo;two people must approve&rdquo; is only as strong as the
+            system that enforces it. EMILIA Quorum makes the rule a fail-closed predicate, checkable
+            by anyone:
+          </p>
+          <div style={{ marginTop: 8 }}>
+            {PREDICATE.map(([label, body], i) => (
+              <div key={i} style={{ display: 'flex', gap: 20, padding: '16px 0', borderTop: `1px solid ${color.border}` }}>
+                <div style={{ fontFamily: font.mono, fontSize: 14, color: color.gold, fontWeight: 600, minWidth: 24 }}>{i + 1}</div>
+                <div style={{ ...styles.body, fontSize: 15, margin: 0, maxWidth: 720 }}>
+                  <strong style={{ color: color.t1 }}>{label}.</strong> {body}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Verifiable / proof */}
+        <section style={styles.sectionWide}>
+          <div style={styles.eyebrow}>VERIFIABLE BY ANYONE</div>
+          <h2 style={{ ...styles.h2, maxWidth: 760 }}>Evidence, not testimony.</h2>
+          <p style={{ ...styles.body, maxWidth: 760 }}>
+            A decision log that says &ldquo;three people approved&rdquo; is testimony, controlled by the
+            party who acted. A quorum receipt is evidence: an auditor, regulator, or counterparty can
+            verify it offline, with open-source code, without trusting the system that issued it. To
+            earn that, the verification is unambiguous enough that independent implementations agree —
+            EMILIA ships three reference verifiers (JavaScript, Python, Go) that pass the same
+            adversarial quorum vectors identically, on every change.
+          </p>
+          <div style={{ display: 'flex', gap: 12, marginTop: 22, flexWrap: 'wrap' }}>
+            <a href="/try/multi-party" style={cta.secondary}>Run the demo</a>
+            <a href="/blog/the-two-person-rule-for-ai-agents" style={cta.secondary}>Read the primer</a>
+          </div>
+        </section>
+
+        {/* Honest status */}
+        <section style={styles.sectionWide}>
+          <div style={styles.eyebrow}>HONEST STATUS</div>
+          <h2 style={{ ...styles.h2, maxWidth: 760 }}>What&rsquo;s real today.</h2>
+          <p style={{ ...styles.body, maxWidth: 760 }}>
+            Multi-party quorum is a verifiable protocol capability today: the three-language reference
+            verifiers agree on it, the server-side enforcement that holds an action until the quorum is
+            satisfied is built and merged into the authorization path, and a live in-browser demo runs
+            an ordered three-party signoff and rejects a duplicate signer in front of you.
+          </p>
+          <p style={{ ...styles.body, maxWidth: 760 }}>
+            What is deliberately still ahead: end-to-end validation in production with real multi-device
+            ceremonies, and — for defense — an accredited deployment. We would rather state that plainly
+            than overclaim a control this consequential. We are taking design partners now.
+          </p>
+          <div style={{ display: 'flex', gap: 12, marginTop: 22, flexWrap: 'wrap' }}>
+            <a href="/partners" style={cta.primary}>Become a design partner</a>
+          </div>
+        </section>
+
+        <SiteFooter />
+      </main>
+    </>
+  );
+}

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -23,6 +23,7 @@ export default function sitemap() {
     { path: '/spec/trust-receipt',    priority: 0.85, changeFrequency: 'monthly' },
     { path: '/govguard',              priority: 0.95, changeFrequency: 'monthly' },
     { path: '/finguard',              priority: 0.95, changeFrequency: 'monthly' },
+    { path: '/quorum',                priority: 0.9, changeFrequency: 'monthly' },
     { path: '/mcp',                   priority: 0.9, changeFrequency: 'monthly' },
     { path: '/for-ai-companies',      priority: 0.9, changeFrequency: 'monthly' },
     { path: '/quickstart',            priority: 0.85, changeFrequency: 'monthly' },

--- a/components/SiteNav.js
+++ b/components/SiteNav.js
@@ -11,6 +11,7 @@ const NAV_LINKS = [
   ['/mcp', 'MCP'],
   ['/govguard', 'GovGuard'],
   ['/finguard', 'FinGuard'],
+  ['/quorum', 'Quorum'],
   ['/demo', 'Demo'],
   ['/try', 'Try it'],
   ['/verify', 'Verify'],


### PR DESCRIPTION
Makes single vs multi-party **two products for two audiences**, as requested.

- **Single signoff** (one named human) → **FinGuard** (treasury/fintech) + **GovGuard** (gov finance) — existing; both now cross-link to Quorum for the dual-control tier.
- **Multi-party quorum** (the two-person rule) → **new `/quorum` page** for the highest-stakes audience: defense, national security, treasury dual-control, benefit integrity. Covers the predicate (threshold/order, distinct humans, action-binding, window, fail-closed), the verifiable/tri-language proof, and links to `/try/multi-party` + the primer.

Wired into nav + sitemap. **Honest status** section on the page: built + enforcement merged + tri-lang conformance + live demo; production E2E + accreditation still ahead (design partners). eslint clean; tokens verified; mirrors the existing product-page pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)