### PR TITLE
feat(examples): Receipt Required for Eve — accountable execution for Vercel Eve tools

### DIFF
--- a/examples/eve-receipt-required/README.md
+++ b/examples/eve-receipt-required/README.md
@@ -1,0 +1,103 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Receipt Required for Eve
+
+**Add accountable authorization to any [Vercel Eve](https://vercel.com/eve) tool in 10 minutes.**
+
+> Vercel Eve makes agent tools easy to build. Arcade makes tool auth easier.
+> **EMILIA makes dangerous tool execution accountable: no receipt, no mutation; if it runs, the proof travels.**
+
+Eve is filesystem-first — a tool is a file in `agent/tools/`. That makes the integration point
+obvious: wrap the *irreversible* tools so they can't mutate without a verifiable **EMILIA
+authorization receipt** — cryptographic proof that a named human approved *this exact action*,
+checkable offline, forever. It's the missing row in the stack: tokens/auth say *who's calling*;
+EMILIA says *who authorized this specific action* — and leaves portable evidence.
+
+This kit is a complete, runnable Eve agent with two gated tools.
+
+```
+agent/
+  agent.ts                 # defineAgent (model)
+  instructions.md          # "no receipt, no mutation"
+  tools/
+    release_funds.ts       # IRREVERSIBLE money movement — gated
+    delete_repo.ts         # IRREVERSIBLE deletion — gated
+  skills/
+    receipt-required.md    # how the agent obtains + attaches a receipt
+lib/
+  emilia-gate.mjs          # the zero-dependency gate (Node crypto only)
+  guards.mjs               # one gate per dangerous action
+demo.mjs                   # prove the loop locally, no Eve runtime needed
+```
+
+## See it work (zero deps, ~5 seconds)
+
+```bash
+node demo.mjs
+```
+```
+1. no receipt          -> BLOCKED (428) — funds NOT moved
+2. human signs         -> RAN ONCE — released $5000 to acct-9931
+3. replay same receipt -> BLOCKED (replay_refused)
+4. receipt for another acct -> BLOCKED (action_mismatch)
+PASS — no receipt, no mutation; if it runs, the proof travels.
+```
+
+## Add it to your own Eve tool in 10 minutes
+
+1. **Drop in the gate (zero dependency — nothing added to your `package.json`):**
+   ```bash
+   mkdir -p lib && curl -o lib/emilia-gate.mjs \
+     https://raw.githubusercontent.com/emiliaprotocol/emilia-protocol/main/packages/require-receipt/dist/emilia-gate.mjs
+   ```
+2. **Declare a gate for the dangerous action** (`lib/guards.mjs`):
+   ```js
+   import { makeReceiptGate } from './emilia-gate.mjs';
+   export const releaseFundsGate = makeReceiptGate({
+     action: 'funds.release',
+     trustedKeys: (process.env.EMILIA_TRUSTED_KEYS || '').split(',').filter(Boolean),
+   });
+   ```
+3. **Wrap the tool's `execute`** (`agent/tools/release_funds.ts`):
+   ```ts
+   import { defineTool } from 'eve/tools';
+   import { z } from 'zod';
+   import { releaseFundsGate } from '../../lib/guards.mjs';
+
+   export default defineTool({
+     description: 'Release funds. IRREVERSIBLE. Requires an EMILIA receipt bound to funds.release:<destination>.',
+     inputSchema: z.object({
+       amount: z.number().positive(),
+       destination: z.string(),
+       emilia_receipt: z.any().optional(),
+     }),
+     async execute({ amount, destination, emilia_receipt }) {
+       const r = await releaseFundsGate.run(emilia_receipt, { target: destination }, async () => {
+         return doTheTransfer(amount, destination); // your real mutation
+       });
+       return r.ok ? { ok: true, ...r.result } : { ok: false, receipt_required: true, challenge: r.body };
+     },
+   });
+   ```
+4. **Add the skill** so the agent knows the loop: copy `agent/skills/receipt-required.md`. Now when a
+   tool returns `receipt_required`, the agent gets a human to authorize the exact action and retries
+   with the receipt.
+
+That's it. The mutation runs only on a valid, action-bound, non-replayed receipt — verified offline.
+
+## Production notes (the two things to get right)
+
+- **Set `EMILIA_TRUSTED_KEYS`** (issuer SPKI, comma-separated). Without it the kit falls back to
+  `allowInlineKey` so the demo runs — but an inline key proves integrity, not *who* authorized. Never
+  ship that for real money.
+- **Use a durable consumed-store** for one-time consumption across Eve's durable restarts / multiple
+  instances: `makeReceiptGate({ ..., store: { has: (id) => kv.has(id), add: (id) => kv.add(id) } })`.
+  The default is in-memory (process-local).
+
+## How it fits the rest of the stack
+
+- **Model / auth:** AI Gateway + Vercel Connect / Arcade handle model access and delegated tokens.
+- **Execution accountability:** EMILIA — the receipt, verified before the mutation.
+- **Transparency:** an EMILIA receipt can also ride as a [SCITT](https://www.rfc-editor.org/rfc/rfc9943)
+  Signed Statement, so the log records *who authorized*, not just *what happened*.
+
+Docs: https://www.emiliaprotocol.ai/gate · Spec: `draft-schrock-ep-authorization-receipts` (IETF) · Apache-2.0

--- a/examples/eve-receipt-required/agent/agent.ts
+++ b/examples/eve-receipt-required/agent/agent.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+import { defineAgent } from 'eve';
+
+// A minimal Eve agent that exposes two irreversible tools (release_funds,
+// delete_repo), both gated by EMILIA Receipt-Required. Model resolves through
+// Vercel AI Gateway; swap for any gateway model string.
+export default defineAgent({
+  model: 'openai/gpt-5.4-mini',
+});

--- a/examples/eve-receipt-required/agent/instructions.md
+++ b/examples/eve-receipt-required/agent/instructions.md
@@ -1,0 +1,11 @@
+You are a backend operations agent. You can move money (`release_funds`) and delete
+repositories (`delete_repo`).
+
+These actions are **irreversible and accountable**. They require an EMILIA authorization
+receipt — proof that a named human approved the exact action. Never try to work around a
+`receipt_required` response. When a tool returns `receipt_required: true`, load the
+**receipt-required** skill and follow it: get a human to authorize the exact action, then
+retry the tool with the `emilia_receipt`.
+
+If you cannot obtain a receipt, do not perform the action. Report clearly that the action is
+pending human authorization. The rule is absolute: **no receipt, no mutation.**

--- a/examples/eve-receipt-required/agent/skills/receipt-required.md
+++ b/examples/eve-receipt-required/agent/skills/receipt-required.md
@@ -1,0 +1,46 @@
+---
+name: receipt-required
+description: How to authorize an irreversible tool (release_funds, delete_repo) when it returns a Receipt-Required challenge. Load this whenever a tool responds with receipt_required: true.
+---
+
+# Receipt Required — obtaining and attaching an EMILIA authorization receipt
+
+Some tools in this agent are **irreversible** (they move money or destroy data). They refuse to run
+unless the call carries a valid **EMILIA authorization receipt** — cryptographic proof that a named
+human approved *this exact action*. This is not authentication and not permissions; it is portable,
+offline-verifiable evidence of *who authorized what*.
+
+## When to use this skill
+
+Use it the moment an irreversible tool returns:
+
+```json
+{ "ok": false, "receipt_required": true, "status": 428, "challenge": { ... } }
+```
+
+Do **not** retry the tool with the same arguments and no receipt — it will refuse again. The action
+did not happen; nothing was mutated.
+
+## The loop
+
+1. **Read the challenge.** `challenge.required.action` is the exact action the receipt must authorize
+   (e.g. `funds.release:acct-9931` or `repo.delete:acme/payments`). The receipt must be bound to that
+   exact target — a receipt for one destination cannot authorize another.
+2. **Get a human to approve.** Ask the operator to authorize the exact action via your EMILIA issuer
+   (the Gate endpoint, the `emilia-gate` CLI, or the device-signoff flow). A named human signs the
+   exact `{ action, target, amount/details }` on their own device. You never mint the receipt
+   yourself.
+3. **Retry with the receipt.** Call the tool again with the same arguments **plus** `emilia_receipt`
+   set to the returned `EP-RECEIPT-v1` object. The tool verifies it offline and, if valid and
+   bound to this exact action, performs the mutation **once**.
+
+## Rules
+
+- **One receipt, one action.** A receipt is consumed on success; replaying it is refused. If you need
+  to run the action again, obtain a new receipt.
+- **Never fabricate or reuse.** Do not edit a receipt's fields, copy one from another action, or
+  invent a key. Tampered or mismatched receipts are rejected by construction.
+- **A transient failure does not burn the approval.** If the mutation itself errors, the receipt is
+  released and can be retried; you do not need a new one.
+
+The invariant: **no receipt, no mutation; if it runs, the proof travels.**

--- a/examples/eve-receipt-required/agent/tools/delete_repo.ts
+++ b/examples/eve-receipt-required/agent/tools/delete_repo.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Eve tool: delete_repo — IRREVERSIBLE data destruction, gated by EMILIA.
+// Same pattern as release_funds: no receipt bound to repo.delete:<owner/name>,
+// no deletion. A receipt for repo A cannot delete repo B (target binding).
+
+import { defineTool } from 'eve/tools';
+import { z } from 'zod';
+import { deleteRepoGate } from '../../lib/guards.mjs';
+
+export default defineTool({
+  description:
+    'Permanently delete a repository. IRREVERSIBLE. Requires an EMILIA authorization receipt bound to ' +
+    'repo.delete:<owner/name>. Omit emilia_receipt to receive a Receipt-Required challenge, then use the ' +
+    'receipt-required skill to obtain one and retry.',
+  inputSchema: z.object({
+    owner: z.string().min(1),
+    name: z.string().min(1),
+    emilia_receipt: z.any().optional().describe('EP-RECEIPT-v1 authorizing repo.delete:<owner/name>.'),
+  }),
+  async execute({ owner, name, emilia_receipt }) {
+    const target = `${owner}/${name}`;
+    const result = await deleteRepoGate.run(emilia_receipt, { target }, async () => {
+      // ── your real, irreversible deletion goes here (e.g. GitHub repos.delete).
+      return { deleted: true, repo: target };
+    });
+
+    if (!result.ok) {
+      return { ok: false, receipt_required: true, status: result.status, challenge: result.body };
+    }
+    return { ok: true, ...result.result, receipt: result.receiptId };
+  },
+});

--- a/examples/eve-receipt-required/agent/tools/release_funds.ts
+++ b/examples/eve-receipt-required/agent/tools/release_funds.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Eve tool: release_funds — IRREVERSIBLE money movement, gated by EMILIA.
+// The filename is the tool name the model sees.
+//
+// Pattern: the tool refuses to mutate unless it receives a valid EMILIA
+// authorization receipt bound to funds.release:<destination>. No receipt → it
+// returns a Receipt-Required challenge telling the agent exactly what to bring
+// (the receipt-required skill explains how to obtain one and retry).
+
+import { defineTool } from 'eve/tools';
+import { z } from 'zod';
+import { releaseFundsGate } from '../../lib/guards.mjs';
+
+export default defineTool({
+  description:
+    'Release funds to a destination account. IRREVERSIBLE. Requires an EMILIA authorization receipt ' +
+    'bound to funds.release:<destination> — a named human must have approved this exact transfer. ' +
+    'If you do not have one, call this tool without emilia_receipt to get a Receipt-Required challenge, ' +
+    'then follow the receipt-required skill to obtain one and retry.',
+  inputSchema: z.object({
+    amount: z.number().positive(),
+    currency: z.string().min(1),
+    destination: z.string().min(1).describe('destination account id / IBAN'),
+    emilia_receipt: z
+      .any()
+      .optional()
+      .describe('EP-RECEIPT-v1 authorizing funds.release:<destination>. Omit to receive the challenge.'),
+  }),
+  async execute({ amount, currency, destination, emilia_receipt }) {
+    const result = await releaseFundsGate.run(
+      emilia_receipt,
+      { target: destination },
+      async () => {
+        // ── your real, irreversible mutation goes here (e.g. bank/PSP transfer).
+        // It runs only after the receipt verifies; the receipt is consumed on
+        // success (one-time) and released on failure (a transient error never
+        // burns a valid approval).
+        return { released: true, amount, currency, destination };
+      },
+    );
+
+    if (!result.ok) {
+      // Receipt missing/invalid/replayed → do NOT mutate. Hand the model a
+      // machine-readable challenge (HTTP 428-shaped) describing what to bring.
+      return { ok: false, receipt_required: true, status: result.status, challenge: result.body };
+    }
+    return { ok: true, ...result.result, receipt: result.receiptId };
+  },
+});

--- a/examples/eve-receipt-required/demo.mjs
+++ b/examples/eve-receipt-required/demo.mjs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Local proof of the Receipt-Required loop for the Eve `release_funds` tool —
+// no Eve runtime or network needed. Runs the SAME gate the tool uses
+// (lib/guards.mjs), so this is a faithful demo of the deployed behavior:
+//
+//   1. no receipt        -> BLOCKED (428 challenge, funds not moved)
+//   2. human signs        -> RUNS ONCE (funds released, receipt consumed)
+//   3. replay same receipt -> BLOCKED (one-time consumption)
+//   4. receipt for another account -> BLOCKED (target binding)
+//
+//   run:  node demo.mjs
+
+import crypto from 'node:crypto';
+import { releaseFundsGate, demoMode } from './lib/guards.mjs';
+
+// Canonical JSON — must match the verifier in lib/emilia-gate.mjs.
+const canon = (v) => (v === null || v === undefined ? JSON.stringify(v)
+  : Array.isArray(v) ? `[${v.map(canon).join(',')}]`
+    : typeof v === 'object' ? `{${Object.keys(v).sort().map((k) => JSON.stringify(k) + ':' + canon(v[k])).join(',')}}`
+      : JSON.stringify(v));
+
+// Stand-in for a real human device-signoff: mint an EP-RECEIPT-v1 bound to an
+// exact action. In production a named human signs this on their own device via
+// your EMILIA issuer; the agent never mints its own.
+function humanApproves(actionType) {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+  const pub = publicKey.export({ type: 'spki', format: 'der' }).toString('base64url');
+  const payload = {
+    receipt_id: 'rcpt_' + crypto.randomBytes(6).toString('hex'),
+    subject: 'agent:ops-bot',
+    created_at: new Date().toISOString(),
+    claim: { action_type: actionType, outcome: 'allow_with_signoff', approver: 'cfo@yourco.example' },
+  };
+  const value = crypto.sign(null, Buffer.from(canon(payload), 'utf8'), privateKey).toString('base64url');
+  return { '@version': 'EP-RECEIPT-v1', payload, signature: { algorithm: 'Ed25519', value }, public_key: pub };
+}
+
+const DEST = 'acct-9931';
+const bound = releaseFundsGate.boundActionFor(DEST); // funds.release:acct-9931
+const doRelease = async () => ({ released: true, amount: 5000, currency: 'USD', destination: DEST });
+
+console.log(`EMILIA × Eve — release_funds demo${demoMode ? ' (demo mode: inline key; set EMILIA_TRUSTED_KEYS in prod)' : ''}`);
+console.log(`action bound to: ${bound}\n`);
+
+const r1 = await releaseFundsGate.run(undefined, { target: DEST }, doRelease);
+console.log(`1. no receipt          -> ${r1.ok ? 'RAN (BUG!)' : `BLOCKED (${r1.status}) — funds NOT moved`}`);
+
+const receipt = humanApproves(bound);
+const r2 = await releaseFundsGate.run(receipt, { target: DEST }, doRelease);
+console.log(`2. human signs         -> ${r2.ok ? `RAN ONCE — released $${r2.result.amount} to ${DEST}` : `BLOCKED (${r2.body?.rejected?.reason})`}`);
+
+const r3 = await releaseFundsGate.run(receipt, { target: DEST }, doRelease);
+console.log(`3. replay same receipt -> ${r3.ok ? 'RAN (BUG!)' : `BLOCKED (${r3.body.rejected.reason})`}`);
+
+const wrong = humanApproves(releaseFundsGate.boundActionFor('attacker-acct'));
+const r4 = await releaseFundsGate.run(wrong, { target: DEST }, doRelease);
+console.log(`4. receipt for another acct -> ${r4.ok ? 'RAN (BUG!)' : `BLOCKED (${r4.body.rejected.reason})`}`);
+
+const pass = !r1.ok && r2.ok && !r3.ok && !r4.ok;
+console.log(`\n${pass ? 'PASS' : 'FAIL'} — no receipt, no mutation; if it runs, the proof travels.`);
+process.exit(pass ? 0 : 1);

--- a/examples/eve-receipt-required/lib/emilia-gate.mjs
+++ b/examples/eve-receipt-required/lib/emilia-gate.mjs
@@ -1,0 +1,523 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// emilia-gate.mjs — the EMILIA Receipt-Required gate, as a single drop-in file.
+//
+//   • Zero dependencies (Node built-in crypto only). Copy this file into your
+//     repo — no npm package, no supply-chain or version surface to own.
+//   • The gate blocks an irreversible action unless it arrives with a valid,
+//     action-bound, non-replayed EMILIA authorization receipt (proof a named
+//     human approved THIS exact action), verified offline (Ed25519 over JCS).
+//   • Off by default: you decide which actions require a receipt.
+//
+//   Quick use:
+//     import { makeReceiptGate } from './emilia-gate.mjs';
+//     const gate = makeReceiptGate({ action: 'db.records.delete', trustedKeys: [ISSUER_SPKI_B64URL] });
+//     const r = await gate.run(receipt, { target: 'customers' }, async () => doDelete());
+//     if (!r.ok) return reply(r.status, r.body);   // 428 Receipt-Required challenge
+//
+//   PRODUCTION NOTES (the two things easy to get wrong):
+//     1. Pass trustedKeys (issuer SPKI keys). Do NOT rely on allowInlineKey for
+//        real actions — an inline key proves integrity, not WHO authorized.
+//     2. The default consumed-store is in-memory (process-local). For restart-
+//        durable / multi-instance one-time consumption, pass a shared store:
+//        makeReceiptGate({ ..., store: { has:(id)=>kv.has(id), add:(id)=>kv.add(id) } }).
+//
+//   Conformance: this drop-in passes EMILIA RR-1 (challenge-on-missing, runs-on-
+//   valid, replay-refused, forged-refused). Verify with @emilia-protocol/fire-drill.
+//
+//   GENERATED — do not edit by hand. Regenerate with:
+//     npx @emilia-protocol/require-receipt   (or: node build-drop-in.mjs)
+//   source: @emilia-protocol/require-receipt@0.4.1  ·  content-sha256:655027fbb947f466
+//   docs: https://www.emiliaprotocol.ai/gate   spec: draft-schrock-ep-authorization-receipts
+
+/**
+ * @emilia-protocol/require-receipt — the demand side of the network.
+ * @license Apache-2.0
+ *
+ * One line that lets ANY service refuse an irreversible agent action unless it
+ * arrives with a verifiable EMILIA Trust Receipt — proof that a named human
+ * accountably authorized this exact action. This is NOT auth ("who are you")
+ * and NOT permissions ("are you allowed here"). It is *portable accountability
+ * evidence the service keeps for its own liability*.
+ *
+ * When the receipt is missing, the service answers with a machine-readable
+ * Receipt Required challenge and tells the agent exactly what to bring — so a
+ * well-behaved agent obtains one and retries on its own. Existing callers keep
+ * the 402 shape; new "Receipt Required" rails can opt into HTTP 428.
+ *
+ * Verification is offline Ed25519 over canonical JSON — same shape as
+ * @emilia-protocol/verify. Zero network. Pin the issuer keys you trust.
+ */
+import crypto from 'node:crypto';
+
+export const LEGACY_RECEIPT_REQUIRED_STATUS = 402;
+export const RECEIPT_REQUIRED_STATUS = 428;
+export const RECEIPT_REQUIRED_HEADER = 'Receipt-Required';
+export const RECEIPT_PROOF_HEADER = 'X-EMILIA-Receipt';
+export const ACTION_RISK_MANIFEST_VERSION = 'EP-ACTION-RISK-MANIFEST-v0.1';
+export const DEFAULT_ACTION_RISK_MANIFEST = '/.well-known/agent-actions.json';
+
+function canonicalize(v) {
+  if (v === null || v === undefined) return JSON.stringify(v);
+  if (Array.isArray(v)) return `[${v.map(canonicalize).join(',')}]`;
+  if (typeof v === 'object') return `{${Object.keys(v).sort().map((k) => JSON.stringify(k) + ':' + canonicalize(v[k])).join(',')}}`;
+  return JSON.stringify(v);
+}
+
+/**
+ * Parse a base64url SPKI-DER public key into a KeyObject, cached by string so a
+ * given key is parsed once (not once per verification). Beyond the perf win this
+ * removes the per-key DER-parsing work from the verify loop, shrinking the timing
+ * difference between "key matched early" and "key matched late". Trusted keys are
+ * public, so this is defense-in-depth, not a secret-dependent path. Returns null
+ * for an unparseable key (treated as "no match").
+ */
+const _keyCache = new Map();
+function parseSpkiKey(b64) {
+  if (_keyCache.has(b64)) return _keyCache.get(b64);
+  let key = null;
+  try {
+    key = crypto.createPublicKey({ key: Buffer.from(b64, 'base64url'), format: 'der', type: 'spki' });
+  } catch {
+    key = null;
+  }
+  _keyCache.set(b64, key);
+  return key;
+}
+
+function asChallengeOptions(opts) {
+  if (!opts) return {};
+  if (typeof opts === 'number') return { status: opts };
+  return opts;
+}
+
+function quoteHeaderValue(value) {
+  return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function definedEntries(obj) {
+  return Object.entries(obj).filter(([, value]) => value !== undefined && value !== null && value !== false);
+}
+
+function isObject(v) {
+  return v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function challengeHeaderParams(opts = {}) {
+  return definedEntries({
+    action: opts.action,
+    action_hash: opts.actionHash,
+    manifest: opts.manifestUrl || opts.manifest,
+    proof: opts.proofHeader || RECEIPT_PROOF_HEADER,
+    profile: opts.profile || 'EP-RECEIPT-v1',
+    assurance: opts.assuranceClass,
+    quorum: opts.quorum ? JSON.stringify(opts.quorum) : null,
+    max_age: Number.isFinite(opts.maxAgeSec) ? String(opts.maxAgeSec) : null,
+  });
+}
+
+/** Build the compact Receipt-Required challenge header value for HTTP 428. */
+export function receiptRequiredHeader(opts = {}) {
+  return challengeHeaderParams(opts)
+    .map(([key, value]) => `${key}="${quoteHeaderValue(value)}"`)
+    .join(', ');
+}
+
+/**
+ * Verify an EP-RECEIPT-v1 document.
+ * @param {object} doc the receipt document
+ * @param {object} opts
+ * @param {string[]} [opts.trustedKeys] base64url SPKI-DER public keys you trust as issuers
+ * @param {boolean} [opts.allowInlineKey=false] also accept the receipt's own inline key (proves integrity, NOT trust)
+ * @param {string|null} [opts.action] require the receipt to be bound to this action_type
+ * @param {number} [opts.maxAgeSec=900] reject receipts older than this
+ * @param {string[]} [opts.allowedOutcomes] acceptable claim.outcome values
+ * @returns {{ok:boolean, reason?:string, outcome?:string, subject?:string, receipt_id?:string, signer?:string}}
+ */
+export function verifyEmiliaReceipt(doc, opts = {}) {
+  const { trustedKeys = [], allowInlineKey = false, action = null, maxAgeSec = 900,
+    allowedOutcomes = ['allow', 'allow_with_signoff'] } = opts;
+
+  if (!doc || doc['@version'] !== 'EP-RECEIPT-v1' || !doc.payload || !doc.signature?.value) {
+    return { ok: false, reason: 'malformed_receipt' };
+  }
+  const payload = doc.payload;
+
+  const candidates = [...trustedKeys];
+  if (allowInlineKey && doc.public_key) candidates.push(doc.public_key);
+  if (candidates.length === 0) return { ok: false, reason: 'no_trusted_keys_configured' };
+
+  const data = Buffer.from(canonicalize(payload), 'utf8');
+  let sig;
+  try { sig = Buffer.from(doc.signature.value, 'base64url'); } catch { return { ok: false, reason: 'bad_signature_encoding' }; }
+
+  let signer = null;
+  for (const k of candidates) {
+    const pub = parseSpkiKey(k); // cached parse — avoids per-call DER parsing + the timing variance it adds
+    if (!pub) continue;
+    try {
+      if (crypto.verify(null, data, pub, sig)) { signer = k; break; }
+    } catch { /* try next key */ }
+  }
+  if (!signer) return { ok: false, reason: 'untrusted_or_invalid_signature' };
+
+  if (maxAgeSec && payload.created_at) {
+    const ageSec = (Date.now() - Date.parse(payload.created_at)) / 1000;
+    if (Number.isFinite(ageSec) && ageSec > maxAgeSec) return { ok: false, reason: 'receipt_expired' };
+  }
+  if (action && payload.claim?.action_type !== action) {
+    return { ok: false, reason: 'action_mismatch', detail: `receipt is for "${payload.claim?.action_type}", required "${action}"` };
+  }
+  const outcome = payload.claim?.outcome;
+  if (allowedOutcomes && !allowedOutcomes.includes(outcome)) {
+    return { ok: false, reason: 'outcome_not_accepted', detail: `outcome "${outcome}" not in [${allowedOutcomes.join(', ')}]` };
+  }
+  return { ok: true, outcome, subject: payload.subject, receipt_id: payload.receipt_id, signer: `${signer.slice(0, 16)}…` };
+}
+
+/**
+ * Build the challenge body that tells an agent exactly what receipt to bring.
+ *
+ * Backward-compatible default: status 402, matching the original demand loop.
+ * New Receipt Required rail: pass `{ status: 428 }` or `{ statusCode: 428 }`.
+ */
+export function receiptChallenge(action, reason, opts = {}) {
+  const o = asChallengeOptions(opts);
+  const status = o.statusCode || o.status || LEGACY_RECEIPT_REQUIRED_STATUS;
+  const proofHeader = o.proofHeader || RECEIPT_PROOF_HEADER;
+  return {
+    type: 'https://emiliaprotocol.ai/errors/emilia_receipt_required',
+    title: 'EMILIA Receipt Required',
+    status,
+    detail: reason || 'This action requires an accountable, verifiable authorization receipt.',
+    required: {
+      action: action || null,
+      action_hash: o.actionHash || null,
+      manifest: o.manifestUrl || o.manifest || null,
+      status,
+      challenge_header: RECEIPT_REQUIRED_HEADER,
+      proof_header: proofHeader,
+      header: `${proofHeader}: base64(<EP-RECEIPT-v1 JSON>)`,
+      acceptable_issuers: o.acceptableIssuers || o.issuers || null,
+      assurance_class: o.assuranceClass || null,
+      quorum: o.quorum || null,
+      max_age_sec: Number.isFinite(o.maxAgeSec) ? o.maxAgeSec : null,
+      how: 'Obtain a receipt (run emilia-gate, the SDK, or POST /api/trust/gate), then resend with the header.',
+      learn_more: 'https://www.emiliaprotocol.ai/agent-guard',
+    },
+  };
+}
+
+/** Validate a .well-known/agent-actions.json Action Risk Manifest. */
+export function validateActionRiskManifest(manifest) {
+  const errors = [];
+  if (!isObject(manifest)) {
+    return { ok: false, errors: ['manifest must be an object'] };
+  }
+  if (manifest['@version'] !== ACTION_RISK_MANIFEST_VERSION) {
+    errors.push(`@version must be ${ACTION_RISK_MANIFEST_VERSION}`);
+  }
+  if (!Array.isArray(manifest.actions)) {
+    errors.push('actions must be an array');
+  }
+
+  const seen = new Set();
+  for (const [i, action] of (manifest.actions || []).entries()) {
+    const p = `actions[${i}]`;
+    if (!isObject(action)) {
+      errors.push(`${p} must be an object`);
+      continue;
+    }
+    if (!action.id || typeof action.id !== 'string') errors.push(`${p}.id must be a string`);
+    if (seen.has(action.id)) errors.push(`${p}.id must be unique`);
+    seen.add(action.id);
+    if (!isObject(action.match)) errors.push(`${p}.match must be an object`);
+    if (typeof action.receipt_required !== 'boolean') errors.push(`${p}.receipt_required must be boolean`);
+    if (action.receipt_required && !action.action_type) errors.push(`${p}.action_type is required when receipt_required is true`);
+    if (action.receipt_required && !['medium', 'high', 'critical'].includes(action.risk)) {
+      errors.push(`${p}.risk must be medium, high, or critical when receipt_required is true`);
+    }
+    if (action.assurance_class && !['software', 'class_a', 'quorum'].includes(action.assurance_class)) {
+      errors.push(`${p}.assurance_class must be software, class_a, or quorum`);
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+function selectorMatches(match = {}, selector = {}) {
+  for (const key of ['protocol', 'tool', 'method', 'path']) {
+    if (match[key] && selector[key] && match[key] !== selector[key]) return false;
+  }
+  if (match.tool && selector.tool) return match.tool === selector.tool;
+  if (match.method && selector.method && match.path && selector.path) return match.method === selector.method && match.path === selector.path;
+  return false;
+}
+
+/**
+ * Find the first manifest entry matching an action selector.
+ * Selectors may use { id }, { action_type } / { action }, or protocol fields
+ * such as { protocol: 'mcp', tool: 'release_payment' }.
+ */
+export function findActionRequirement(manifest, selector = {}) {
+  const actions = Array.isArray(manifest?.actions) ? manifest.actions : [];
+  return actions.find((entry) => (
+    (selector.id && entry.id === selector.id) ||
+    (selector.action_type && entry.action_type === selector.action_type) ||
+    (selector.action && entry.action_type === selector.action) ||
+    selectorMatches(entry.match, selector)
+  )) || null;
+}
+
+/**
+ * Express/Connect middleware: demand a valid EMILIA receipt for the route.
+ * @param {object} opts verify options + { action?: string | (req)=>string, statusCode?: 402|428 }
+ */
+export function requireEmiliaReceipt(opts = {}) {
+  return function emiliaReceiptGate(req, res, next) {
+    const action = typeof opts.action === 'function' ? opts.action(req) : opts.action;
+    const status = opts.statusCode || opts.status || LEGACY_RECEIPT_REQUIRED_STATUS;
+    const challengeOpts = { ...opts, action, status };
+    let doc = null;
+    const hdr = req.headers?.['x-emilia-receipt'];
+    if (hdr) { try { doc = JSON.parse(Buffer.from(hdr, 'base64').toString('utf8')); } catch { /* fallthrough */ } }
+    if (!doc && req.body && req.body.emilia_receipt) doc = req.body.emilia_receipt;
+
+    if (!doc) {
+      res.setHeader(RECEIPT_REQUIRED_HEADER, receiptRequiredHeader(challengeOpts));
+      if (status === LEGACY_RECEIPT_REQUIRED_STATUS) {
+        res.setHeader('WWW-Authenticate', `EMILIA realm="agent-actions"${action ? `, action="${action}"` : ''}`);
+      }
+      return res.status(status).json(receiptChallenge(action, 'No EMILIA receipt presented.', challengeOpts));
+    }
+    const v = verifyEmiliaReceipt(doc, { ...opts, action });
+    if (!v.ok) {
+      res.setHeader(RECEIPT_REQUIRED_HEADER, receiptRequiredHeader(challengeOpts));
+      if (status === LEGACY_RECEIPT_REQUIRED_STATUS) {
+        res.setHeader('WWW-Authenticate', `EMILIA realm="agent-actions"${action ? `, action="${action}"` : ''}`);
+      }
+      return res.status(status).json({ ...receiptChallenge(action, `Receipt rejected: ${v.reason}.`, challengeOpts), rejected: v });
+    }
+    req.emiliaReceipt = v;
+    return next();
+  };
+}
+
+/**
+ * Receipt Required conformance harness. Exercises a guarded dispatcher against
+ * the four normative behaviors and returns a structured report. The badge is
+ * EARNED by passing this — never self-asserted. (Don't trust us; run the check.)
+ *
+ * Level RR-1 requires all of: a Receipt-Required challenge on a missing receipt,
+ * the action running on a valid action-bound receipt, replay of the same receipt
+ * refused (one-time consumption), and a forged receipt refused.
+ *
+ * @param {object} p
+ * @param {(name:string, args:object, receipt:object|null)=>Promise<{status:number, body?:object}>} p.dispatch
+ * @param {string} p.tool       receipt-required tool/route name to probe
+ * @param {object} [p.args]     arguments passed to the tool
+ * @param {string} p.action     canonical action_type the receipt must bind
+ * @param {()=>(object|Promise<object>)} p.issueReceipt  mints a FRESH valid
+ *   EP-RECEIPT-v1 bound to `action` that this dispatcher accepts
+ * @param {object} [p.manifest] optional Action Risk Manifest to validate
+ * @returns {Promise<{level:string, passed:boolean, checks:object, detail:object}>}
+ */
+export async function receiptRequiredConformance({ dispatch, tool, args = {}, action, issueReceipt, manifest }) {
+  const checks = {};
+  const detail = {};
+  const RR = RECEIPT_REQUIRED_STATUS;
+
+  if (manifest !== undefined) {
+    const m = validateActionRiskManifest(manifest);
+    checks.manifest_valid = m.ok;
+    if (!m.ok) detail.manifest_errors = m.errors;
+  }
+
+  // 1. missing receipt -> a Receipt Required challenge (428, or legacy 402)
+  const r1 = await dispatch(tool, args, null);
+  checks.challenge_on_missing = (r1.status === RR || r1.status === LEGACY_RECEIPT_REQUIRED_STATUS) && !!r1.body?.required;
+  detail.missing_status = r1.status;
+
+  // 2. valid, action-bound receipt -> the action runs
+  const good = await issueReceipt(action);
+  const r2 = await dispatch(tool, args, good);
+  checks.runs_on_valid = r2.status === 200;
+  detail.valid_status = r2.status;
+
+  // 3. the SAME receipt again -> refused (one-time consumption)
+  const r3 = await dispatch(tool, args, good);
+  checks.replay_refused = r3.status !== 200;
+  detail.replay_status = r3.status;
+
+  // 4. a forged receipt (a signed field altered) -> refused
+  const forged = await issueReceipt(action);
+  if (forged?.payload?.claim) forged.payload.claim.action_type = `${action}.tampered`;
+  const r4 = await dispatch(tool, args, forged);
+  checks.forged_refused = r4.status !== 200;
+  detail.forged_status = r4.status;
+
+  const passed = Object.values(checks).every(Boolean);
+  return { level: passed ? 'RR-1' : 'none', passed, checks, detail };
+}
+
+const requireReceiptExports = {
+  verifyEmiliaReceipt,
+  requireEmiliaReceipt,
+  receiptChallenge,
+  receiptRequiredHeader,
+  validateActionRiskManifest,
+  findActionRequirement,
+  receiptRequiredConformance,
+};
+
+export default requireReceiptExports;
+
+// ── inlined from gate.js ───────────────────────────────────────────────────
+
+/**
+ * @emilia-protocol/require-receipt — makeReceiptGate
+ * @license Apache-2.0
+ *
+ * The canonical, hardened Receipt-Required gate. Encodes, in ONE reviewed place,
+ * the three properties that are easy to get wrong when hand-rolling a guard:
+ *
+ *   1. TARGET BINDING — a receipt is bound to the exact resource, not just the
+ *      action type, so a valid receipt for resource A cannot act on resource B.
+ *   2. CONSUME-AFTER-SUCCESS (+ replay safety) — a receipt is RESERVED for the
+ *      duration of the side effect, COMMITTED (one-time-consumed) only if the
+ *      action succeeds, and RELEASED if it fails — so a transient failure never
+ *      burns a valid approval, and a reserved/consumed receipt can never drive a
+ *      second action (concurrent or after restart, given a shared store).
+ *   3. SANITIZED REJECTIONS — a refusal returns only a `{ reason }` code, never
+ *      the verified receipt's signer/subject/library detail.
+ *
+ * Prefer `gate.run(receipt, { target }, fn)` — it orchestrates verify → run →
+ * commit/release so a caller cannot get the ordering wrong. Use the lower-level
+ * `check` / `commit` / `release` only when you must gate and act in separate steps.
+ */
+
+/** Default in-memory consumed-store. Process-local — pass a shared/durable store
+ *  ({ has, add }) for multi-instance or restart-durable one-time consumption. */
+function inMemoryStore() {
+  const consumed = new Set();
+  return { has: (id) => consumed.has(id), add: (id) => consumed.add(id) };
+}
+
+function normalizeTarget(target) {
+  if (target === undefined || target === null) return null;
+  if (Array.isArray(target)) return target.map(String).sort().join(',');
+  return String(target);
+}
+
+/**
+ * Build a hardened Receipt-Required gate for one action type.
+ *
+ * @param {object} opts
+ * @param {string|((target:any)=>string)} opts.action  base action_type, or a fn
+ *   that derives the fully-bound action from the target.
+ * @param {string[]} [opts.trustedKeys]      issuer SPKI keys you trust (recommended).
+ * @param {boolean} [opts.allowInlineKey=false] also accept the receipt's own key
+ *   (proves integrity, NOT issuer trust) — demo only; leave off in production.
+ * @param {number} [opts.maxAgeSec=900]
+ * @param {string[]} [opts.allowedOutcomes]
+ * @param {number} [opts.statusCode=428]
+ * @param {string} [opts.manifestUrl]
+ * @param {string} [opts.assuranceClass]
+ * @param {{has:(id:string)=>boolean, add:(id:string)=>void}} [opts.store]
+ *   consumed-receipt store; defaults to in-memory (process-local). A durable
+ *   store makes one-time consumption survive restarts and span instances. The
+ *   in-flight reservation that blocks *concurrent* replay is always process-local.
+ */
+export function makeReceiptGate(opts = {}) {
+  const {
+    action,
+    trustedKeys = [],
+    allowInlineKey = false,
+    maxAgeSec = 900,
+    allowedOutcomes,
+    statusCode = RECEIPT_REQUIRED_STATUS,
+    manifestUrl,
+    assuranceClass,
+    store = inMemoryStore(),
+  } = opts;
+
+  if (!action) throw new Error('makeReceiptGate: `action` is required');
+
+  const inflight = new Set(); // reservations held during an in-progress action
+
+  const boundActionFor = (target) => {
+    const base = typeof action === 'function' ? action(target) : action;
+    if (typeof action === 'function') return base; // fn already folds in the target
+    const t = normalizeTarget(target);
+    return t === null ? base : `${base}:${t}`;
+  };
+
+  const challengeOpts = () => ({ statusCode, manifestUrl, assuranceClass, maxAgeSec });
+
+  function refuse(boundAction, reason) {
+    return {
+      ok: false,
+      status: statusCode,
+      body: { ...receiptChallenge(boundAction, `Receipt rejected: ${reason}.`, challengeOpts()), rejected: { reason } },
+    };
+  }
+
+  /**
+   * Verify + reserve a receipt WITHOUT consuming it. On ok, the caller MUST
+   * later call commit(receiptId) on success or release(receiptId) on failure.
+   * @returns {{ok:true, receiptId, outcome, signer, subject, boundAction}
+   *          | {ok:false, status, body}}
+   */
+  function check(receipt, { target } = {}) {
+    const boundAction = boundActionFor(target);
+
+    if (!receipt) {
+      return {
+        ok: false,
+        status: statusCode,
+        body: receiptChallenge(boundAction, 'This action requires an accountable, verifiable authorization receipt.', challengeOpts()),
+      };
+    }
+
+    const v = verifyEmiliaReceipt(receipt, { trustedKeys, allowInlineKey, action: boundAction, maxAgeSec, allowedOutcomes });
+    if (!v.ok) return refuse(boundAction, v.reason); // sanitized: reason code only
+
+    if (store.has(v.receipt_id) || inflight.has(v.receipt_id)) return refuse(boundAction, 'replay_refused');
+
+    inflight.add(v.receipt_id); // reserve for the duration of the action
+    return { ok: true, receiptId: v.receipt_id, outcome: v.outcome, signer: v.signer, subject: v.subject, boundAction };
+  }
+
+  /** Finalize one-time consumption after the action SUCCEEDS. */
+  function commit(receiptId) {
+    inflight.delete(receiptId);
+    store.add(receiptId);
+  }
+
+  /** Release the reservation after the action FAILS — the approval stays retryable. */
+  function release(receiptId) {
+    inflight.delete(receiptId);
+  }
+
+  /**
+   * The safe path: verify+reserve, run the side effect, then commit on success
+   * or release on failure. `fn` MUST throw on failure (so the approval is not
+   * consumed). Receives the check result: fn({ receiptId, outcome, signer, ... }).
+   * @returns {Promise<{ok:true, receiptId, outcome, signer, result}|{ok:false, status, body}>}
+   */
+  async function run(receipt, ctx, fn) {
+    if (typeof ctx === 'function') { fn = ctx; ctx = {}; }
+    const c = check(receipt, ctx || {});
+    if (!c.ok) return c;
+    try {
+      const result = await fn(c);
+      commit(c.receiptId);
+      return { ok: true, receiptId: c.receiptId, outcome: c.outcome, signer: c.signer, result };
+    } catch (err) {
+      release(c.receiptId); // failure -> not consumed -> retryable
+      throw err;
+    }
+  }
+
+  return { check, commit, release, run, boundActionFor };
+}

--- a/examples/eve-receipt-required/lib/guards.mjs
+++ b/examples/eve-receipt-required/lib/guards.mjs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Receipt-Required guards for this Eve agent's dangerous tools.
+//
+// One gate per irreversible action. Both the Eve tool files (agent/tools/*.ts) and
+// the local demo (demo.mjs) import these, so what you demo is exactly what runs.
+//
+// Zero dependency: this composes lib/emilia-gate.mjs (Node crypto only).
+
+import { makeReceiptGate } from './emilia-gate.mjs';
+
+// Issuer keys you trust, as comma-separated base64url SPKI. In production, set
+// EMILIA_TRUSTED_KEYS and DO NOT rely on inline keys. With no trusted keys
+// configured we fall back to allowInlineKey so the demo runs out of the box —
+// that proves integrity, not WHO authorized, so it is demo-only.
+const trustedKeys = (process.env.EMILIA_TRUSTED_KEYS || '').split(',').map((s) => s.trim()).filter(Boolean);
+const demoMode = trustedKeys.length === 0;
+
+/** Release funds — receipt bound to funds.release:<destination>. */
+export const releaseFundsGate = makeReceiptGate({
+  action: 'funds.release',
+  trustedKeys,
+  allowInlineKey: demoMode,
+  maxAgeSec: 900,
+});
+
+/** Delete a repository — receipt bound to repo.delete:<owner/name>. */
+export const deleteRepoGate = makeReceiptGate({
+  action: 'repo.delete',
+  trustedKeys,
+  allowInlineKey: demoMode,
+  maxAgeSec: 900,
+});
+
+export { demoMode };

--- a/tests/eve-receipt-required.test.js
+++ b/tests/eve-receipt-required.test.js
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The Eve "Receipt Required" kit must gate its dangerous tools: no receipt -> blocked,
+// valid+bound -> runs once, replay -> blocked, wrong-target -> blocked. Runs the SAME
+// gate the Eve tool files import (examples/eve-receipt-required/lib/guards.mjs).
+
+import { test, expect } from 'vitest';
+import crypto from 'node:crypto';
+import { releaseFundsGate } from '../examples/eve-receipt-required/lib/guards.mjs';
+
+const canon = (v) => (v === null || v === undefined ? JSON.stringify(v)
+  : Array.isArray(v) ? `[${v.map(canon).join(',')}]`
+    : typeof v === 'object' ? `{${Object.keys(v).sort().map((k) => JSON.stringify(k) + ':' + canon(v[k])).join(',')}}`
+      : JSON.stringify(v));
+
+function humanApproves(actionType) {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+  const pub = publicKey.export({ type: 'spki', format: 'der' }).toString('base64url');
+  const payload = {
+    receipt_id: 'rcpt_' + crypto.randomBytes(6).toString('hex'),
+    subject: 'agent:ops-bot',
+    created_at: new Date().toISOString(),
+    claim: { action_type: actionType, outcome: 'allow_with_signoff', approver: 'cfo@yourco.example' },
+  };
+  const value = crypto.sign(null, Buffer.from(canon(payload), 'utf8'), privateKey).toString('base64url');
+  return { '@version': 'EP-RECEIPT-v1', payload, signature: { algorithm: 'Ed25519', value }, public_key: pub };
+}
+
+test('release_funds gate: block / run-once / replay-block / wrong-target-block', async () => {
+  const DEST = 'acct-9931';
+  const bound = releaseFundsGate.boundActionFor(DEST);
+  const run = () => ({ released: true });
+
+  const r1 = await releaseFundsGate.run(undefined, { target: DEST }, run);
+  expect(r1.ok).toBe(false);
+  expect(r1.status).toBe(428);
+
+  const receipt = humanApproves(bound);
+  const r2 = await releaseFundsGate.run(receipt, { target: DEST }, run);
+  expect(r2.ok).toBe(true);
+
+  const r3 = await releaseFundsGate.run(receipt, { target: DEST }, run);
+  expect(r3.ok).toBe(false);
+  expect(r3.body.rejected.reason).toBe('replay_refused');
+
+  const wrong = humanApproves(releaseFundsGate.boundActionFor('attacker-acct'));
+  const r4 = await releaseFundsGate.run(wrong, { target: DEST }, run);
+  expect(r4.ok).toBe(false);
+  expect(r4.body.rejected.reason).toBe('action_mismatch');
+});


### PR DESCRIPTION
Rides the Vercel Eve launch: a complete runnable Eve agent that gates dangerous tools (release_funds, delete_repo) behind a verifiable EMILIA receipt, zero runtime dependency (one copied file), Eve-native layout (defineTool/defineAgent/skills). node demo.mjs proves block → sign → run-once → replay-block → wrong-target-block. 'No receipt, no mutation.' Verified demo PASS + vitest + lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)