### PR TITLE
fix(seo): 410 Gone for phantom crawler URLs /$ and /&

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -321,6 +321,19 @@ function buildCSP(nonce) {
 export async function middleware(request) {
   const { pathname } = request.nextUrl;
 
+  // Phantom URLs that crawlers mis-extract from the rendered HTML and that were
+  // never real links: /$ comes from React's streaming-SSR Suspense comment
+  // markers (<!--/$-->), /& from an escaped inline code snippet
+  // (<ep-trust-badge /&gt;). They correctly 404, but 410 Gone tells search
+  // engines the URL is permanently gone so they drop it from coverage instead
+  // of re-crawling. Exact match only — everything else falls through.
+  if (pathname === '/$' || pathname === '/&') {
+    return new NextResponse('410 Gone', {
+      status: 410,
+      headers: { 'content-type': 'text/plain', 'x-robots-tag': 'noindex' },
+    });
+  }
+
   // Non-API page requests: inject per-request nonce and CSP header.
   // The nonce is forwarded via x-nonce request header so server components
   // can read it (e.g. in app/layout.js) and pass it to <Script> tags.


### PR DESCRIPTION
Resolves the 2 **'Not found (404)'** URLs from Search Console: `/$` and `/&`.

**Diagnosis:** never real links — crawlers extract them from the rendered HTML:
- `/$` ← React's streaming-SSR Suspense comment markers (`<!--/$-->`)
- `/&` ← an escaped inline code snippet (`<ep-trust-badge /&gt;`)

**Fix:** exact-match check at the top of the existing middleware returns **410 Gone** (+ `x-robots-tag: noindex`) for these two paths, so search engines drop them permanently rather than re-crawling 404s. Every other request falls through untouched (API rate-limiting + page CSP-nonce logic unchanged). eslint clean.

This + the earlier permanent-redirect PR (#165) clears both critical Search Console buckets at the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)