### PR TITLE
docs(scitt): cite RFC 9943 (SCITT architecture published 2026-06-30)

### DIFF
--- a/app/standards/page.js
+++ b/app/standards/page.js
@@ -38,7 +38,7 @@ const PILLARS = [
   {
     role: 'ACCOUNTABILITY RAIL',
     status: 'standardizing now',
-    title: 'SCITT — draft-ietf-scitt-architecture',
+    title: 'SCITT — RFC 9943 + SCRAPI',
     body:
       'A SCITT "Receipt" is a transparency / INCLUSION proof: it proves a statement was logged in an append-only ledger. ' +
       'SCITT is deliberately AGNOSTIC about who authorized anything — that delegated-away question is exactly EMILIA’s payload. ' +

--- a/docs/EP-RECEIPT-SCITT-PROFILE.md
+++ b/docs/EP-RECEIPT-SCITT-PROFILE.md
@@ -2,7 +2,7 @@
 # EP-RECEIPT-SCITT-PROFILE-v1 — an EMILIA authorization receipt as a SCITT Signed Statement
 
 **Status:** working profile for SCITT WG engagement. Maps the EMILIA authorization receipt onto
-`draft-ietf-scitt-architecture` + `draft-ietf-scitt-scrapi`. Not yet posted to a list.
+**RFC 9943** (the SCITT architecture, published 2026-06-30) + `draft-ietf-scitt-scrapi`. Shared with the SCITT WG list 2026-06-30.
 
 ## What this profile does (and does not) claim
 
@@ -87,9 +87,10 @@ those terms — not as "decay physics."
 
 - **EMILIA** — `draft-schrock-ep-authorization-receipts` (individual I-D, Apache-2.0). Reference
   verifiers JS/Python/Go; JWS profile shipped (`EP-RECEIPT-JWS-PROFILE-v1`).
-- **SCITT** — `draft-ietf-scitt-architecture` + `draft-ietf-scitt-scrapi` + COSE Receipts
-  (`draft-ietf-cose-merkle-tree-proofs`): active WG drafts (Microsoft Signing Transparency is GA, so
-  the substrate is real). **Not** an endorsement by the SCITT WG; this is a complement profile.
+- **SCITT** — architecture now **RFC 9943** (published 2026-06-30) + `draft-ietf-scitt-scrapi` + COSE
+  Receipts (`draft-ietf-cose-merkle-tree-proofs`): SCRAPI and COSE-Merkle remain active WG drafts
+  (Microsoft Signing Transparency is GA, so the substrate is real). **Not** an endorsement by the
+  SCITT WG; this is a complement profile.
 - **COSE / Ed25519** — RFC 9052 / RFC 9053 / RFC 8032 (published).
 
 Runnable examples (zero-dependency, signature-correct) are in `examples/scitt/`.

--- a/docs/strategy/IETF-LANDSCAPE.md
+++ b/docs/strategy/IETF-LANDSCAPE.md
@@ -27,7 +27,7 @@ platform trustworthy / which workload is this."* EMILIA answers the **orthogonal
 question: *"did a NAMED HUMAN authorize THIS exact irreversible action."* Same
 evidence bundle, different trust root.
 
-### 3. ACCOUNTABILITY RAIL (standardizing now) — SCITT, draft-ietf-scitt-architecture
+### 3. ACCOUNTABILITY RAIL (architecture now RFC 9943) — SCITT
 A SCITT **"Receipt"** is a transparency / **inclusion** proof: it proves a statement
 was logged in an append-only ledger. SCITT is deliberately **agnostic about who
 authorized anything** — that delegated-away question is exactly EMILIA's payload. So

--- a/docs/strategy/RATS-SCITT-MAPPING.md
+++ b/docs/strategy/RATS-SCITT-MAPPING.md
@@ -32,7 +32,7 @@ The COSA / `@emilia-protocol/attest` machine-attestation loop maps cleanly onto 
 
 **"Decay" → freshness, in standard terms.** Replay/staleness control is *freshness*, not physics: RATS freshness (nonce / epoch) for the attestation, plus EMILIA's validity window + observed-evidence freshness for the authorization. Don't ship the word "decay" to the list.
 
-## B. Packing Slip / Bill of Lading / lineage as SCITT Signed Statements (draft-ietf-scitt-architecture)
+## B. Packing Slip / Bill of Lading / lineage as SCITT Signed Statements (RFC 9943)
 
 | SCITT term | EMILIA / COSA component |
 |---|---|
@@ -55,7 +55,7 @@ EMILIA's canonical base is RFC 8785 (JCS). For interop it serializes as **JWS (R
 ## Status (cite accurately)
 
 - **RATS architecture — RFC 9334** (Informational, published). **EAT — RFC 9711** (Proposed Standard, published).
-- **SCITT — `draft-ietf-scitt-architecture` + `draft-ietf-scitt-scrapi` + COSE Receipts (`draft-ietf-cose-merkle-tree-proofs`)** — active WG drafts, not yet RFCs. Real deployment exists (Microsoft Signing Transparency is GA), so the substrate is not theoretical.
+- **SCITT — RFC 9943 (architecture, published 2026-06-30) + `draft-ietf-scitt-scrapi` + COSE Receipts (`draft-ietf-cose-merkle-tree-proofs`)** — the architecture is now a published RFC; SCRAPI and COSE-Merkle remain active WG drafts. Real deployment exists (Microsoft Signing Transparency is GA), so the substrate is not theoretical.
 - **EMILIA — `draft-schrock-ep-authorization-receipts`** — individual Internet-Draft, Apache-2.0. *Not* an IETF standard and *not* endorsed by the RATS or SCITT WGs. These are complement relationships, not adoption claims.
 
 ## Why this dodges the three objections that stalled monolithic proposals


### PR DESCRIPTION
SCITT architecture became RFC 9943 today. Updates the living WG-facing docs (profile shared on-list, mapping, /standards, landscape) to cite it; SCRAPI + COSE-Merkle stay drafts. Posted I-D artifacts untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)