### PR TITLE
fix(k6): louder hint when PERF_TEST_API_KEY is rejected (credential, not perf regression)

### DIFF
--- a/tests/k6/baseline.js
+++ b/tests/k6/baseline.js
@@ -177,8 +177,17 @@ export function setup() {
     { headers: HEADERS },
   );
   if (res.status !== 200) {
+    // A 401/403 here is almost always a credential problem, not a perf
+    // regression: the PERF_TEST_API_KEY was revoked/rotated (e.g. swept by a
+    // dormant-key cleanup). Say so loudly so the fix is obvious — re-provision
+    // the "k6 Perf Initiator" entity key and update the PERF_TEST_API_KEY secret.
+    const authHint = (res.status === 401 || res.status === 403)
+      ? ' — PERF_TEST_API_KEY was rejected (likely revoked/rotated). This is a credential '
+        + 'issue, NOT a perf regression: re-provision the "k6 Perf Initiator" entity key and '
+        + 'update the PERF_TEST_API_KEY GitHub secret.'
+      : '';
     throw new Error(
-      `[setup] Failed to fetch handshake-policies (HTTP ${res.status}): ${res.body}`,
+      `[setup] Failed to fetch handshake-policies (HTTP ${res.status}): ${res.body}${authHint}`,
     );
   }
   const body = JSON.parse(res.body);


### PR DESCRIPTION
k6 baseline setup() now special-cases 401/403 with a clear re-provision hint, so a revoked/rotated perf key reads as a credential issue rather than a perf regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)