### PR TITLE
fix(ci): allowlist JWS conformance vectors in gitleaks (Secret Scanning green)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -27,6 +27,11 @@ title = "emilia-protocol gitleaks config"
     '''tests/.*\.test\.js$''',
     '''mcp-server/tests/.*\.test\.js$''',
     '''sdks/.*/tests?/.*''',
+    '''packages/.*\.test\.js$''',
+    # Conformance vectors are deterministic test signatures over a published
+    # test seed (e.g. compact JWS in jws.json structurally resemble JWTs).
+    # They contain no real key material — only reproducible test-key outputs.
+    '''conformance/vectors/.*''',
   ]
 
 # ── Custom rules ─────────────────────────────────────────────────


### PR DESCRIPTION
Secret Scanning failed because the jwt-token rule flagged conformance/vectors/jws.json — compact JWS test vectors structurally look like JWTs but are deterministic test-seed signatures, no real secrets. Adds path allowlists for conformance/vectors/* and packages/**.test.js. Verified locally: no leaks across full history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)