### PR TITLE
require-receipt: HTTP/API conformance + hardened killer demo + tightened messaging

### DIFF
--- a/app/api/demo/require-receipt/route.js
+++ b/app/api/demo/require-receipt/route.js
@@ -2,149 +2,263 @@
  * POST /api/demo/require-receipt
  * @license Apache-2.0
  *
- * Public, unauthenticated demo of the DEMAND side of EMILIA — the
- * "No receipt, no irreversible action" loop made runnable.
+ * Public, unauthenticated demo of the DEMAND side of EMILIA: the
+ * "No receipt, no irreversible action" loop made runnable over HTTP.
  *
- * A counterparty drops `requireEmiliaReceipt(...)` in front of an
- * irreversible agent action. The action below ("delete the production
- * customer database") is irreversible by construction, so the endpoint
- * REFUSES to run it unless the caller presents a verifiable EMILIA
- * authorization receipt:
+ * The route guards three consequential actions:
+ *   - release funds
+ *   - delete a repository
+ *   - change a vendor bank account
  *
- *   • No receipt        → 402 "EMILIA Receipt Required" + machine-readable
- *                         challenge telling the agent exactly what to bring
- *                         (so a well-behaved agent self-serves one and
- *                         retries, like a browser handling 401).
- *   • Invalid receipt   → 402 + the verifier's rejection reason
- *                         (expired / action_mismatch / bad_signature / …).
- *   • Valid receipt     → 200. The action is "performed" (this is a demo:
- *                         nothing is actually destroyed) and the endpoint
- *                         echoes back the portable evidence it would retain
- *                         for its own liability.
+ * The sequence is the product:
+ *   - No receipt      -> 428 Receipt Required
+ *   - Valid receipt   -> 200 + evidence packet
+ *   - Same receipt    -> 428 replay_refused
+ *   - Forged receipt  -> 428 verifier rejection
  *
- * This is NOT auth ("who are you") and NOT permissions ("are you allowed").
- * It is *portable accountability evidence the service keeps* — proof that a
- * named human accountably authorized THIS exact action. The receipt is the
- * record; it does not by itself grant access.
+ * This is not auth ("who are you") and not permissions ("are you allowed").
+ * It is portable accountability evidence the service keeps: proof that a named
+ * human accountably authorized this exact action, under this policy.
  *
- * Reference semantics: integrity-only trust (`allowInlineKey: true`) so
- * anyone can try the loop with a self-signed EP-RECEIPT-v1 document — it
- * proves the receipt was not tampered with, NOT that EMILIA vouches for the
- * issuer. In production the verifier PINS the trusted issuer keys it accepts
- * (e.g. from /.well-known/ep-keys.json). See @emilia-protocol/require-receipt.
+ * Reference semantics: integrity-only trust (`allowInlineKey: true`) so anyone
+ * can try the loop with a self-signed EP-RECEIPT-v1 document. Production
+ * integrations pin trusted issuer keys.
  *
  * Present a receipt via header `X-EMILIA-Receipt: base64(<EP-RECEIPT-v1 JSON>)`
  * or body `{ "emilia_receipt": <doc> }`.
- *
- * Privacy: this endpoint never echoes the caller's raw action parameters or
- * the full receipt payload — only the non-sensitive verification facts
- * (receipt_id, subject, outcome, truncated signer) the integrator would log.
  */
 
 import { NextResponse } from 'next/server';
-import { verifyEmiliaReceipt, receiptChallenge } from '@/packages/require-receipt/index.js';
+import {
+  RECEIPT_PROOF_HEADER,
+  RECEIPT_REQUIRED_HEADER,
+  RECEIPT_REQUIRED_STATUS,
+  receiptChallenge,
+  receiptRequiredHeader,
+} from '@/packages/require-receipt/index.js';
+import { makeReceiptGate } from '@/packages/require-receipt/gate.js';
 import { readLimitedJson } from '@/lib/http/body-limit';
 
 export const runtime = 'nodejs';
 
-// The sample irreversible action this demo guards. Fixed so the loop is
-// deterministic: a receipt must be bound to THIS action_type to pass.
-const SAMPLE_ACTION = 'demo.delete_production_database';
-
-const WWW_AUTH = `EMILIA realm="agent-actions", action="${SAMPLE_ACTION}"`;
 const MAX_RECEIPT_DEMO_BYTES = 256 * 1024;
+const MANIFEST_URL = '/.well-known/agent-actions.json';
+const RR = RECEIPT_REQUIRED_STATUS;
+
+const DEMO_ACTIONS = {
+  release_funds: {
+    id: 'release_funds',
+    label: 'Release funds',
+    action_type: 'payment.release',
+    target: 'wire:vendor-acme-250000',
+    assurance_class: 'class_a',
+    policy_id: 'demo.payment-release.class-a.v1',
+    mutation: 'Release a $250,000 vendor payment.',
+    evidence_kind: 'money_movement',
+  },
+  delete_repo: {
+    id: 'delete_repo',
+    label: 'Delete repository',
+    action_type: 'github.repo.delete',
+    target: 'repo:emilia/prod-ledger',
+    assurance_class: 'quorum',
+    policy_id: 'demo.github-repo-delete.quorum.v1',
+    mutation: 'Delete the emilia/prod-ledger repository.',
+    evidence_kind: 'code_state',
+  },
+  change_bank_account: {
+    id: 'change_bank_account',
+    label: 'Change bank account',
+    action_type: 'payment.bank_details.change',
+    target: 'vendor:acme-routing-9124',
+    assurance_class: 'class_a',
+    policy_id: 'demo.vendor-bank-change.class-a.v1',
+    mutation: 'Change ACME vendor payout destination.',
+    evidence_kind: 'payment_destination',
+  },
+};
+
+const DEFAULT_DEMO = 'release_funds';
+const gates = new Map();
+
+function boundActionFor(demo) {
+  return `${demo.action_type}:${demo.target}`;
+}
+
+function selectDemo(body = {}) {
+  const selector = body?.demo || body?.scenario || body?.action || body?.action_type || DEFAULT_DEMO;
+  return Object.values(DEMO_ACTIONS).find((demo) =>
+    selector === demo.id || selector === demo.action_type || selector === boundActionFor(demo),
+  ) || DEMO_ACTIONS[DEFAULT_DEMO];
+}
+
+function gateFor(demo) {
+  if (!gates.has(demo.id)) {
+    gates.set(demo.id, makeReceiptGate({
+      action: demo.action_type,
+      allowInlineKey: true,
+      allowedOutcomes: ['allow', 'allow_with_signoff'],
+      assuranceClass: demo.assurance_class,
+      manifestUrl: MANIFEST_URL,
+      maxAgeSec: 900,
+      statusCode: RR,
+    }));
+  }
+  return gates.get(demo.id);
+}
+
+function challengeHeaders(demo) {
+  return {
+    [RECEIPT_REQUIRED_HEADER]: receiptRequiredHeader({
+      action: boundActionFor(demo),
+      assuranceClass: demo.assurance_class,
+      manifestUrl: MANIFEST_URL,
+      maxAgeSec: 900,
+      proofHeader: RECEIPT_PROOF_HEADER,
+    }),
+    'Cache-Control': 'no-store',
+  };
+}
+
+function bodySummary(demo) {
+  return {
+    id: demo.id,
+    label: demo.label,
+    action: boundActionFor(demo),
+    action_type: demo.action_type,
+    target: demo.target,
+    assurance_class: demo.assurance_class,
+    policy_id: demo.policy_id,
+  };
+}
+
+function refusedResponse(demo, body, status = RR) {
+  return NextResponse.json(
+    {
+      ...body,
+      demo: bodySummary(demo),
+      loop: {
+        invariant: 'No receipt, no irreversible action.',
+        product: 'EMILIA makes agent accountability verifiable.',
+      },
+    },
+    { status, headers: challengeHeaders(demo) },
+  );
+}
+
+function receiptOptions(demo) {
+  return {
+    status: RR,
+    manifestUrl: MANIFEST_URL,
+    assuranceClass: demo.assurance_class,
+    maxAgeSec: 900,
+  };
+}
 
 export async function POST(request) {
   const parsed = await readLimitedJson(request, MAX_RECEIPT_DEMO_BYTES, { invalidValue: {} });
+  const body = parsed.ok ? parsed.value : {};
+  const demo = selectDemo(body);
+
   if (!parsed.ok) {
-    return NextResponse.json(
-      {
-        ...receiptChallenge(SAMPLE_ACTION, 'Refusing an irreversible action: request body is too large.'),
-        loop: { rule: 'No receipt, no irreversible action.', sample_action: SAMPLE_ACTION },
-      },
-      { status: 413, headers: { 'WWW-Authenticate': WWW_AUTH } },
+    return refusedResponse(
+      demo,
+      receiptChallenge(
+        boundActionFor(demo),
+        'Refusing a consequential action: request body is too large.',
+        receiptOptions(demo),
+      ),
+      413,
     );
   }
 
-  // 1) Look for a presented receipt — header first, then body.
   let doc = null;
-  const body = parsed.value;
-  if (body && body.emilia_receipt) doc = body.emilia_receipt;
+  if (body?.emilia_receipt) doc = body.emilia_receipt;
   if (!doc) {
     const hdr = request.headers.get('x-emilia-receipt');
     if (hdr) {
-      try { doc = JSON.parse(Buffer.from(hdr, 'base64').toString('utf8')); } catch { /* fallthrough → no receipt */ }
+      try {
+        doc = JSON.parse(Buffer.from(hdr, 'base64').toString('utf8'));
+      } catch {
+        doc = null;
+      }
     }
   }
 
-  // 2) No receipt → refuse the irreversible action with a 402 challenge.
   if (!doc) {
-    return NextResponse.json(
+    return refusedResponse(
+      demo,
       {
         ...receiptChallenge(
-          SAMPLE_ACTION,
-          'Refusing an irreversible action: no EMILIA authorization receipt was presented.',
+          boundActionFor(demo),
+          'Refusing a consequential action: no EMILIA authorization receipt was presented.',
+          receiptOptions(demo),
         ),
-        loop: {
-          rule: 'No receipt, no irreversible action.',
-          sample_action: SAMPLE_ACTION,
-          why: 'This action cannot be undone. The service requires portable, verifiable proof that a named human accountably authorized THIS exact action before it will run — and keeps that proof as its own accountability evidence. This is not auth and not permissions.',
-          to_proceed: [
-            'Obtain an EP-RECEIPT-v1 authorization receipt bound to action_type "' + SAMPLE_ACTION + '" (run emilia-gate, the SDK, or POST /api/trust/gate).',
-            'Resend this request with header  X-EMILIA-Receipt: base64(<EP-RECEIPT-v1 JSON>)  (or body { "emilia_receipt": <doc> }).',
-          ],
-          verifier: 'Offline Ed25519 over canonical JSON. This demo accepts self-signed receipts (allowInlineKey) to prove integrity; production pins trusted issuer keys.',
-        },
+        to_proceed: [
+          `Sign an EP-RECEIPT-v1 receipt bound to "${boundActionFor(demo)}".`,
+          `Retry with header ${RECEIPT_PROOF_HEADER}: base64(<EP-RECEIPT-v1 JSON>) or body { "emilia_receipt": <doc> }.`,
+        ],
+        verifier: 'Offline Ed25519 over canonical JSON. Demo accepts inline self-signed keys; production pins trusted issuer keys.',
       },
-      { status: 402, headers: { 'WWW-Authenticate': WWW_AUTH } },
     );
   }
 
-  // 3) Receipt present but invalid → 402 with the verifier's reason.
-  const v = verifyEmiliaReceipt(doc, {
-    allowInlineKey: true,           // demo only: integrity, not trust
-    action: SAMPLE_ACTION,          // receipt MUST be bound to this action
-    maxAgeSec: 900,                 // and fresh
-    allowedOutcomes: ['allow', 'allow_with_signoff'],
-  });
-  if (!v.ok) {
-    return NextResponse.json(
-      {
-        ...receiptChallenge(SAMPLE_ACTION, `Refusing an irreversible action: receipt rejected (${v.reason}).`),
-        rejected: v,
-        loop: { rule: 'No receipt, no irreversible action.', sample_action: SAMPLE_ACTION },
-      },
-      { status: 402, headers: { 'WWW-Authenticate': WWW_AUTH } },
-    );
+  const out = await gateFor(demo).run(doc, { target: demo.target }, async (verified) => ({
+    simulated: true,
+    mutation: demo.mutation,
+    authorized_action: verified.boundAction,
+  }));
+  if (!out.ok) {
+    return refusedResponse(demo, out.body, out.status);
   }
 
-  // 4) Valid receipt → the irreversible action is authorized.
-  //    (Demo: nothing is actually destroyed.) We retain only the
-  //    non-sensitive verification facts as our accountability record.
   return NextResponse.json({
     status: 200,
     allowed: true,
-    action: SAMPLE_ACTION,
-    note: 'Demo only — no data was destroyed. With a valid receipt the irreversible action would run, and the service would keep this receipt as its own portable accountability evidence.',
+    demo: bodySummary(demo),
+    action: out.result.authorized_action,
+    note: 'Demo only - no money moved, repo was deleted, or bank account changed.',
+    result: out.result,
     evidence: {
-      receipt_id: v.receipt_id,
-      subject: v.subject,
-      outcome: v.outcome,
-      signer: v.signer,             // already truncated by the verifier
+      receipt_id: out.receiptId,
+      outcome: out.outcome,
+      signer: out.signer,
     },
-  });
+    evidence_packet: {
+      '@version': 'EP-DEMO-EVIDENCE-v1',
+      statement: "EMILIA makes agent accountability verifiable. If the action runs, anyone can verify who approved exactly what, under which policy, without trusting EMILIA's server.",
+      receipt_id: out.receiptId,
+      authorized_action: out.result.authorized_action,
+      policy_id: demo.policy_id,
+      evidence_kind: demo.evidence_kind,
+      checks: [
+        'missing_receipt_refuses_428',
+        'exact_action_receipt_verifies_offline',
+        'receipt_consumed_once',
+        'replay_refused',
+        'tamper_refused',
+      ],
+      verifier: {
+        offline: true,
+        algorithm: 'Ed25519 over canonical JSON',
+        production_note: 'Pin trusted issuer keys; inline keys are accepted here only for a public self-contained demo.',
+      },
+    },
+  }, { headers: { 'Cache-Control': 'no-store' } });
 }
 
-/** Convenience: GET explains the loop and how to drive it. */
 export async function GET() {
   return NextResponse.json({
-    title: 'EMILIA require-receipt demo',
-    rule: 'No receipt, no irreversible action.',
-    sample_action: SAMPLE_ACTION,
+    title: 'EMILIA Receipt Required HTTP demo',
+    invariant: 'No receipt, no irreversible action.',
+    core_message: 'EMILIA makes agent accountability verifiable. Before an agent changes money, code, permissions, records, or regulated state, the system requires a receipt. If the action runs, anyone can verify who approved exactly what, under which policy, without trusting our server.',
+    actions: Object.values(DEMO_ACTIONS).map(bodySummary),
     try_it: {
-      refuse: 'POST here with no receipt → 402 EMILIA Receipt Required.',
-      allow: 'POST here with header X-EMILIA-Receipt: base64(<EP-RECEIPT-v1 JSON>) bound to action "' + SAMPLE_ACTION + '" → 200.',
+      refuse: `POST here with { "demo": "${DEFAULT_DEMO}" } and no receipt -> 428 Receipt Required.`,
+      allow: `POST here with ${RECEIPT_PROOF_HEADER}: base64(<EP-RECEIPT-v1 JSON>) bound to the demo action -> 200 + evidence_packet.`,
+      replay: 'POST the same receipt again -> 428 replay_refused.',
+      forged: 'Tamper with the receipt payload -> 428 untrusted_or_invalid_signature.',
     },
-    docs: 'https://www.emiliaprotocol.ai/agent-guard',
-  });
+    docs: 'https://www.emiliaprotocol.ai/gate',
+  }, { headers: { 'Cache-Control': 'no-store' } });
 }

