### PR TITLE
fix(rr-kit): secure-by-default (fail closed without trusted keys; honest replay/manifest docs)

### DIFF
--- a/receipt-required-pr-kit/README.md
+++ b/receipt-required-pr-kit/README.md
@@ -11,7 +11,9 @@ replayed receipt  -> refused (one-time consumption)
 forged receipt    -> refused (signature / action-binding fails)
 ```
 
-That set of four is the **RR-1** conformance level. `receipt-required.test.js` re-proves it on every push.
+That set of four is the **RR-1** conformance level. `receipt-required.test.js` re-proves it on every push (including that the secure default below fails closed).
+
+> **Replay scope:** "one-time consumption" holds within the configured store. The **default store is process-local (in-memory)** — it does *not* survive a restart or span multiple instances. For durable / multi-instance replay protection, pass a durable `store` ({ has, add }) to the gate (Redis/DB).
 
 ## 10-minute adoption
 
@@ -19,7 +21,7 @@ That set of four is the **RR-1** conformance level. `receipt-required.test.js` r
 2. Copy `agent-actions.json` into your repo and point it at your dangerous tool (set `tool`, `action_type`).
 3. Route that tool through `dispatch()` in `example-dangerous-action.js` (or copy the ~15 lines of gate logic into your existing handler).
 4. `npm test` — confirms RR-1 (the four checks).
-5. Serve `agent-actions.json` at `/.well-known/agent-actions.json` so agents discover what to bring.
+5. Serve `agent-actions.json` at `/.well-known/agent-actions.json` so agents discover what to bring, then set `EMILIA_MANIFEST_URL` to that path. The 428 challenge only advertises a manifest URL once you've configured one — it won't point agents at a 404.
 
 ## Files
 
@@ -36,4 +38,12 @@ Not auth ("who are you"), not permissions ("are you allowed here"). It's **porta
 
 Fully offline — the real verifier from [`@emilia-protocol/require-receipt`](https://www.npmjs.com/package/@emilia-protocol/require-receipt) (Apache-2.0), no API key, no account, no EMILIA server trusted. Spec: IETF Internet-Drafts `draft-schrock-ep-authorization-receipts` + `draft-schrock-ep-enforcement-point` (individual I-Ds, not RFCs).
 
-> **Production:** the demo uses `allowInlineKey: true` so it runs with no setup. In production, pin `trustedKeys: [<issuer SPKI you trust>]` and drop `allowInlineKey` — otherwise a self-signed receipt would verify.
+## Secure by default
+
+This kit will **not** accept a self-signed (inline-key) receipt for a destructive action by default. Posture is set by env, read at call time:
+
+- **`EMILIA_TRUSTED_KEYS`** (comma-separated base64url SPKI) — the issuer key(s) you trust. Set this for production. Receipts not signed by a pinned key are refused.
+- **No trusted keys + no inline opt-in → fails closed.** The action is refused (`receipt_enforcement_misconfigured`); it never runs under an untrusted key. For a destructive operation, refusing is the safe outcome.
+- **`EMILIA_ALLOW_INLINE_KEY=1`** — accept inline (self-signed) receipt keys. **Non-production demos only** — never for a real destructive action.
+
+Production checklist: pin `EMILIA_TRUSTED_KEYS`; leave `EMILIA_ALLOW_INLINE_KEY` unset; configure a durable replay `store` if you run more than one instance; serve the manifest and set `EMILIA_MANIFEST_URL`.

--- a/receipt-required-pr-kit/example-dangerous-action.js
+++ b/receipt-required-pr-kit/example-dangerous-action.js
@@ -1,17 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Receipt Required, dropped in front of ONE dangerous action — built on the
-// canonical hardened gate from @emilia-protocol/require-receipt.
+// Receipt Required, in front of ONE dangerous action — built on the canonical
+// hardened gate from @emilia-protocol/require-receipt.
 //
 //   missing receipt   -> 428 Receipt Required (refused)
 //   valid receipt     -> the action runs (and the receipt is consumed)
-//   replayed receipt  -> refused (one-time consumption)
+//   replayed receipt  -> refused (one-time consumption; see store note below)
 //   forged receipt    -> refused (signature / action-binding fails)
 //
-// The gate (makeReceiptGate) encodes the easy-to-get-wrong parts in one reviewed
-// place: target binding (a receipt for one resource can't act on another),
-// consume-after-success (a failed action never burns a valid approval), and
-// sanitized {reason}-only rejections. Don't hand-roll these.
+// SECURE BY DEFAULT: a destructive action will NOT accept a self-signed
+// (inline-key) receipt. Pin the issuer key(s) you trust via EMILIA_TRUSTED_KEYS
+// (comma-separated base64url SPKI). With enforcement on and no trusted keys
+// configured, the gate FAILS CLOSED — the action is refused, never run under an
+// untrusted key. Set EMILIA_ALLOW_INLINE_KEY=1 to accept inline keys for
+// NON-PRODUCTION demos only.
 
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -24,7 +26,16 @@ import {
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const MANIFEST = JSON.parse(readFileSync(resolve(HERE, 'agent-actions.json'), 'utf8'));
-const MANIFEST_URL = MANIFEST.service?.manifest_url || '/.well-known/agent-actions.json';
+
+// Posture is read from the environment at call time, so deployment config — not
+// a hardcoded demo default — decides how receipts are trusted.
+const trustedKeys = () =>
+  (process.env.EMILIA_TRUSTED_KEYS || '').split(',').map((s) => s.trim()).filter(Boolean);
+const allowInlineKey = () => /^(1|true)$/i.test(process.env.EMILIA_ALLOW_INLINE_KEY || '');
+// Only advertise a manifest URL the host actually serves. Set EMILIA_MANIFEST_URL
+// once you serve agent-actions.json (e.g. at /.well-known/agent-actions.json);
+// otherwise the 428 challenge won't point at a URL that 404s.
+const manifestUrl = () => process.env.EMILIA_MANIFEST_URL || undefined;
 
 // The actual dangerous work. Replace the body with your real action; THROW on
 // failure so the gate leaves the approval retryable instead of burning it.
@@ -33,17 +44,21 @@ function performDangerousAction(name, args) {
 }
 
 // One gate per action type (each keeps its own one-time-consumption store).
+// NOTE: the default store is process-local (in-memory) — it does NOT survive a
+// restart and does NOT span multiple instances. For durable / multi-instance
+// one-time consumption, pass a durable `store` ({ has, add }) below (Redis/DB).
 const gates = new Map();
 function gateFor(req) {
   if (!gates.has(req.action_type)) {
+    const keys = trustedKeys();
     gates.set(req.action_type, makeReceiptGate({
       action: req.action_type,
-      // Demo: trust the receipt's inline key. PRODUCTION: pass
-      // `trustedKeys: [<issuer SPKI>]` and drop allowInlineKey.
-      allowInlineKey: true,
+      // Pinned issuer keys (secure) if configured; inline only in explicit demo
+      // mode. dispatch() fails closed before we get here if neither is set.
+      ...(keys.length ? { trustedKeys: keys } : { allowInlineKey: true }),
       maxAgeSec: req.max_age_sec,
       statusCode: RECEIPT_REQUIRED_STATUS,
-      manifestUrl: MANIFEST_URL,
+      ...(manifestUrl() ? { manifestUrl: manifestUrl() } : {}),
       assuranceClass: req.assurance_class,
       // store: <durable {has,add}> for restart/multi-instance one-time use.
     }));
@@ -60,9 +75,24 @@ export async function dispatch(name, args = {}, receipt = null) {
     return { status: 200, body: performDangerousAction(name, args) };
   }
 
-  // Bind the receipt to the SPECIFIC target (the dangerous tool's `table`), so a
-  // receipt approving "wipe customers" can't also wipe "orders". The gate runs
-  // the action and consumes the receipt only on success.
+  // FAIL CLOSED: enforcement is on but no issuer key is trusted. Refuse the
+  // destructive action rather than accept a self-signed receipt. Configure
+  // EMILIA_TRUSTED_KEYS (pinned issuer SPKI), or EMILIA_ALLOW_INLINE_KEY=1 for
+  // non-production demos only.
+  if (!trustedKeys().length && !allowInlineKey()) {
+    return {
+      status: 500,
+      body: {
+        rejected: { reason: 'receipt_enforcement_misconfigured' },
+        detail: 'Set EMILIA_TRUSTED_KEYS to the issuer key(s) you trust; '
+          + 'refusing to accept self-signed receipts for a destructive action.',
+      },
+    };
+  }
+
+  // Bind the receipt to the SPECIFIC target (e.g. the table), so a receipt
+  // approving "wipe customers" can't also wipe "orders". The gate runs the
+  // action and consumes the receipt only on success.
   const r = await gateFor(req).run(
     receipt,
     { target: args?.table },

--- a/receipt-required-pr-kit/package.json
+++ b/receipt-required-pr-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "receipt-required-pr-kit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "description": "Drop-in 'Receipt Required' rail for one dangerous action — missing -> 428, valid -> runs, replay -> refused, forged -> refused (RR-1).",
@@ -8,6 +8,6 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@emilia-protocol/require-receipt": "^0.4.0"
+    "@emilia-protocol/require-receipt": "^0.4.1"
   }
 }

--- a/receipt-required-pr-kit/receipt-required.test.js
+++ b/receipt-required-pr-kit/receipt-required.test.js
@@ -20,6 +20,13 @@ import { dispatch } from './example-dangerous-action.js';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const MANIFEST = JSON.parse(readFileSync(resolve(HERE, 'agent-actions.json'), 'utf8'));
 
+// These conformance checks are self-contained: each receipt is minted with a
+// fresh key, so we run the gate in explicit NON-PRODUCTION inline mode. In
+// production you pin EMILIA_TRUSTED_KEYS instead (see the fail-closed test below,
+// which proves the secure default refuses a destructive action with no trusted
+// key configured).
+process.env.EMILIA_ALLOW_INLINE_KEY = '1';
+
 // Byte-identical to @emilia-protocol/verify's EP-RECEIPT-v1 canonicalization.
 const canonicalize = (v) => (v === null || v === undefined ? JSON.stringify(v)
   : Array.isArray(v) ? `[${v.map(canonicalize).join(',')}]`
@@ -86,4 +93,24 @@ test('consume-after-success: a failed action leaves the receipt retryable', asyn
   const replay = await dispatch('delete_all_records', { table: 'inventory' }, receipt);
   assert.notEqual(replay.status, 200, 'consumed receipt should be refused on replay');
   assert.equal(replay.body.rejected.reason, 'replay_refused');
+});
+
+test('secure default: enforcement on with NO trusted key fails closed (does not run)', async () => {
+  // Simulate production posture: no inline opt-in, no pinned issuer keys.
+  const prevInline = process.env.EMILIA_ALLOW_INLINE_KEY;
+  const prevKeys = process.env.EMILIA_TRUSTED_KEYS;
+  delete process.env.EMILIA_ALLOW_INLINE_KEY;
+  delete process.env.EMILIA_TRUSTED_KEYS;
+  try {
+    // Even a well-formed receipt must NOT run the destructive action when no
+    // issuer key is trusted — accepting a self-signed receipt here would be the
+    // exact unsafe default we refuse to ship.
+    const res = await dispatch('delete_all_records', { table: 'customers' }, issueReceipt('db.records.delete_all:customers'));
+    assert.notEqual(res.status, 200, 'destructive action must not run without a trusted key');
+    assert.equal(res.body.rejected.reason, 'receipt_enforcement_misconfigured');
+    assert.notEqual(res.body.ran, true, 'the action must not have executed');
+  } finally {
+    if (prevInline === undefined) delete process.env.EMILIA_ALLOW_INLINE_KEY; else process.env.EMILIA_ALLOW_INLINE_KEY = prevInline;
+    if (prevKeys === undefined) delete process.env.EMILIA_TRUSTED_KEYS; else process.env.EMILIA_TRUSTED_KEYS = prevKeys;
+  }
 });


### PR DESCRIPTION
Acts on external review (portkey-admin-mcp#15). Three real defects fixed: (1) no more self-signed-by-default — pin EMILIA_TRUSTED_KEYS or fail closed; (2) honest replay-store docs (default is process-local); (3) manifest only advertised when served. Kit v1.1.0, conformance 4/4 incl. new fail-closed test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)