### PR TITLE
feat(fire-drill): RR-1 maintainer-activation engine (reports + program + badge)

### DIFF
--- a/app/fire-drill/registry/page.js
+++ b/app/fire-drill/registry/page.js
@@ -3,11 +3,13 @@
 // capability and publish a repo. Registry-level signal (name + description), not
 // a tool-level scan. Each row backlinks to the real repo + its result page.
 
+import Link from 'next/link';
 import SiteNav from '@/components/SiteNav';
 import SiteFooter from '@/components/SiteFooter';
 import { styles, cta, color, font } from '@/lib/tokens';
 import { REGISTRY_CORPUS } from '../../../packages/fire-drill/registry-corpus.js';
 import registryIndex from '../../../packages/fire-drill/registry-index.json';
+import reports from '../../../packages/fire-drill/reports.json';
 
 export const metadata = {
   title: 'Agent Action Firewall — MCP registry index (43,800 servers) | EMILIA',
@@ -43,15 +45,37 @@ export default function RegistryIndexPage() {
             </p>
             <p style={{ ...styles.body, fontSize: 13, color: color.t3, marginTop: 14, maxWidth: 760 }}>
               Registry-level signal (name + description), not a tool-level manifest scan or a deployment scan or a vulnerability
-              report. Listed below: {REGISTRY_CORPUS.length} high-risk-advertising servers that publish a repo. Is one yours?{' '}
-              <a href="/gate#eg1" style={{ color: color.gold }}>Add a gate, earn EG-1.</a>
+              report. Listed below: {REGISTRY_CORPUS.length} high-risk-advertising servers that publish a repo. We&rsquo;re testing
+              the ecosystem for receipt-required dangerous actions — maintainers can <a href="/fire-drill/rr-1" style={{ color: color.gold }}>earn RR-1</a> and
+              make their most dangerous action safer than the default.
             </p>
             <div style={{ display: 'flex', gap: 12, marginTop: 22, flexWrap: 'wrap' }}>
-              <a href="/fire-drill" style={cta.primary}>Run it on your server</a>
-              <a href="/fire-drill/report" style={cta.secondary}>Full report</a>
+              <Link href="/fire-drill/rr-1" style={cta.primary}>Earn RR-1</Link>
+              <Link href="/fire-drill/report" style={cta.secondary}>Full report</Link>
             </div>
           </div>
         </section>
+
+        {reports.reports.filter((r) => r.published).length > 0 && (
+          <section style={{ ...styles.section, paddingTop: 0, paddingBottom: 18 }}>
+            <div style={styles.container}>
+              <div style={{ ...styles.eyebrow, color: color.gold }}>VERIFIED FIRE DRILL REPORTS · {reports.reports.filter((r) => r.published).length}</div>
+              <p style={{ ...styles.body, fontSize: 13, color: color.t3, marginTop: 8, maxWidth: 760 }}>
+                Where we read the source and confirmed a real dangerous handler, the report cites the exact code and the
+                Receipt Required fix. Each is a path to RR-1, not a callout.
+              </p>
+              <div style={{ marginTop: 8 }}>
+                {reports.reports.filter((r) => r.published).map((r) => (
+                  <div key={r.slug} style={{ display: 'flex', gap: 14, alignItems: 'center', padding: '11px 0', borderTop: `1px solid ${color.border}`, flexWrap: 'wrap' }}>
+                    <Link href={`/fire-drill/report/${r.slug}`} style={{ ...styles.body, fontSize: 14, color: color.t1, minWidth: 260, fontWeight: 600 }}>{r.name}</Link>
+                    <span style={{ fontFamily: font.mono, fontSize: 12, color: '#DC2626' }}>{r.dangerous_tool}</span>
+                    <Link href={`/fire-drill/report/${r.slug}`} style={{ ...styles.body, fontSize: 13, color: color.gold, marginLeft: 'auto' }}>report →</Link>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+        )}
 
         {families.map(([fam, servers]) => (
           <section key={fam} style={{ ...styles.section, paddingTop: 0, paddingBottom: 18 }}>

--- a/app/fire-drill/report/[slug]/page.js
+++ b/app/fire-drill/report/[slug]/page.js
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// /fire-drill/report/[slug] — a per-MCP Fire Drill REPORT for a VERIFIED target.
+// Unlike the registry-level pages (name/description signal), each report here
+// cites a real dangerous handler read from the repo source (file + symbol +
+// verbatim quote), states it currently runs unguarded, proposes the Receipt
+// Required wrapper, and shows the after-patch RR-1 outcomes. Non-shaming:
+// it ends at "earn RR-1", and reports go live in tandem with the fix PR.
+
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import SiteNav from '@/components/SiteNav';
+import SiteFooter from '@/components/SiteFooter';
+import { styles, cta, color, font } from '@/lib/tokens';
+import reports from '../../../../packages/fire-drill/reports.json';
+
+const PUBLISHED = reports.reports.filter((r) => r.published);
+const BY_SLUG = Object.fromEntries(PUBLISHED.map((r) => [r.slug, r]));
+
+const FAMILY_LABEL = {
+  money_movement: 'money movement',
+  production_deploy: 'production deploy',
+  data_destruction: 'data destruction',
+  permission_change: 'permission change',
+  data_export: 'data export',
+  webhook: 'external dispatch / webhook',
+};
+
+export function generateStaticParams() {
+  return PUBLISHED.map((r) => ({ slug: r.slug }));
+}
+
+export function generateMetadata({ params }) {
+  const r = BY_SLUG[params.slug];
+  if (!r) return { title: 'Report not found — EMILIA Fire Drill' };
+  return {
+    title: `Fire Drill: ${r.name} — ${r.dangerous_tool} | EMILIA`,
+    description: `EMILIA Fire Drill of ${r.name}: dangerous action ${r.dangerous_tool} (${FAMILY_LABEL[r.family] || r.family}) currently runs with no authorization receipt. Proposed fix: Receipt Required (RR-1).`,
+  };
+}
+
+function StatusPill({ status }) {
+  const map = {
+    report_ready: { t: 'Report ready', c: color.t2 },
+    pr_open: { t: 'Fix PR open', c: color.gold },
+    merged: { t: 'RR-1 — merged', c: '#16a34a' },
+  };
+  const s = map[status] || map.report_ready;
+  return (
+    <span style={{ fontFamily: font.mono, fontSize: 12, color: s.c, border: `1px solid ${s.c}`, borderRadius: 10, padding: '2px 9px' }}>
+      {s.t}
+    </span>
+  );
+}
+
+function Outcome({ n, label, result }) {
+  return (
+    <div style={{ display: 'flex', gap: 12, alignItems: 'baseline', padding: '10px 0', borderTop: `1px solid ${color.border}` }}>
+      <span style={{ fontFamily: font.mono, fontSize: 13, color: color.gold, minWidth: 20 }}>{n}</span>
+      <span style={{ ...styles.body, fontSize: 14.5, color: color.t1, fontWeight: 600, minWidth: 260 }}>{label}</span>
+      <span style={{ fontFamily: font.mono, fontSize: 12.5, color: '#16a34a' }}>{result}</span>
+    </div>
+  );
+}
+
+export default function FireDrillReportPage({ params }) {
+  const r = BY_SLUG[params.slug];
+  if (!r) notFound();
+  const fam = FAMILY_LABEL[r.family] || r.family;
+
+  return (
+    <>
+      <SiteNav activePage="Fire Drill" />
+      <main style={styles.page}>
+        <section style={{ ...styles.section, paddingTop: 80, paddingBottom: 22 }}>
+          <div style={styles.container}>
+            <div style={{ display: 'flex', gap: 14, alignItems: 'center', flexWrap: 'wrap' }}>
+              <div style={{ ...styles.eyebrow, color: color.gold, margin: 0 }}>EMILIA FIRE DRILL · REPORT</div>
+              <StatusPill status={r.status} />
+            </div>
+            <h1 style={{ ...styles.h1, marginTop: 14 }}>{r.name}</h1>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 18, marginTop: 14, flexWrap: 'wrap' }}>
+              <span style={{ fontFamily: font.mono, fontSize: 13, color: '#DC2626', textTransform: 'uppercase', letterSpacing: 1 }}>{fam}</span>
+              <a href={r.repo} target="_blank" rel="noopener noreferrer" style={{ ...styles.body, fontSize: 13, color: color.gold, marginLeft: 'auto' }}>repository ↗</a>
+            </div>
+          </div>
+        </section>
+
+        {/* Dangerous action found */}
+        <section style={{ ...styles.section, paddingTop: 0, paddingBottom: 18 }}>
+          <div style={styles.container}>
+            <h2 style={styles.h2}>Dangerous action found</h2>
+            <p style={{ ...styles.body, maxWidth: 760, marginTop: 10 }}>
+              <code style={{ fontFamily: font.mono, color: color.t1 }}>{r.dangerous_tool}</code> — {r.dangerous_summary}
+            </p>
+            <pre style={{
+              fontFamily: font.mono, fontSize: 12.5, color: color.t1, background: '#0b0e14',
+              border: `1px solid ${color.border}`, borderRadius: 8, padding: '12px 14px', overflowX: 'auto', marginTop: 12,
+            }}>{`// ${r.handler_file}  ·  ${r.handler_symbol}\n${r.handler_quote}`}</pre>
+            <p style={{ ...styles.body, fontSize: 14, color: color.t2, marginTop: 14, maxWidth: 760 }}>
+              <b style={{ color: '#DC2626' }}>Currently:</b> {r.currently}
+            </p>
+          </div>
+        </section>
+
+        {/* Proposed fix + after-patch */}
+        <section style={{ ...styles.section, paddingTop: 0 }}>
+          <div style={styles.container}>
+            <h2 style={styles.h2}>Proposed fix — Receipt Required</h2>
+            <p style={{ ...styles.body, maxWidth: 760, marginTop: 10 }}>{r.proposed_fix}</p>
+            <h3 style={{ ...styles.body, fontSize: 14, fontWeight: 700, color: color.t1, marginTop: 22 }}>Result after patch (RR-1):</h3>
+            <div style={{ marginTop: 6 }}>
+              <Outcome n="1" label="Missing receipt" result={r.after_patch.missing} />
+              <Outcome n="2" label="Valid receipt" result={r.after_patch.valid} />
+              <Outcome n="3" label="Replayed receipt" result={r.after_patch.replay} />
+              <Outcome n="4" label="Forged receipt" result={r.after_patch.forged} />
+            </div>
+            <div style={{ display: 'flex', gap: 12, marginTop: 24, alignItems: 'center', flexWrap: 'wrap' }}>
+              {r.pr_url ? (
+                <a href={r.pr_url} target="_blank" rel="noopener noreferrer" style={cta.primary}>View the fix PR ↗</a>
+              ) : (
+                <a href="https://www.npmjs.com/package/@emilia-protocol/require-receipt" target="_blank" rel="noopener noreferrer" style={cta.primary}>Earn RR-1</a>
+              )}
+              <Link href="/fire-drill/rr-1" style={cta.secondary}>What is RR-1?</Link>
+              {/* eslint-disable-next-line @next/next/no-img-element -- static SVG badge, next/image is overkill */}
+              <img src="/badges/rr-1.svg" alt="Receipt Required: RR-1" width={178} height={20} style={{ marginLeft: 'auto' }} />
+            </div>
+          </div>
+        </section>
+
+        <section style={{ ...styles.section, paddingTop: 0 }}>
+          <div style={styles.container}>
+            <p style={{ ...styles.body, fontSize: 13, color: color.t3, maxWidth: 760 }}>
+              Scope: this is a static reference-implementation assessment of a <b>missing human-authorization receipt</b> on one
+              irreversible action, derived from the repository&rsquo;s public source. It is <b>not</b> a vulnerability report, not a
+              claim the action is exploitable, and not auth or permissions. {r.maintainer_note}
+            </p>
+          </div>
+        </section>
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/app/fire-drill/rr-1/page.js
+++ b/app/fire-drill/rr-1/page.js
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// /fire-drill/rr-1 — the RR-1 maintainer program. Social proof ("we are testing
+// the MCP ecosystem for receipt-required dangerous actions; maintainers can earn
+// RR-1") + the make-you-look-good badge ("safer than the default ecosystem"),
+// NOT a shame badge. Drives maintainers to the 10-minute Receipt Required PR kit.
+
+import Link from 'next/link';
+import SiteNav from '@/components/SiteNav';
+import SiteFooter from '@/components/SiteFooter';
+import { styles, cta, color, font } from '@/lib/tokens';
+import registryIndex from '../../../packages/fire-drill/registry-index.json';
+import reports from '../../../packages/fire-drill/reports.json';
+
+export const metadata = {
+  title: 'RR-1 — the Receipt Required badge for MCP maintainers | EMILIA',
+  description:
+    'We are testing the MCP ecosystem for receipt-required dangerous actions. RR-1 means your most dangerous action is safer than the ecosystem default: missing receipt blocked, valid receipt runs once, replay refused, forged refused.',
+};
+
+const BADGE = 'https://www.emiliaprotocol.ai/badges/rr-1.svg';
+const BADGE_MD = `[![Receipt Required: RR-1](${BADGE})](https://www.emiliaprotocol.ai/fire-drill/rr-1)`;
+
+export default function RR1Page() {
+  const { rr1 } = reports;
+  return (
+    <>
+      <SiteNav activePage="Fire Drill" />
+      <main style={styles.page}>
+        <section style={{ ...styles.section, paddingTop: 80, paddingBottom: 24 }}>
+          <div style={styles.container}>
+            <div style={{ ...styles.eyebrow, color: color.gold }}>RR-1 · RECEIPT REQUIRED, LEVEL 1</div>
+            <h1 style={{ ...styles.h1, marginTop: 14 }}>
+              We&rsquo;re testing the MCP ecosystem for receipt-required dangerous actions.
+            </h1>
+            <p style={{ ...styles.body, maxWidth: 760, marginTop: 16 }}>
+              We scanned the full public MCP registry: <b>{registryIndex.servers_scanned.toLocaleString()}</b> servers,
+              and <b>{registryIndex.pct_advertise_high_risk}%</b> advertise a capability that can move money, destroy or
+              export data, deploy infrastructure, or change permissions. Almost none require a verifiable human
+              authorization before that action runs. <b>RR-1 is how a maintainer fixes that — and gets credit for it.</b>
+            </p>
+            <div style={{ display: 'flex', gap: 12, marginTop: 22, flexWrap: 'wrap' }}>
+              <a href="https://www.npmjs.com/package/@emilia-protocol/require-receipt" target="_blank" rel="noopener noreferrer" style={cta.primary}>Earn RR-1 in 10 minutes</a>
+              <Link href="/fire-drill/registry" style={cta.secondary}>The ecosystem index</Link>
+            </div>
+          </div>
+        </section>
+
+        {/* The badge is a credential, not a warning */}
+        <section style={{ ...styles.section, paddingTop: 0, paddingBottom: 18 }}>
+          <div style={styles.container}>
+            <div style={{
+              display: 'flex', gap: 24, alignItems: 'center', flexWrap: 'wrap',
+              border: `1px solid ${color.border}`, borderRadius: 12, padding: '22px 24px', background: '#0b0e14',
+            }}>
+              {/* eslint-disable-next-line @next/next/no-img-element -- static SVG badge, next/image is overkill */}
+              <img src="/badges/rr-1.svg" alt="Receipt Required: RR-1" width={178} height={20} />
+              <p style={{ ...styles.body, fontSize: 14, color: color.t2, margin: 0, flex: 1, minWidth: 280 }}>
+                {rr1.framing}
+              </p>
+            </div>
+            <p style={{ ...styles.body, fontSize: 13, color: color.t3, marginTop: 12 }}>
+              Earn it, then add the badge to your README:
+            </p>
+            <pre style={{
+              fontFamily: font.mono, fontSize: 12.5, color: color.t1, background: '#0b0e14',
+              border: `1px solid ${color.border}`, borderRadius: 8, padding: '12px 14px', overflowX: 'auto', marginTop: 6,
+            }}>{BADGE_MD}</pre>
+          </div>
+        </section>
+
+        {/* The four checks */}
+        <section style={styles.section}>
+          <div style={styles.container}>
+            <h2 style={{ ...styles.h2 }}>What RR-1 certifies</h2>
+            <p style={{ ...styles.body, maxWidth: 720, marginTop: 12 }}>
+              Four behaviors on your most dangerous action — re-proven on every push by{' '}
+              <code style={{ fontFamily: font.mono }}>receipt-required.test.js</code>:
+            </p>
+            <div style={{ marginTop: 14 }}>
+              {rr1.checks.map((c, i) => (
+                <div key={c.id} style={{ display: 'flex', gap: 14, alignItems: 'baseline', padding: '11px 0', borderTop: `1px solid ${color.border}` }}>
+                  <span style={{ fontFamily: font.mono, fontSize: 13, color: color.gold, minWidth: 22 }}>{i + 1}</span>
+                  <span style={{ ...styles.body, fontSize: 15, color: color.t1, fontWeight: 600, minWidth: 300 }}>{c.claim}</span>
+                  <span style={{ fontFamily: font.mono, fontSize: 12.5, color: color.t2 }}>{c.expect}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section style={{ ...styles.section, paddingTop: 0 }}>
+          <div style={styles.container}>
+            <p style={{ ...styles.body, fontSize: 13, color: color.t3, maxWidth: 720 }}>
+              RR-1 is a reference-implementation conformance level, <b>not</b> a vulnerability rating and <b>not</b> auth or
+              permissions. It is portable accountability evidence — proof a named human authorized an irreversible action —
+              a <i>necessary, not sufficient</i> condition: it does not prove the decision was wise or lawful. Built on the
+              offline verifier in <code style={{ fontFamily: font.mono }}>@emilia-protocol/require-receipt</code> (Apache-2.0);
+              spec: IETF <code style={{ fontFamily: font.mono }}>draft-schrock-ep-authorization-receipts</code>.
+            </p>
+          </div>
+        </section>
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/packages/fire-drill/reports.json
+++ b/packages/fire-drill/reports.json
@@ -1,0 +1,269 @@
+{
+  "@version": "EP-FIRE-DRILL-REPORT-v1",
+  "note": "Per-MCP Fire Drill reports for VERIFIED targets only — each cites a real dangerous handler read from the repo source (file + symbol + verbatim quote). This is a static reference-implementation assessment of a missing human-authorization receipt, NOT a vulnerability claim. Distinct from registry-index.json, which is registry-level (name/description) signal across the whole ecosystem.",
+  "rr1": {
+    "name": "RR-1",
+    "title": "Receipt Required, Level 1",
+    "checks": [
+      {
+        "id": "missing",
+        "claim": "Missing receipt is blocked",
+        "expect": "428 Receipt Required"
+      },
+      {
+        "id": "valid",
+        "claim": "Valid receipt runs the action exactly once",
+        "expect": "action runs, receipt consumed"
+      },
+      {
+        "id": "replay",
+        "claim": "Replayed receipt is refused",
+        "expect": "one-time consumption"
+      },
+      {
+        "id": "forged",
+        "claim": "Forged / rewritten receipt is refused",
+        "expect": "signature / action-binding fails"
+      }
+    ],
+    "framing": "RR-1 is a maintainer credential, not a warning. A server at RR-1 makes its most dangerous action safer than the ecosystem default — where 10% of registered MCP servers advertise a high-risk capability and almost none require a verifiable human authorization before it runs."
+  },
+  "after_patch_default": {
+    "missing": "blocked — 428 Receipt Required",
+    "valid": "runs exactly once, receipt consumed",
+    "replay": "refused — one-time consumption",
+    "forged": "refused — signature / action-binding fails"
+  },
+  "reports": [
+    {
+      "slug": "signaltech-bolthub-sdk",
+      "name": "ai.bolthub/registry (bolthub-sdk)",
+      "repo": "https://github.com/signaltech-org/bolthub-sdk",
+      "family": "money_movement",
+      "dangerous_tool": "executeToolCall (per-tool L402 auto-pay)",
+      "dangerous_summary": "every dynamically-registered marketplace tool can auto-pay a real Lightning (L402) invoice from the agent's wallet.",
+      "handler_file": "packages/mcp-bridge/src/tool-handler.ts",
+      "handler_symbol": "executeToolCall() → l402Client.request() → wallet.payInvoice()",
+      "handler_quote": "return await this.wallet.payInvoice(invoice);",
+      "currently": "runs unguarded — the only precondition on a real-sats payment is a numeric budgetSats cap. No named human authorizes the spend before it settles.",
+      "proposed_fix": "Wrap the per-tool handler at packages/mcp-bridge/src/server.ts:70 (`async (args) => executeToolCall(tool, args, l402Client)`) with @emilia-protocol/require-receipt, so a verifiable human-authorization receipt for the exact tool + amount is required before the L402 invoice is paid.",
+      "after_patch": {
+        "missing": "blocked — 428 Receipt Required",
+        "valid": "pays once, receipt consumed",
+        "replay": "refused — one-time consumption",
+        "forged": "refused — signature / action-binding fails"
+      },
+      "pr_url": null,
+      "status": "report_ready",
+      "maintainer_note": "Maintainer active (last push 2026-06-26); this report is intended to go live alongside a fix PR.",
+      "published": true
+    },
+    {
+      "slug": "scope-bid-scope-mcp",
+      "name": "bid.scope (scope-mcp)",
+      "repo": "https://github.com/scope-bid/scope-mcp",
+      "family": "webhook",
+      "dangerous_tool": "scope_dispatch_matter",
+      "dangerous_summary": "irreversibly dispatches a budgeted hiring / procurement matter to external vendors.",
+      "handler_file": "packages/mcp-core/src/tools.ts",
+      "handler_symbol": "scope_dispatch_matter handler (registerCoreTools)",
+      "handler_quote": "return api.post(\"/api/scopes\", { ... });",
+      "currently": "runs unguarded — the handler's only precondition is an `if (!api.hasAuth())` token check at tools.ts:141. No human signs off the external dispatch.",
+      "proposed_fix": "Insert a @emilia-protocol/require-receipt check immediately after the `if (!api.hasAuth())` guard (tools.ts:141), before the `api.post(\"/api/scopes\", ...)` dispatch, so a human authorization receipt for the exact matter is required first.",
+      "after_patch": {
+        "missing": "blocked — 428 Receipt Required",
+        "valid": "dispatches once, receipt consumed",
+        "replay": "refused — one-time consumption",
+        "forged": "refused — signature / action-binding fails"
+      },
+      "pr_url": null,
+      "status": "report_ready",
+      "maintainer_note": "Maintainer active (last push 2026-06-10); this report is intended to go live alongside a fix PR.",
+      "published": true
+    },
+    {
+      "slug": "cuongpo-coti-mcp",
+      "name": "coti-mcp",
+      "repo": "https://github.com/cuongpo/coti-mcp",
+      "family": "money_movement",
+      "dangerous_tool": "transfer_native",
+      "dangerous_summary": "sends native COTI on-chain from the server's wallet to an arbitrary recipient.",
+      "handler_file": "tools/native/transferNative.ts",
+      "handler_symbol": "performTransferNative(recipient_address, amount_wei, gas_limit?)",
+      "handler_quote": "const tx = await wallet.sendTransaction({ to: recipient_address, value: amount_wei, ...txOptions });",
+      "currently": "runs unguarded — the transfer_native tool (index.ts:281) calls performTransferNative with no human authorization in front of an irreversible on-chain transfer.",
+      "proposed_fix": "Wrap transferNativeHandler (registered at index.ts:281) with @emilia-protocol/require-receipt so a human authorization receipt for the exact recipient + amount is required before performTransferNative broadcasts.",
+      "after_patch": {
+        "missing": "blocked — 428 Receipt Required",
+        "valid": "transfers once, receipt consumed",
+        "replay": "refused — one-time consumption",
+        "forged": "refused — signature / action-binding fails"
+      },
+      "pr_url": null,
+      "status": "report_ready",
+      "maintainer_note": "Maintainer currently dormant (last push 2025-10). This report stands as ecosystem evidence; a fix PR is low-priority until the repo shows activity.",
+      "published": false
+    },
+    {
+      "slug": "bigvik193-reddit-ads-mcp",
+      "name": "reddit-ads-mcp",
+      "repo": "https://github.com/BigVik193/reddit-ads-mcp",
+      "family": "money_movement",
+      "dangerous_tool": "createCampaign",
+      "dangerous_summary": "commits live advertising spend by creating a campaign on Reddit's Ads API.",
+      "handler_file": "src/index.ts",
+      "handler_symbol": "createCampaign tool → RedditClient.createCampaign()",
+      "handler_quote": "const response = await this.adsAxiosInstance.post(`/ad_accounts/${adAccountId}/campaigns`, campaignData)",
+      "currently": "runs unguarded — createCampaign (registered at src/index.ts:1133) POSTs a spend-committing ad campaign with no human authorization.",
+      "proposed_fix": "Wrap the createCampaign tool handler (src/index.ts:1133) with @emilia-protocol/require-receipt so a human authorization receipt for the exact account + budget is required before the campaign is created.",
+      "after_patch": {
+        "missing": "blocked — 428 Receipt Required",
+        "valid": "creates once, receipt consumed",
+        "replay": "refused — one-time consumption",
+        "forged": "refused — signature / action-binding fails"
+      },
+      "pr_url": null,
+      "status": "report_ready",
+      "maintainer_note": "Maintainer currently dormant (last push 2025-09). This report stands as ecosystem evidence; a fix PR is low-priority until the repo shows activity.",
+      "published": false
+    },
+    {
+      "slug": "ctaylor86-mcp-video-download-server",
+      "name": "mcp-video-download-server",
+      "repo": "https://github.com/ctaylor86/mcp-video-download-server",
+      "family": "data_export",
+      "dangerous_tool": "download_video_to_cloud",
+      "dangerous_summary": "uploads a downloaded video to an external S3/R2 bucket and returns a public URL.",
+      "handler_file": "src/index.ts",
+      "handler_symbol": "registerTool(\"download_video_to_cloud\") → CloudStorageService.uploadFile (src/storage.ts)",
+      "handler_quote": "const publicUrl = await storage.uploadFile(result.filePath, `video_${Date.now()}_`);",
+      "currently": "runs unguarded — content is exported to an external cloud sink and made publicly reachable with no human authorization.",
+      "proposed_fix": "Wrap the download_video_to_cloud handler with @emilia-protocol/require-receipt so a human authorization receipt for the exact export is required before storage.uploadFile sends data to the external bucket.",
+      "after_patch": {
+        "missing": "blocked — 428 Receipt Required",
+        "valid": "exports once, receipt consumed",
+        "replay": "refused — one-time consumption",
+        "forged": "refused — signature / action-binding fails"
+      },
+      "pr_url": null,
+      "status": "report_ready",
+      "maintainer_note": "Maintainer currently dormant (last push 2025-09). This report stands as ecosystem evidence; a fix PR is low-priority until the repo shows activity.",
+      "published": false
+    },
+    {
+      "slug": "eveoy-eveoy-mcp",
+      "name": "eveoy-mcp",
+      "repo": "https://github.com/eveoy/eveoy-mcp",
+      "family": "money_movement",
+      "dangerous_tool": "start_checkout",
+      "dangerous_summary": "creates a Stripe checkout session and a Zoho CRM deal from an agent call.",
+      "handler_file": "src/mcp/tools/start-checkout.ts",
+      "handler_symbol": "registerStartCheckout",
+      "handler_quote": "data = await callEdge(/create-checkout-session, { ... });",
+      "currently": "runs unguarded — start_checkout calls the create-checkout-session edge function on both the JWT and agent paths with no human authorization.",
+      "proposed_fix": "Wrap the start_checkout handler body just before the callEdge(/create-checkout-session, ...) calls with @emilia-protocol/require-receipt, so a human authorization receipt for the exact checkout is required first.",
+      "after_patch": {
+        "missing": "blocked — 428 Receipt Required",
+        "valid": "checks out once, receipt consumed",
+        "replay": "refused — one-time consumption",
+        "forged": "refused — signature / action-binding fails"
+      },
+      "pr_url": null,
+      "status": "report_ready",
+      "maintainer_note": "Maintainer active (last push 2026-06-30); report intended to go live alongside a fix PR.",
+      "published": false
+    },
+    {
+      "slug": "bvcc-agent-mcp",
+      "name": "bvcc-agent-mcp",
+      "repo": "https://github.com/blockventurechaincapital-crypto/bvcc-agent-mcp",
+      "family": "money_movement",
+      "dangerous_tool": "sendNative / sendToken / swap (write capabilities)",
+      "dangerous_summary": "signs and broadcasts on-chain fund transfers and swaps across multiple chains from the agent wallet.",
+      "handler_file": "src/server.ts",
+      "handler_symbol": "capability dispatch closure (server.tool callback, ~line 141)",
+      "handler_quote": "const result = await cap.invoke(client, rest as never);",
+      "currently": "runs unguarded — write-kind capabilities broadcast irreversible on-chain transactions; the only switch is an all-or-nothing BVCC_MCP_READONLY flag, no per-action human authorization.",
+      "proposed_fix": "Gate the write branch in the dispatch closure (src/server.ts:141): when cap.kind===write, require a @emilia-protocol/require-receipt authorization receipt before cap.invoke — one chokepoint covering every fund-moving tool.",
+      "after_patch": {
+        "missing": "blocked — 428 Receipt Required",
+        "valid": "sends once, receipt consumed",
+        "replay": "refused — one-time consumption",
+        "forged": "refused — signature / action-binding fails"
+      },
+      "pr_url": null,
+      "status": "report_ready",
+      "maintainer_note": "Maintainer active (last push 2026-06-29). Handler bodies live in the external @bvcc/agent-sdk; the in-repo seam is the dispatch closure. Report intended to go live alongside a fix PR.",
+      "published": false
+    },
+    {
+      "slug": "rippermercs-tensorfeed",
+      "name": "tensorfeed",
+      "repo": "https://github.com/RipperMercs/tensorfeed",
+      "family": "webhook",
+      "dangerous_tool": "create_watch",
+      "dangerous_summary": "registers a premium webhook watch and spends a paid credit.",
+      "handler_file": "mcp-server/src/index.ts",
+      "handler_symbol": "registerTool(create_watch) handler (~line 1793)",
+      "handler_quote": "const data = await fetchJSON(/premium/watches, { method: POST, body, auth: true });",
+      "currently": "runs unguarded — create_watch registers a webhook callback and spends a credit with no human authorization over the callback_url + type.",
+      "proposed_fix": "Wrap the top of the create_watch async handler with @emilia-protocol/require-receipt so it refuses to register the webhook + spend the credit without a receipt covering type + callback_url.",
+      "after_patch": {
+        "missing": "blocked — 428 Receipt Required",
+        "valid": "registers once, receipt consumed",
+        "replay": "refused — one-time consumption",
+        "forged": "refused — signature / action-binding fails"
+      },
+      "pr_url": null,
+      "status": "report_ready",
+      "maintainer_note": "Maintainer active (last push 2026-06-29); report intended to go live alongside a fix PR.",
+      "published": false
+    },
+    {
+      "slug": "codeswhat-portkey-admin-mcp",
+      "name": "portkey-admin-mcp",
+      "repo": "https://github.com/CodesWhat/portkey-admin-mcp",
+      "family": "permission_change",
+      "dangerous_tool": "delete_user",
+      "dangerous_summary": "permanently deletes a user — revoking their API keys and ending sessions.",
+      "handler_file": "src/tools/users.tools.ts",
+      "handler_symbol": "delete_user handler (~line 321)",
+      "handler_quote": "await service.users.deleteUser(params.user_id);",
+      "currently": "runs unguarded — delete_user issues the permanent DELETE /admin/users/{id} unconditionally; the only protection is prose warnings (no confirmation/approval/receipt; dry_run exists only for prompt create/update).",
+      "proposed_fix": "Wrap the delete_user handler body at users.tools.ts:321 so a @emilia-protocol/require-receipt check runs before service.users.deleteUser() executes the permanent deletion.",
+      "after_patch": {
+        "missing": "blocked — 428 Receipt Required",
+        "valid": "deletes once, receipt consumed",
+        "replay": "refused — one-time consumption",
+        "forged": "refused — signature / action-binding fails"
+      },
+      "pr_url": null,
+      "status": "report_ready",
+      "maintainer_note": "Maintainer active (last push 2026-06-28); report intended to go live alongside a fix PR.",
+      "published": false
+    },
+    {
+      "slug": "mnemopay-sdk",
+      "name": "mnemopay-sdk",
+      "repo": "https://github.com/mnemopay/mnemopay-sdk",
+      "family": "money_movement",
+      "dangerous_tool": "payout_create",
+      "dangerous_summary": "initiates an outbound Paystack bank transfer to a recipient.",
+      "handler_file": "src/mcp/server.ts",
+      "handler_symbol": "executeTool case \"payout_create\"",
+      "handler_quote": "transfer = await rail.initiateTransfer(recipient.recipientCode, args.amount, args.reason, agent.agentId);",
+      "currently": "runs unguarded — payout_create fires the bank transfer immediately; the repo has a HITL approval queue but it is wired for charge/escrow, not for payout_create.",
+      "proposed_fix": "Gate the case \"payout_create\" block (or the dispatcher before executeTool) with @emilia-protocol/require-receipt so the outbound transfer requires a human authorization receipt before initiateTransfer fires.",
+      "after_patch": {
+        "missing": "blocked — 428 Receipt Required",
+        "valid": "pays out once, receipt consumed",
+        "replay": "refused — one-time consumption",
+        "forged": "refused — signature / action-binding fails"
+      },
+      "pr_url": null,
+      "status": "report_ready",
+      "maintainer_note": "Maintainer active (last push 2026-06-26). NOTE: competitor-adjacent (its own trust/identity/HITL framing) — held from outreach pending review.",
+      "published": false
+    }
+  ]
+}

--- a/public/badges/rr-1.svg
+++ b/public/badges/rr-1.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="178" height="20" role="img" aria-label="Receipt Required: RR-1">
+  <title>Receipt Required: RR-1 — dangerous actions require a verifiable human authorization receipt</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r"><rect width="178" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="119" height="20" fill="#3a3f4b"/>
+    <rect x="119" width="59" height="20" fill="#16a34a"/>
+    <rect width="178" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110" text-rendering="geometricPrecision">
+    <text x="605" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="1090">Receipt Required</text>
+    <text x="605" y="140" transform="scale(.1)" textLength="1090">Receipt Required</text>
+    <text x="1475" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="490">RR-1</text>
+    <text x="1475" y="140" transform="scale(.1)" textLength="490">RR-1</text>
+  </g>
+</svg>


### PR DESCRIPTION
Fire Drill → maintainer-activation engine. RR-1 program page (social proof + look-good badge), per-MCP report pages for 10 code-verified targets (real handler cited, before/after RR-1), self-hosted badge, reframed index. Only published reports render (2 live). Build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)