### PR TITLE
fix(fire-drill): registry 500 on Vercel (import corpus JSON, not fs.readFileSync)

### DIFF
--- a/packages/fire-drill/registry-corpus.js
+++ b/packages/fire-drill/registry-corpus.js
@@ -5,12 +5,14 @@
 // tool-level scan and NOT a vulnerability claim. Used to render honest,
 // repo-backlinked /fire-drill/registry/<slug> result pages.
 
-import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const here = path.dirname(fileURLToPath(import.meta.url));
-const data = JSON.parse(fs.readFileSync(path.join(here, 'registry-corpus.json'), 'utf8'));
+// Import the JSON directly — do NOT fs.readFileSync a computed path. On the
+// dynamic /fire-drill/registry route this module runs inside a Vercel
+// serverless function, and Next's file tracer won't bundle a runtime
+// readFileSync target → ENOENT 500 in prod (while working locally, where the
+// file is on disk). A static JSON import is inlined into every consumer's
+// bundle, so the data is always present at runtime — same mechanism as the
+// already-working reports.json / registry-index.json imports.
+import data from './registry-corpus.json';
 
 export const REGISTRY_CORPUS = data.servers || [];
 export const REGISTRY_CORPUS_META = {


### PR DESCRIPTION
/fire-drill/registry (dynamic route) 500'd on Vercel: registry-corpus.js read its JSON via runtime fs.readFileSync, which Next's tracer doesn't bundle into the serverless function (ENOENT). Worked locally + on static [slug] pages, masking it. Fix: static JSON import (inlined into the bundle). Verified 200 with full corpus locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)