### PR TITLE
feat(fire-drill): ship fire-drill as an MCP server (@emilia-protocol/fire-drill-mcp)

### DIFF
--- a/packages/fire-drill-mcp/README.md
+++ b/packages/fire-drill-mcp/README.md
@@ -1,0 +1,49 @@
+# @emilia-protocol/fire-drill-mcp
+
+[![npm version](https://img.shields.io/npm/v/@emilia-protocol/fire-drill-mcp)](https://www.npmjs.com/package/@emilia-protocol/fire-drill-mcp)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![MCP](https://img.shields.io/badge/protocol-MCP-5a5aff)](https://modelcontextprotocol.io)
+
+**The Agent Action Firewall Test — as an MCP server.** A directory full of MCP servers, plus one whose job is to audit the others: point it at any MCP manifest, OpenAPI spec, or tool list and it tells you which dangerous actions an agent can take **without an accountable human receipt**.
+
+> If your agent can take an irreversible action without a receipt, you do not have control. You have hope.
+
+---
+
+## What it does
+
+`fire_drill_scan` flags every dangerous operation — money movement, data destruction, production deploy, permission change, bulk export, regulated override — that can run with no human in the loop, and returns an **Agent Action Firewall score (0–100)**, **EG-1 pass/fail**, the failing operations, and the fix.
+
+It's a **static** assessment of a documented tool surface — not a live deployment scan and not a vulnerability report. The scoring logic is the exact same zero-dependency engine behind `npx @emilia-protocol/fire-drill` and the web tool at [emiliaprotocol.ai/fire-drill](https://www.emiliaprotocol.ai/fire-drill).
+
+## Tools
+
+| Tool | What it returns |
+|---|---|
+| `fire_drill_scan` | Score one target (`target` object, or `target_json` string): an MCP manifest, OpenAPI spec, or `{ tools: [...] }`. Auto-detects the shape. |
+| `fire_drill_leaderboard` | The **Agent Action Safety Index** — a representative corpus of MCP servers pre-scored, worst first. |
+
+## Install
+
+```jsonc
+// claude_desktop_config.json / any MCP client
+{
+  "mcpServers": {
+    "fire-drill": {
+      "command": "npx",
+      "args": ["-y", "@emilia-protocol/fire-drill-mcp"]
+    }
+  }
+}
+```
+
+Then ask your agent: *"Run fire_drill_scan on this MCP manifest"* and paste a server's `tools` list — or *"Show me the agent action safety leaderboard."*
+
+## The fix
+
+A failing score means an agent can act irreversibly with nobody accountable. Close it with [**EMILIA Gate**](https://www.emiliaprotocol.ai/gate) — deny-by-default enforcement that runs an action only with a valid, in-scope, non-replayed authorization receipt (proof a named human approved that exact action) — then earn **EG-1**.
+
+- Protocol & receipts: [emiliaprotocol.ai](https://www.emiliaprotocol.ai) · IETF I-D `draft-schrock-ep-authorization-receipts`
+- The guard server: [`@emilia-protocol/mcp-server`](https://www.npmjs.com/package/@emilia-protocol/mcp-server)
+
+Apache-2.0.

--- a/packages/fire-drill-mcp/index.js
+++ b/packages/fire-drill-mcp/index.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+/**
+ * @emilia-protocol/fire-drill-mcp
+ * @license Apache-2.0
+ *
+ * The Agent Action Firewall Test, exposed over MCP.
+ *
+ * A directory of MCP servers, plus one server whose job is to audit the others:
+ * given any MCP manifest, OpenAPI spec, or tool list, it reports which dangerous
+ * actions an agent can take WITHOUT an accountable human receipt.
+ *
+ * Pure wrapper — all scoring logic lives in @emilia-protocol/fire-drill (zero-dep,
+ * the same source of truth as `npx @emilia-protocol/fire-drill` and the web /fire-drill).
+ *
+ * Tools:
+ *   fire_drill_scan        — score a target (manifest / OpenAPI / tool list)
+ *   fire_drill_leaderboard — the Agent Action Safety Index (pre-scanned corpus, worst first)
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+
+import { scan, FIRE_DRILL_VERSION, TAGLINE } from '@emilia-protocol/fire-drill';
+import { REPRESENTATIVE_CORPUS } from '@emilia-protocol/fire-drill/corpus.js';
+
+const TOOLS = [
+  {
+    name: 'fire_drill_scan',
+    description:
+      'Run the Agent Action Firewall Test on an MCP server manifest, an OpenAPI spec, or a tool list. ' +
+      'Flags every dangerous operation (money movement, data destruction, production deploy, permission ' +
+      'change, bulk export, regulated override) that can run WITHOUT an accountable human receipt. Returns ' +
+      'an Agent Action Firewall score (0–100), EG-1 pass/fail, the failing operations, and the fix. Static ' +
+      'assessment of the documented tool surface — not a live deployment scan and not a vulnerability report.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        target: {
+          type: 'object',
+          description:
+            'The thing to scan, as a JSON object: an MCP manifest ({ tools: [...] }), an OpenAPI spec, ' +
+            'or a bare tool array wrapped as { tools: [...] }. The scanner auto-detects the shape.',
+        },
+        target_json: {
+          type: 'string',
+          description: 'Alternative to `target`: the same payload as a JSON string. Used if `target` is omitted.',
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'fire_drill_leaderboard',
+    description:
+      'The Agent Action Safety Index: a representative corpus of MCP servers pre-scored by the Agent Action ' +
+      'Firewall Test, worst first (most ungated dangerous actions at the top). Use to show how a given server ' +
+      'compares, or to find which popular servers let agents act without a receipt.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+];
+
+function ok(obj) {
+  return { content: [{ type: 'text', text: JSON.stringify(obj, null, 2) }] };
+}
+function fail(message) {
+  return { content: [{ type: 'text', text: JSON.stringify({ error: message }, null, 2) }], isError: true };
+}
+
+const server = new Server(
+  { name: 'emilia-fire-drill', version: '0.1.0' },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args = {} } = request.params;
+
+  if (name === 'fire_drill_scan') {
+    let input = args.target;
+    if (input === undefined && typeof args.target_json === 'string') {
+      try {
+        input = JSON.parse(args.target_json);
+      } catch {
+        return fail('target_json must be valid JSON (an MCP manifest, OpenAPI spec, or { tools: [...] }).');
+      }
+    }
+    if (input === undefined || input === null || typeof input !== 'object') {
+      return fail('Provide `target` (a JSON object) or `target_json` (a JSON string) to scan.');
+    }
+    try {
+      const report = scan(input);
+      return ok({ fire_drill_version: FIRE_DRILL_VERSION, tagline: TAGLINE, report });
+    } catch (e) {
+      return fail(`Scan failed: ${e?.message || e}`);
+    }
+  }
+
+  if (name === 'fire_drill_leaderboard') {
+    const scanned = REPRESENTATIVE_CORPUS.map((c) => {
+      const report = scan(c.manifest);
+      return {
+        name: c.name,
+        slug: c.slug,
+        repo: c.repo,
+        score: report.score,
+        eg1: report.eg1,
+        dangerous: report.summary?.dangerous ?? 0,
+        ungated: report.summary?.ungated ?? 0,
+      };
+    }).sort((a, b) => a.score - b.score);
+    return ok({ fire_drill_version: FIRE_DRILL_VERSION, index: 'Agent Action Safety Index', servers: scanned });
+  }
+
+  return fail(`Unknown tool: ${name}`);
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/fire-drill-mcp/package.json
+++ b/packages/fire-drill-mcp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@emilia-protocol/fire-drill-mcp",
+  "version": "0.1.0",
+  "description": "The Agent Action Firewall Test, as an MCP server. Point your agent at any MCP manifest, OpenAPI spec, or tool list and fire_drill_scan flags every dangerous action — money movement, data destruction, production deploy, permission change, bulk export, regulated override — that can run without an accountable human receipt. Returns an Agent Action Firewall score, the failing operations, the fix, and EG-1 pass/fail. A server that audits the other servers. Static, zero-infrastructure, fails legibly.",
+  "type": "module",
+  "license": "Apache-2.0",
+  "bin": {
+    "emilia-fire-drill-mcp": "./index.js"
+  },
+  "main": "./index.js",
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "scripts": {
+    "start": "node index.js"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "agent-security",
+    "ai-safety",
+    "ai-agents",
+    "audit",
+    "authorization",
+    "security-scanner"
+  ],
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@emilia-protocol/fire-drill": "^0.4.0"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/emiliaprotocol/emilia-protocol.git",
+    "directory": "packages/fire-drill-mcp"
+  },
+  "homepage": "https://www.emiliaprotocol.ai/fire-drill",
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
A server that audits the other servers — `fire_drill_scan` + `fire_drill_leaderboard` over MCP, wrapping the existing zero-dep fire-drill engine. Verified end-to-end over stdio. README carries the Glama install-config block. This is the legitimate second Glama listing (the guard server is the first); publishing to npm is the outward step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)