--- a/app/gate/page.js
+++ b/app/gate/page.js
@@ -111,10 +111,10 @@ export default function GatePage() {
             <div style={{ ...styles.eyebrow, color: color.gold }}>EMILIA GATE · THE CONSEQUENCE FIREWALL</div>
             <h1 style={{ ...styles.h1, marginTop: 16 }}>The firewall for machine action.</h1>
             <p style={{ ...styles.lead, maxWidth: 760, marginTop: 16 }}>
-              Antivirus scanned files. Firewalls filtered packets. EMILIA Gate verifies actions
-              before machines change the world. It sits at the actuator boundary and refuses any
-              consequential action unless it carries a valid, non-replayed authorization receipt —
-              proof a named human approved that exact action.
+              EMILIA makes agent accountability verifiable. Before an agent changes money, code,
+              permissions, records, or regulated state, the system requires a receipt. If the
+              action runs, anyone can verify who approved exactly what, under which policy, without
+              trusting EMILIA&apos;s server.
             </p>
             <p style={{ ...styles.body, maxWidth: 760, marginTop: 12, fontSize: 15, color: color.t2 }}>
               Not authentication, not permissions, not anomaly detection. A policy-enforcement point
@@ -124,6 +124,7 @@ export default function GatePage() {
             <div style={{ display: 'flex', gap: 12, marginTop: 32, flexWrap: 'wrap' }}>
               <a href="#loop" style={cta.primary}>How it works</a>
               <a href="#surfaces" style={cta.secondary}>Where it runs</a>
+              <a href="/api/demo/require-receipt" style={cta.secondary}>Open HTTP demo</a>
               <a href="/pilot?v=gate" style={cta.secondary}>Request pilot</a>
             </div>
           </div>

--- a/app/page.js
+++ b/app/page.js
@@ -164,10 +164,10 @@ export default function HomePage() {
                 fontSize: 17, color: color.t2,
                 maxWidth: 490, lineHeight: 1.72, margin: '0 0 40px',
               }}>
-                EMILIA is the authorization-receipt layer for irreversible AI-agent actions. Before an
-                agent moves money, changes a record, deploys code, or deletes data, a named human signs
-                the <em style={{ fontStyle: 'normal', color: color.t1, fontWeight: 600 }}>exact</em> action on their own device — and afterward, anyone can verify who approved
-                exactly what, offline, without trusting EMILIA or a compromised agent.
+                EMILIA makes agent accountability verifiable. Before an agent changes money, code,
+                permissions, records, or regulated state, the system requires a receipt. If the
+                action runs, anyone can verify who approved exactly what, under which policy,
+                without trusting EMILIA&apos;s server.
               </p>
 
               <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>

--- a/docs/REQUIRE-RECEIPT-LOOP.md
+++ b/docs/REQUIRE-RECEIPT-LOOP.md
@@ -6,214 +6,163 @@ Copyright the EMILIA Protocol authors.
 # The "No receipt, no irreversible action" loop
 
 **Live demo endpoint:** `POST /api/demo/require-receipt`
-**Powered by:** [`@emilia-protocol/require-receipt`](../packages/require-receipt) (the demand side of the network)
+**Powered by:** [`@emilia-protocol/require-receipt`](../packages/require-receipt)
+**HTTP conformance:** [`tests/http-api-conformance.test.js`](../tests/http-api-conformance.test.js)
 
-This is a runnable reference for the core demand-side move: a service **refuses
-to run an irreversible action unless the request arrives with a verifiable
-EMILIA authorization receipt** — proof that a named human accountably authorized
-*this exact action*.
+EMILIA makes agent accountability verifiable. Before an agent changes money,
+code, permissions, records, or regulated state, the system requires a receipt.
+If the action runs, anyone can verify who approved exactly what, under which
+policy, without trusting EMILIA's server.
 
-It is **not auth** ("who are you") and **not permissions** ("are you allowed
-here"). The receipt is *portable accountability evidence the service keeps for
-its own liability*. It is the record of an authorization; it does not by itself
-grant access.
+This is **not auth** ("who are you") and **not permissions** ("are you allowed
+here"). The receipt is portable accountability evidence the service keeps: proof
+that a named human or quorum authorized this exact action, under the policy in
+force, before the mutation reached the system of record.
 
-The sample action this demo guards is irreversible by construction:
-`demo.delete_production_database`. (Nothing is actually destroyed — it's a demo.)
+The public demo guards three concrete actions:
+
+- `release_funds` -> `payment.release:wire:vendor-acme-250000`
+- `delete_repo` -> `github.repo.delete:repo:emilia/prod-ledger`
+- `change_bank_account` -> `payment.bank_details.change:vendor:acme-routing-9124`
+
+Nothing is actually mutated. The route simulates the mutation and exports the
+evidence packet an integrator would retain.
 
 ---
 
-## The loop
+## The HTTP-RR-1 Sequence
 
+```text
+Agent calls a consequential endpoint
+        |
+        v
+Missing receipt?
+        |
+        +-- yes -> HTTP 428 Receipt Required
+        |          Receipt-Required: action="payment.release:wire:..."
+        |          JSON body explains the exact receipt to bring
+        |
+        +-- no  -> Verify receipt offline:
+                   - Ed25519 canonical JSON signature
+                   - exact action binding
+                   - acceptable outcome
+                   - freshness
+                   - one-time consumption
+                   - trusted issuer keys in production
+                         |
+                         +-- fail -> HTTP 428 + sanitized rejection reason
+                         |
+                         +-- pass -> mutation runs, receipt is consumed once,
+                                     evidence_packet is exported
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│  Agent wants to run an IRREVERSIBLE action                        │
-└───────────────────────────────┬─────────────────────────────────┘
-                                 │  POST /api/demo/require-receipt
-                                 ▼
-                    ┌────────────────────────┐
-                    │  Receipt presented?     │
-                    └──────┬──────────┬───────┘
-                       no  │          │  yes
-                           ▼          ▼
-              402 Receipt        ┌──────────────────────┐
-              Required           │ Verify (offline      │
-              + challenge        │ Ed25519, canonical   │
-              "here is exactly   │ JSON): bound to this  │
-               what to bring"    │ action? fresh?        │
-                           │     │ acceptable outcome?   │
-                           │     └──────┬─────────┬──────┘
-                           │       no   │         │  yes
-                           │            ▼         ▼
-                           │      402 + reason   200 OK
-                           │      (rejected:{})  action runs;
-                           │                     service keeps
-                           ▼                     the receipt as
-              Agent obtains a receipt            its accountability
-              and RETRIES  ◄────────────────────  evidence
-```
 
-A well-behaved agent treats the `402` like a browser treats `401`: it reads the
-machine-readable challenge, obtains a receipt bound to the named action, and
-retries — **no human in the loop**. That is why the demand side is self-adopting.
+The conformance test proves the API boundary, not just the verifier library:
 
-`402` deliberately aligns with the emerging "challenge-to-transact" convention
-for agent commerce (x402 / AP2): receipts ride the same rail payments do.
+1. Missing receipt returns `428 Receipt Required`.
+2. A receipt bound to the exact action runs.
+3. The same receipt replay is refused.
+4. A tampered receipt is refused.
+5. The successful response exports an evidence packet.
 
----
-
-## Verification semantics
-
-The demo verifies receipts with `allowInlineKey: true` — it accepts a
-**self-signed** EP-RECEIPT-v1 document so anyone can drive the loop end to end.
-That proves the receipt was **not tampered with**; it does **not** mean EMILIA
-vouches for the issuer.
-
-In production the verifier instead **pins the trusted issuer keys** it will
-accept (for example from `/.well-known/ep-keys.json`) and passes them as
-`trustedKeys`. Every fact the endpoint returns (`receipt_id`, `subject`,
-`outcome`, `signer`) is something the caller can independently re-derive by
-verifying the same receipt offline — no EMILIA-vouched opinion or score is
-involved.
-
-The endpoint requires the receipt to be:
-
-- **bound to the action** — `claim.action_type === "demo.delete_production_database"`
-- **fresh** — `created_at` within `maxAgeSec` (900s)
-- **an acceptable outcome** — `allow` or `allow_with_signoff`
-
-Privacy: the endpoint never echoes your raw action parameters or the full
-receipt payload — only the non-sensitive verification facts an integrator would
-log.
-
----
-
-## Try it with curl
-
-### 1. No receipt → `402 EMILIA Receipt Required`
+Run it:
 
 ```bash
-curl -i -X POST http://localhost:3000/api/demo/require-receipt
+npx vitest run tests/http-api-conformance.test.js
 ```
 
-Response (truncated):
+---
 
-```http
-HTTP/1.1 402 Payment Required
-WWW-Authenticate: EMILIA realm="agent-actions", action="demo.delete_production_database"
-Content-Type: application/json
+## Try It
 
-{
-  "type": "https://emiliaprotocol.ai/errors/emilia_receipt_required",
-  "title": "EMILIA Receipt Required",
-  "status": 402,
-  "detail": "Refusing an irreversible action: no EMILIA authorization receipt was presented.",
-  "required": {
-    "action": "demo.delete_production_database",
-    "header": "X-EMILIA-Receipt: base64(<EP-RECEIPT-v1 JSON>)",
-    "how": "Obtain a receipt (run emilia-gate, the SDK, or POST /api/trust/gate), then resend with the header.",
-    "learn_more": "https://www.emiliaprotocol.ai/agent-guard"
-  },
-  "loop": {
-    "rule": "No receipt, no irreversible action.",
-    "sample_action": "demo.delete_production_database",
-    "why": "This action cannot be undone. The service requires portable, verifiable proof that a named human accountably authorized THIS exact action before it will run...",
-    "to_proceed": [ "...", "..." ]
-  }
-}
-```
-
-### 2. Invalid receipt → `402` with the rejection reason
-
-Send a receipt that is malformed, expired, or bound to the wrong action:
+### 1. No receipt -> `428 Receipt Required`
 
 ```bash
 curl -i -X POST http://localhost:3000/api/demo/require-receipt \
   -H 'Content-Type: application/json' \
-  -d '{"emilia_receipt":{"@version":"EP-RECEIPT-v1","payload":{"claim":{"action_type":"some.other.action"}},"signature":{"value":"AAAA"}}}'
+  -d '{"demo":"release_funds"}'
 ```
 
-Response (truncated):
+Response shape:
 
 ```http
-HTTP/1.1 402 Payment Required
-WWW-Authenticate: EMILIA realm="agent-actions", action="demo.delete_production_database"
+HTTP/1.1 428 Precondition Required
+Receipt-Required: action="payment.release:wire:vendor-acme-250000", manifest="/.well-known/agent-actions.json", proof="X-EMILIA-Receipt", profile="EP-RECEIPT-v1", assurance="class_a", max_age="900"
+Content-Type: application/json
+```
 
+```json
 {
   "title": "EMILIA Receipt Required",
-  "status": 402,
-  "detail": "Refusing an irreversible action: receipt rejected (untrusted_or_invalid_signature).",
-  "rejected": { "ok": false, "reason": "untrusted_or_invalid_signature" }
-}
-```
-
-Possible `rejected.reason` values: `malformed_receipt`,
-`bad_signature_encoding`, `untrusted_or_invalid_signature`, `receipt_expired`,
-`action_mismatch`, `outcome_not_accepted`.
-
-### 3. Valid receipt → `200`
-
-Present a valid EP-RECEIPT-v1 document bound to
-`demo.delete_production_database`. You can produce one with the SDK or
-`emilia-gate`; this demo accepts a self-signed receipt (`allowInlineKey`).
-
-```bash
-# RECEIPT_B64 = base64 of an EP-RECEIPT-v1 JSON document
-curl -i -X POST http://localhost:3000/api/demo/require-receipt \
-  -H "X-EMILIA-Receipt: $RECEIPT_B64"
-```
-
-Response:
-
-```http
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-{
-  "status": 200,
-  "allowed": true,
-  "action": "demo.delete_production_database",
-  "note": "Demo only — no data was destroyed. With a valid receipt the irreversible action would run, and the service would keep this receipt as its own portable accountability evidence.",
-  "evidence": {
-    "receipt_id": "...",
-    "subject": "...",
-    "outcome": "allow",
-    "signer": "MCowBQYDK2Vw…"
+  "status": 428,
+  "required": {
+    "action": "payment.release:wire:vendor-acme-250000",
+    "proof_header": "X-EMILIA-Receipt"
+  },
+  "loop": {
+    "invariant": "No receipt, no irreversible action.",
+    "product": "EMILIA makes agent accountability verifiable."
   }
 }
 ```
 
-### See the loop description (GET)
+### 2. Valid receipt -> `200` + evidence packet
+
+Present an EP-RECEIPT-v1 document bound to the exact demo action:
 
 ```bash
-curl -s http://localhost:3000/api/demo/require-receipt | jq
+curl -i -X POST http://localhost:3000/api/demo/require-receipt \
+  -H 'Content-Type: application/json' \
+  -d '{"demo":"release_funds","emilia_receipt":{...}}'
 ```
+
+Response shape:
+
+```json
+{
+  "status": 200,
+  "allowed": true,
+  "action": "payment.release:wire:vendor-acme-250000",
+  "evidence": {
+    "receipt_id": "rcpt_...",
+    "outcome": "allow_with_signoff",
+    "signer": "MCowBQYDK2Vw..."
+  },
+  "evidence_packet": {
+    "@version": "EP-DEMO-EVIDENCE-v1",
+    "authorized_action": "payment.release:wire:vendor-acme-250000",
+    "policy_id": "demo.payment-release.class-a.v1",
+    "checks": [
+      "missing_receipt_refuses_428",
+      "exact_action_receipt_verifies_offline",
+      "receipt_consumed_once",
+      "replay_refused",
+      "tamper_refused"
+    ]
+  }
+}
+```
+
+### 3. Replay -> `428 replay_refused`
+
+Send the same receipt again. It fails because the gate has already consumed the
+receipt once.
+
+### 4. Tamper -> `428 untrusted_or_invalid_signature`
+
+Change the payload after signature. It fails because the canonical JSON bytes no
+longer match the Ed25519 signature.
 
 ---
 
-## Drop it in front of your own action
+## Production Notes
 
-```js
-import { requireEmiliaReceipt } from '@emilia-protocol/require-receipt';
+The public demo accepts inline, self-signed keys so anyone can run the loop
+without an EMILIA account. That proves integrity only. Production deployments
+pin trusted issuer keys, usually discovered from `/.well-known/ep-keys.json` or
+configured out-of-band.
 
-app.post(
-  '/delete-account',
-  requireEmiliaReceipt({
-    trustedKeys: [process.env.EMILIA_ISSUER_PUBKEY], // base64url SPKI you trust
-    action: 'account.delete',
-    maxAgeSec: 900,
-  }),
-  (req, res) => {
-    // Only reached with a fresh, untampered, action-bound receipt from a
-    // trusted issuer. req.emiliaReceipt holds the verified claim — keep it.
-    res.json({ deleted: true, receipt: req.emiliaReceipt.receipt_id });
-  },
-);
-```
+For x402/AP2-compatible flows that deliberately need the legacy commercial
+challenge shape, the library still supports `402`. New Receipt Required rails
+SHOULD use `428 Precondition Required`.
 
-A guardrail blocks *your* agent (a cost). A required receipt makes *every*
-counterparty demand portable proof of accountable authorization. See
-[/agent-guard](https://www.emiliaprotocol.ai/agent-guard) and the package
-[README](../packages/require-receipt/README.md).
-
-Apache-2.0 · part of [EMILIA Protocol](https://www.emiliaprotocol.ai)
+Apache-2.0 - part of [EMILIA Protocol](https://www.emiliaprotocol.ai)

--- a/docs/conformance/HTTP_API_CONFORMANCE.md
+++ b/docs/conformance/HTTP_API_CONFORMANCE.md
@@ -1,0 +1,46 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright the EMILIA Protocol authors.
+-->
+
+# HTTP/API Conformance
+
+Verifier conformance proves that JavaScript, Python, and Go agree on receipt
+validity. HTTP/API conformance proves the adoption claim at the boundary where a
+real system would mutate state.
+
+An EMILIA Receipt Required API earns **HTTP-RR-1** when it demonstrates:
+
+1. **Missing receipt -> 428.** The endpoint refuses before mutation and returns
+   a machine-readable `Receipt-Required` challenge.
+2. **Exact-action receipt -> runs.** A receipt bound to the exact action and
+   target reaches the simulated executor.
+3. **Replay -> refused.** The same receipt cannot authorize the action twice.
+4. **Tamper -> refused.** A forged or modified receipt fails closed.
+5. **Evidence -> exported.** The success response includes the receipt id,
+   authorized action, policy id, and offline verification notes.
+
+The public test target is:
+
+```text
+POST /api/demo/require-receipt
+```
+
+It covers three high-risk families:
+
+- funds release
+- repository deletion
+- vendor bank-account change
+
+Run the conformance check:
+
+```bash
+npx vitest run tests/http-api-conformance.test.js
+```
+
+Schema/security drift checks are separate operational gates and should continue
+to run with:
+
+```bash
+npm run schema:security
+```

--- a/tests/http-api-conformance.test.js
+++ b/tests/http-api-conformance.test.js
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// HTTP/API conformance for the public Receipt Required demo. Verifier
+// conformance proves cryptographic parity; this proves the product rail at the
+// HTTP boundary: challenge, exact-action receipt, one-time consumption, tamper
+// refusal, and evidence export.
+
+import { describe, expect, it } from 'vitest';
+import { GET, POST } from '../app/api/demo/require-receipt/route.js';
+import { signAction } from '../examples/mcp/_kit.mjs';
+
+function request(body, headers = {}) {
+  return new Request('https://www.emiliaprotocol.ai/api/demo/require-receipt', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+function b64(doc) {
+  return Buffer.from(JSON.stringify(doc), 'utf8').toString('base64');
+}
+
+async function catalog() {
+  const res = await GET();
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.core_message).toContain('agent accountability verifiable');
+  expect(body.actions.map((a) => a.id)).toEqual([
+    'release_funds',
+    'delete_repo',
+    'change_bank_account',
+  ]);
+  return body.actions;
+}
+
+describe('HTTP/API Receipt Required conformance', () => {
+  it('advertises the public demo catalog and the exact core message', async () => {
+    const actions = await catalog();
+    expect(actions).toHaveLength(3);
+    for (const action of actions) {
+      expect(action.action).toMatch(`${action.action_type}:`);
+      expect(action.policy_id).toMatch(/^demo\./);
+    }
+  });
+
+  it('earns HTTP-RR-1 on release funds, repo deletion, and bank-account changes', async () => {
+    for (const action of await catalog()) {
+      const missing = await POST(request({ demo: action.id }));
+      expect(missing.status).toBe(428);
+      expect(missing.headers.get('receipt-required')).toContain(action.action);
+      const missingBody = await missing.json();
+      expect(missingBody.required.action).toBe(action.action);
+      expect(missingBody.loop.invariant).toBe('No receipt, no irreversible action.');
+
+      const receipt = signAction(action.action, { approver: `ep:approver:http-${action.id}` });
+      const valid = await POST(request({ demo: action.id, emilia_receipt: receipt }));
+      expect(valid.status).toBe(200);
+      const validBody = await valid.json();
+      expect(validBody.allowed).toBe(true);
+      expect(validBody.action).toBe(action.action);
+      expect(validBody.evidence.receipt_id).toBe(receipt.payload.receipt_id);
+      expect(validBody.evidence_packet.authorized_action).toBe(action.action);
+      expect(validBody.evidence_packet.policy_id).toBe(action.policy_id);
+      expect(validBody.evidence_packet.checks).toContain('replay_refused');
+
+      const replay = await POST(request({ demo: action.id, emilia_receipt: receipt }));
+      expect(replay.status).toBe(428);
+      const replayBody = await replay.json();
+      expect(replayBody.rejected.reason).toBe('replay_refused');
+
+      const forged = signAction(action.action, { approver: 'ep:approver:forged', tamper: true });
+      const forgedRes = await POST(request({ demo: action.id, emilia_receipt: forged }));
+      expect(forgedRes.status).toBe(428);
+      const forgedBody = await forgedRes.json();
+      expect(forgedBody.rejected.reason).toBe('untrusted_or_invalid_signature');
+    }
+  });
+
+  it('accepts the standard X-EMILIA-Receipt header and still exports evidence', async () => {
+    const [action] = await catalog();
+    const receipt = signAction(action.action, { approver: 'ep:approver:http-header' });
+    const res = await POST(request(
+      { demo: action.id },
+      { 'x-emilia-receipt': b64(receipt) },
+    ));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.evidence.receipt_id).toBe(receipt.payload.receipt_id);
+    expect(body.evidence_packet.verifier.offline).toBe(true);
+  });
+});


### PR DESCRIPTION
HTTP-level conformance for the require-receipt loop + hardened public demo (release_funds/delete_repo/change_bank_account: missing→428, valid→runs, replay→refused, tamper→refused, success→evidence_packet) + tightened homepage/Gate messaging + docs.

Verified locally: 266/266 tests (incl. new 3 conformance), build clean, schema:security 118 assertions satisfied. No authority/schema/migration files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)