### PR TITLE
fix(migrations): capture out-of-band objects (complete prod-matching schema from scratch)

### DIFF
--- a/supabase/migrations/099_resolve_authenticated_actor.sql
+++ b/supabase/migrations/099_resolve_authenticated_actor.sql
@@ -1,0 +1,75 @@
+-- 099_resolve_authenticated_actor.sql
+--
+-- Captures the resolve_authenticated_actor() auth RPC into the migration set.
+-- This function is called by lib/supabase.js authenticateRequest() and is
+-- required for EVERY authenticated API request, but it had no creating migration
+-- — it existed only out-of-band on deployed databases, so a from-scratch replay
+-- produced a DB where no authenticated call worked. Definition captured verbatim
+-- from the production database (pg_get_functiondef) on 2026-06-20.
+--
+-- CREATE OR REPLACE is idempotent: a no-op (identical redefinition) on databases
+-- that already have it; the missing definition on fresh replays / CI / DR.
+
+CREATE OR REPLACE FUNCTION public.resolve_authenticated_actor(p_key_hash text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_key_record RECORD;
+  v_entity RECORD;
+  v_active_count INT;
+  v_revoked_count INT;
+BEGIN
+  -- Count active vs revoked keys for this hash
+  SELECT
+    COUNT(*) FILTER (WHERE revoked_at IS NULL) AS active,
+    COUNT(*) FILTER (WHERE revoked_at IS NOT NULL) AS revoked
+  INTO v_active_count, v_revoked_count
+  FROM api_keys
+  WHERE key_hash = p_key_hash;
+
+  -- No rows at all
+  IF v_active_count = 0 AND v_revoked_count = 0 THEN
+    RETURN jsonb_build_object('error', 'auth_failed', 'reason', 'key_not_found');
+  END IF;
+
+  -- All revoked
+  IF v_active_count = 0 AND v_revoked_count > 0 THEN
+    RETURN jsonb_build_object('error', 'auth_failed', 'reason', 'key_revoked');
+  END IF;
+
+  -- Get first active key record
+  SELECT entity_id, permissions
+  INTO v_key_record
+  FROM api_keys
+  WHERE key_hash = p_key_hash AND revoked_at IS NULL
+  LIMIT 1;
+
+  -- Update last_used_at (fire-and-forget within same transaction)
+  UPDATE api_keys SET last_used_at = now() WHERE key_hash = p_key_hash AND revoked_at IS NULL;
+
+  -- Validate entity_id
+  IF v_key_record.entity_id IS NULL THEN
+    RETURN jsonb_build_object('error', 'malformed_key_record', 'reason', 'missing_entity_id');
+  END IF;
+
+  -- Fetch entity
+  SELECT *
+  INTO v_entity
+  FROM entities
+  WHERE id = v_key_record.entity_id;
+
+  -- Entity not found or inactive
+  IF v_entity IS NULL OR v_entity.status != 'active' THEN
+    RETURN jsonb_build_object('error', 'auth_failed', 'reason', 'entity_inactive');
+  END IF;
+
+  -- Success: return entity as JSON + permissions
+  RETURN jsonb_build_object(
+    'entity', row_to_json(v_entity)::JSONB,
+    'permissions', COALESCE(v_key_record.permissions, '[]'::JSONB)
+  );
+END;
+$function$;

--- a/supabase/migrations/100_out_of_band_tables.sql
+++ b/supabase/migrations/100_out_of_band_tables.sql
@@ -1,0 +1,79 @@
+-- 100_out_of_band_tables.sql
+--
+-- Captures three tables the app references that had no creating migration —
+-- they existed only out-of-band on deployed databases. Migrations 072 and 076
+-- already ALTER / add RLS for these and were guarded (to_regclass) so a
+-- from-scratch replay skips them when absent; this migration creates them in
+-- dependency order (after entities) so the replayed schema is complete and the
+-- guards become moot on fresh DBs. Definitions captured verbatim from production
+-- (information_schema + pg_get_constraintdef + pg_indexes) on 2026-06-20.
+--
+-- (policy_versions, also referenced in 072, intentionally NOT created — it does
+-- not exist in production either, so 072's guard is the correct handling.)
+--
+-- Everything here is idempotent (IF NOT EXISTS / DROP POLICY IF EXISTS), so it is
+-- a safe no-op on databases that already have these objects.
+
+-- ── fraud_flags ──────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS fraud_flags (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity_id    uuid NOT NULL REFERENCES entities(id),
+  submitted_by uuid NOT NULL REFERENCES entities(id),
+  flags        text[] NOT NULL,
+  detail       jsonb NOT NULL DEFAULT '{}'::jsonb,
+  blocked      boolean NOT NULL DEFAULT false,
+  reviewed     boolean NOT NULL DEFAULT false,
+  reviewed_at  timestamptz,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_fraud_flags_entity
+  ON fraud_flags (entity_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_fraud_flags_unreviewed
+  ON fraud_flags (reviewed, created_at DESC) WHERE reviewed = false;
+ALTER TABLE fraud_flags ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "service_role_bypass" ON fraud_flags;
+CREATE POLICY "service_role_bypass" ON fraud_flags TO service_role USING (true) WITH CHECK (true);
+
+-- ── partner_inquiries (public lead-capture form) ─────────────────────────────
+CREATE TABLE IF NOT EXISTS partner_inquiries (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  inquiry_type  text NOT NULL DEFAULT 'partner',
+  name          text NOT NULL,
+  email         text NOT NULL,
+  organization  text,
+  title         text,
+  website       text,
+  message       text,
+  metadata_json jsonb,
+  trust_surface text,
+  timeline      text
+);
+CREATE INDEX IF NOT EXISTS idx_partner_inquiries_email ON partner_inquiries (email);
+ALTER TABLE partner_inquiries ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "service_role_bypass" ON partner_inquiries;
+CREATE POLICY "service_role_bypass" ON partner_inquiries TO service_role USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS "anon_insert" ON partner_inquiries;
+CREATE POLICY "anon_insert" ON partner_inquiries FOR INSERT TO anon WITH CHECK (true);
+
+-- ── investor_inquiries (public lead-capture form) ────────────────────────────
+CREATE TABLE IF NOT EXISTS investor_inquiries (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  inquiry_type  text NOT NULL DEFAULT 'investor',
+  name          text NOT NULL,
+  email         text NOT NULL,
+  organization  text,
+  title         text,
+  website       text,
+  message       text,
+  metadata_json jsonb,
+  why_emilia    text,
+  help_offer    text
+);
+CREATE INDEX IF NOT EXISTS idx_investor_inquiries_email ON investor_inquiries (email);
+ALTER TABLE investor_inquiries ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "service_role_bypass" ON investor_inquiries;
+CREATE POLICY "service_role_bypass" ON investor_inquiries TO service_role USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS "anon_insert" ON investor_inquiries;
+CREATE POLICY "anon_insert" ON investor_inquiries FOR INSERT TO anon WITH CHECK (true);


### PR DESCRIPTION
Closes the migration-completeness gap flagged in #163. Several objects the app depends on had **no creating migration** and existed only out-of-band on deployed DBs — so a from-scratch replay produced an incomplete schema where **no authenticated API call worked**.

Captured **verbatim from production** (`pg_get_functiondef` / `information_schema` / `pg_get_constraintdef` / `pg_indexes`) — not guessed:

- **099** — `resolve_authenticated_actor(text)`: the auth RPC behind `authenticateRequest()` (active/revoked key counting, entity-status check, SECURITY DEFINER, pinned search_path). `CREATE OR REPLACE`.
- **100** — `fraud_flags`, `partner_inquiries`, `investor_inquiries`: tables + indexes + RLS + service_role/anon policies. `IF NOT EXISTS` / `DROP POLICY IF EXISTS`.
- `policy_versions` **intentionally not created** — confirmed it doesn't exist in production either (count 0), so 072's guard is correct.

Everything is **idempotent** → no-op on prod (objects already exist), creates them on fresh DBs/CI/DR.

### Verified
Fresh `supabase start` applies **all 96 migrations (exit 0)**; then `E2E_WEBAUTHN=1 npx playwright test e2e/multi-party-quorum.spec.js` **passes (12.1s)** with **no hand-reconstructed function** — auth + the ordered multi-party quorum work purely from migrations. The DB can now be rebuilt from migrations alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)