### PR TITLE
Reorder AAIF pitch page into a live-walkthrough flow + 3-4 min run-of-show

### DIFF
--- a/app/aaif-video-pitch/page.js
+++ b/app/aaif-video-pitch/page.js
@@ -71,19 +71,21 @@ export default function AaifVideoPitchPage() {
   const publishedReports = reports.reports.filter((r) => r.published).length;
 
   return (
-    <main style={s.page}>
+    <main style={s.page} className="aaif-deck">
       <style>{`
         html { scroll-behavior: smooth; }
         #ep-eu-ai-act-banner { display: none !important; }
         nextjs-portal { display: none !important; }
+        .aaif-deck { scroll-snap-type: y mandatory; overflow-y: auto; height: 100vh; }
+        .aaif-deck > section { scroll-snap-align: start; scroll-snap-stop: always; }
         @media (max-width: 900px) {
-          .aaif-deck-grid { grid-template-columns: 1fr !important; }
           .aaif-stats { grid-template-columns: 1fr !important; }
           .aaif-proof-grid { grid-template-columns: repeat(2, minmax(0, 1fr)) !important; }
           .aaif-void-map { grid-template-columns: 1fr !important; }
         }
         @media (max-width: 640px) {
-          .aaif-hero { padding: 52px 20px 24px !important; }
+          .aaif-deck { scroll-snap-type: y proximity; }
+          .aaif-hero, .aaif-slide { padding: 52px 20px 32px !important; }
           .aaif-layer-row { grid-template-columns: 1fr !important; }
           .aaif-check-grid { grid-template-columns: 1fr !important; }
           .aaif-proof-grid { grid-template-columns: 1fr !important; }
@@ -132,8 +134,8 @@ export default function AaifVideoPitchPage() {
         </div>
       </section>
 
-      <section style={s.deckGrid} className="aaif-deck-grid">
-        <article id="gap" style={{ ...s.panel, ...s.widePanel, ...s.anchor }}>
+      <section id="gap" style={{ ...s.slide, ...s.anchor }} className="aaif-slide">
+        <div style={s.slideInner}>
           <div style={s.eyebrow}>01 · THE LANDSCAPE GAP</div>
           <h2 style={s.h2}>Many drafts describe the agent stack. The missing primitive is proof of human authorization.</h2>
           <div style={s.voidMap} className="aaif-void-map">
@@ -155,9 +157,11 @@ export default function AaifVideoPitchPage() {
             <Link href="/standards" style={s.secondaryLink}>Open standards map</Link>
             <a href={draftUrl} style={s.secondaryLink} target="_blank" rel="noopener noreferrer">Open I-D</a>
           </div>
-        </article>
+        </div>
+      </section>
 
-        <article style={s.panel}>
+      <section style={s.slide} className="aaif-slide">
+        <div style={s.slideInner}>
           <div style={s.eyebrow}>02 · WHERE IT SITS</div>
           <h2 style={s.h2}>A small layer between intent and mutation.</h2>
           <div style={s.layerStack}>
@@ -169,9 +173,11 @@ export default function AaifVideoPitchPage() {
             ))}
           </div>
           <p style={s.statement}>Decision logs are testimony. Receipts are evidence.</p>
-        </article>
+        </div>
+      </section>
 
-        <article id="demo" style={{ ...s.panel, ...s.anchor }}>
+      <section id="demo" style={{ ...s.slide, ...s.anchor }} className="aaif-slide">
+        <div style={s.slideInner}>
           <div style={s.eyebrow}>03 · LIVE DEMO</div>
           <h2 style={s.h2}>Try to break the action layer.</h2>
           <p style={s.body}>An irreversible action is blocked without a receipt, runs once with an exact-action receipt, and rejects replay or tampering.</p>
@@ -184,9 +190,11 @@ export default function AaifVideoPitchPage() {
             ))}
           </div>
           <Link href="/try/receipt-required" style={s.primaryLink}>Open live demo</Link>
-        </article>
+        </div>
+      </section>
 
-        <article id="scitt" style={{ ...s.panel, ...s.anchor }}>
+      <section id="scitt" style={{ ...s.slide, ...s.anchor }} className="aaif-slide">
+        <div style={s.slideInner}>
           <div style={s.eyebrow}>04 · SCITT COMPOSITION PROOF</div>
           <h2 style={s.h2}>An authorization receipt can ride as a SCITT Signed Statement.</h2>
           <p style={s.body}>The end-to-end harness wraps the same canonical EP payload as COSE_Sign1, registers it through the SCRAPI path, and verifies mock transparency evidence in CI. SCITT proves the statement was logged; EMILIA proves who authorized the action.</p>
@@ -203,9 +211,11 @@ export default function AaifVideoPitchPage() {
             <a href={scittProfileUrl} style={s.secondaryLink} target="_blank" rel="noopener noreferrer">SCITT profile</a>
             <a href={scittHarnessUrl} style={s.secondaryLink} target="_blank" rel="noopener noreferrer">Harness</a>
           </div>
-        </article>
+        </div>
+      </section>
 
-        <article id="surfaces" style={{ ...s.panel, ...s.anchor }}>
+      <section id="surfaces" style={{ ...s.slide, ...s.anchor }} className="aaif-slide">
+        <div style={s.slideInner}>
           <div style={s.eyebrow}>05 · HIGHER-STAKES SURFACES</div>
           <h2 style={s.h2}>Single approval, quorum, and human-control profiles use the same receipt spine.</h2>
           <div style={s.capabilityGrid}>
@@ -217,9 +227,11 @@ export default function AaifVideoPitchPage() {
             ))}
           </div>
           <p style={s.body}>The defense-facing human-control surface maps receipt evidence to DoD Directive 3000.09, EU AI Act Article 14, NIST AI RMF, and the LAWS debate - carefully scoped as authorization proof, not proof of wisdom.</p>
-        </article>
+        </div>
+      </section>
 
-        <article style={s.panel}>
+      <section style={s.slide} className="aaif-slide">
+        <div style={s.slideInner}>
           <div style={s.eyebrow}>BUILT, TESTED, LIGHTWEIGHT</div>
           <h2 style={s.h2}>Small enough to try. Serious enough to review.</h2>
           <div style={s.proofGrid} className="aaif-proof-grid">
@@ -231,9 +243,11 @@ export default function AaifVideoPitchPage() {
             ))}
           </div>
           <pre style={s.command}>npx @emilia-protocol/issue demo</pre>
-        </article>
+        </div>
+      </section>
 
-        <article style={s.panel}>
+      <section style={s.slide} className="aaif-slide">
+        <div style={s.slideInner}>
           <div style={s.eyebrow}>REAL AND SMALL</div>
           <h2 style={s.h2}>A primitive, not a platform pitch.</h2>
           <ul style={s.bullets}>
@@ -243,9 +257,11 @@ export default function AaifVideoPitchPage() {
             <li>No account or backend for the local demo: <code>npx @emilia-protocol/issue demo</code>.</li>
           </ul>
           <a href={draftUrl} style={s.secondaryLink} target="_blank" rel="noopener noreferrer">Open datatracker draft</a>
-        </article>
+        </div>
+      </section>
 
-        <article style={s.panel}>
+      <section style={s.slide} className="aaif-slide">
+        <div style={s.slideInner}>
           <div style={s.eyebrow}>ECOSYSTEM PROOF</div>
           <h2 style={s.h2}>The maintainer path is a badge, not a scold.</h2>
           <div style={s.stats} className="aaif-stats">
@@ -267,16 +283,18 @@ export default function AaifVideoPitchPage() {
             <Link href="/fire-drill/registry" style={s.secondaryLink}>Registry index</Link>
             <Link href="/fire-drill/rr-1" style={s.secondaryLink}>RR-1 page</Link>
           </div>
-        </article>
+        </div>
       </section>
 
-      <section id="ask" style={{ ...s.closeCard, ...s.anchor }}>
-        <div style={s.eyebrow}>06 · THE ASK</div>
-        <h2 style={s.closeTitle}>If this is the missing human-authorization layer, where should it belong?</h2>
-        <p style={s.closeBody}>Early, non-binding read on fit. Composes with MCP, goose, and AGENTS.md. Apache-2.0 reference implementation.</p>
-        <div style={s.closeLinks}>
-          <span>team@emiliaprotocol.ai</span>
-          <a href={repoUrl} style={s.closeLink} target="_blank" rel="noopener noreferrer">github.com/emiliaprotocol/emilia-protocol</a>
+      <section id="ask" style={{ ...s.slide, ...s.anchor, borderBottom: 'none' }} className="aaif-slide">
+        <div style={s.slideInner}>
+          <div style={s.eyebrow}>06 · THE ASK</div>
+          <h2 style={s.closeTitle}>If this is the missing human-authorization layer, where should it belong?</h2>
+          <p style={s.closeBody}>Early, non-binding read on fit. Composes with MCP, goose, and AGENTS.md. Apache-2.0 reference implementation.</p>
+          <div style={s.closeLinks}>
+            <span>team@emiliaprotocol.ai</span>
+            <a href={repoUrl} style={s.closeLink} target="_blank" rel="noopener noreferrer">github.com/emiliaprotocol/emilia-protocol</a>
+          </div>
         </div>
       </section>
     </main>
@@ -382,27 +400,21 @@ const s = {
     fontFamily: font.mono,
     fontSize: 11,
   },
-  deckGrid: {
-    maxWidth: 1220,
-    margin: '0 auto',
-    padding: '44px 28px',
-    display: 'grid',
-    gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
-    gap: 16,
+  slide: {
+    minHeight: 'calc(100vh - 68px)',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    padding: '64px 32px',
+    borderBottom: '1px solid rgba(250,250,249,0.14)',
   },
-  panel: {
-    border: '1px solid rgba(250,250,249,0.14)',
-    borderRadius: radius.base,
-    background: '#211D1A',
-    padding: 26,
-    minHeight: 390,
+  slideInner: {
+    maxWidth: 1040,
+    margin: '0 auto',
+    width: '100%',
   },
   anchor: {
-    scrollMarginTop: 92,
-  },
-  widePanel: {
-    gridColumn: '1 / -1',
-    minHeight: 360,
+    scrollMarginTop: 68,
   },
   h2: {
     margin: 0,
@@ -616,12 +628,6 @@ const s = {
     fontFamily: font.mono,
     fontSize: 14,
     overflowX: 'auto',
-  },
-  closeCard: {
-    maxWidth: 1220,
-    margin: '0 auto',
-    padding: '72px 28px 86px',
-    borderTop: '1px solid rgba(250,250,249,0.14)',
   },
   closeTitle: {
     margin: 0,

--- a/app/aaif-video-pitch/page.js
+++ b/app/aaif-video-pitch/page.js
@@ -120,7 +120,7 @@ export default function AaifVideoPitchPage() {
 
       <section style={s.deckGrid} className="aaif-deck-grid">
         <article id="gap" style={{ ...s.panel, ...s.widePanel, ...s.anchor }}>
-          <div style={s.eyebrow}>THE LANDSCAPE GAP</div>
+          <div style={s.eyebrow}>01 · THE LANDSCAPE GAP</div>
           <h2 style={s.h2}>Many drafts describe the agent stack. The missing primitive is proof of human authorization.</h2>
           <div style={s.voidMap} className="aaif-void-map">
             <div style={s.ringGrid} className="aaif-ring-grid">
@@ -144,7 +144,7 @@ export default function AaifVideoPitchPage() {
         </article>
 
         <article style={s.panel}>
-          <div style={s.eyebrow}>WHERE IT SITS</div>
+          <div style={s.eyebrow}>02 · WHERE IT SITS</div>
           <h2 style={s.h2}>A small layer between intent and mutation.</h2>
           <div style={s.layerStack}>
             {stackRows.map(([name, job], index) => (
@@ -158,7 +158,7 @@ export default function AaifVideoPitchPage() {
         </article>
 
         <article id="demo" style={{ ...s.panel, ...s.anchor }}>
-          <div style={s.eyebrow}>LIVE DEMO</div>
+          <div style={s.eyebrow}>03 · LIVE DEMO</div>
           <h2 style={s.h2}>Try to break the action layer.</h2>
           <p style={s.body}>An irreversible action is blocked without a receipt, runs once with an exact-action receipt, and rejects replay or tampering.</p>
           <div style={s.checkGrid} className="aaif-check-grid">
@@ -173,7 +173,7 @@ export default function AaifVideoPitchPage() {
         </article>
 
         <article id="scitt" style={{ ...s.panel, ...s.anchor }}>
-          <div style={s.eyebrow}>SCITT COMPOSITION PROOF</div>
+          <div style={s.eyebrow}>04 · SCITT COMPOSITION PROOF</div>
           <h2 style={s.h2}>An authorization receipt can ride as a SCITT Signed Statement.</h2>
           <p style={s.body}>The end-to-end harness wraps the same canonical EP payload as COSE_Sign1, registers it through the SCRAPI path, and verifies mock transparency evidence in CI. SCITT proves the statement was logged; EMILIA proves who authorized the action.</p>
           <div style={s.checkGrid} className="aaif-check-grid">
@@ -192,7 +192,7 @@ export default function AaifVideoPitchPage() {
         </article>
 
         <article id="surfaces" style={{ ...s.panel, ...s.anchor }}>
-          <div style={s.eyebrow}>HIGHER-STAKES SURFACES</div>
+          <div style={s.eyebrow}>05 · HIGHER-STAKES SURFACES</div>
           <h2 style={s.h2}>Single approval, quorum, and human-control profiles use the same receipt spine.</h2>
           <div style={s.capabilityGrid}>
             {capabilityCards.map(([name, body, href]) => (
@@ -257,7 +257,7 @@ export default function AaifVideoPitchPage() {
       </section>
 
       <section id="ask" style={{ ...s.closeCard, ...s.anchor }}>
-        <div style={s.eyebrow}>THE ASK</div>
+        <div style={s.eyebrow}>06 · THE ASK</div>
         <h2 style={s.closeTitle}>If this is the missing human-authorization layer, where should it belong?</h2>
         <p style={s.closeBody}>Early, non-binding read on fit. Composes with MCP, goose, and AGENTS.md. Apache-2.0 reference implementation.</p>
         <div style={s.closeLinks}>

--- a/app/aaif-video-pitch/page.js
+++ b/app/aaif-video-pitch/page.js
@@ -172,18 +172,6 @@ export default function AaifVideoPitchPage() {
           <Link href="/try/receipt-required" style={s.primaryLink}>Open live demo</Link>
         </article>
 
-        <article style={s.panel}>
-          <div style={s.eyebrow}>REAL AND SMALL</div>
-          <h2 style={s.h2}>A primitive, not a platform pitch.</h2>
-          <ul style={s.bullets}>
-            <li>Active individual Internet-Draft, not an IETF endorsement.</li>
-            <li>Reference verifiers in JavaScript, Python, and Go agree on shared conformance vectors.</li>
-            <li>26 TLA+ safety properties and Alloy checks are machine-checked in CI.</li>
-            <li>No account or backend for the local demo: <code>npx @emilia-protocol/issue demo</code>.</li>
-          </ul>
-          <a href={draftUrl} style={s.secondaryLink} target="_blank" rel="noopener noreferrer">Open datatracker draft</a>
-        </article>
-
         <article id="scitt" style={{ ...s.panel, ...s.anchor }}>
           <div style={s.eyebrow}>SCITT COMPOSITION PROOF</div>
           <h2 style={s.h2}>An authorization receipt can ride as a SCITT Signed Statement.</h2>
@@ -229,6 +217,18 @@ export default function AaifVideoPitchPage() {
             ))}
           </div>
           <pre style={s.command}>npx @emilia-protocol/issue demo</pre>
+        </article>
+
+        <article style={s.panel}>
+          <div style={s.eyebrow}>REAL AND SMALL</div>
+          <h2 style={s.h2}>A primitive, not a platform pitch.</h2>
+          <ul style={s.bullets}>
+            <li>Active individual Internet-Draft, not an IETF endorsement.</li>
+            <li>Reference verifiers in JavaScript, Python, and Go agree on shared conformance vectors.</li>
+            <li>26 TLA+ safety properties and Alloy checks are machine-checked in CI.</li>
+            <li>No account or backend for the local demo: <code>npx @emilia-protocol/issue demo</code>.</li>
+          </ul>
+          <a href={draftUrl} style={s.secondaryLink} target="_blank" rel="noopener noreferrer">Open datatracker draft</a>
         </article>
 
         <article style={s.panel}>

--- a/docs/marketing/aaif-speaker-notes-manik.md
+++ b/docs/marketing/aaif-speaker-notes-manik.md
@@ -1,37 +1,37 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 # AAIF pitch — 3–4 min run-of-show (for Manik, CTO, AAIF)
 
-**Format:** present live off the page — https://www.emiliaprotocol.ai/aaif-video-pitch — scroll top-to-bottom; the page order *is* the pitch order. Use the top nav (Gap · Demo · SCITT · Surfaces · Ask) as your 5 stops.
+**Format:** present live off the page — https://www.emiliaprotocol.ai/aaif-video-pitch — scroll top-to-bottom; the page order *is* the pitch order. Each section is badged **01–06** matching the headings below. The top nav (Gap · Demo · SCITT · Surfaces · Ask) jumps to §01/§03/§04/§05/§06.
 **Register:** engineer-to-engineer. Claims are checkable — say so.
 **Say once, out loud:** "It's an active *individual* Internet-Draft, not an IETF endorsement."
 **Total:** ~3.5 min at a brisk pace. Times are ceilings — if you're at 4:00, skip to the Ask.
 
 ---
 
-## 0 · Hook — hero + film  (0:00–0:25)
+## Hook — hero + film  (the open, before §01 · 0:00–0:25)
 - Let the film run ~8s silent, then: "Agent stack's filling in fast — identity, tools, execution, logs. One primitive nobody produces: portable proof a *named human* authorized *this exact irreversible action* before it ran."
 - "Not a platform. A small artifact + a verifier. I want your read on whether it's real and where it belongs."
 
-## 1 · The gap — STOP 1 (0:25–1:00)
+## §01 · The gap  ·  nav: Gap  (0:25–1:00)
 - Point at the void map. "Each ring answers a different question — none answers *who authorized this*. Logs get close, but a log is the operator's own editable record."
 - **Line:** "Logs are testimony. Receipts are evidence."
 
-## 2 · Where it sits (0:55–1:20)
+## §02 · Where it sits  (0:55–1:20)
 - Stack: MCP → goose → AGENTS.md → EMILIA. "A thin layer between intent and mutation. Composes with what you run; replaces none of it."
 
-## 3 · The demo — STOP 2  (1:20–2:05)  ← the part a CTO trusts
+## §03 · The demo  ·  nav: Demo  (1:20–2:05)  ← the part a CTO trusts
 - Four states: missing → 428 · valid → runs once · replay → refused · forged → rejected.
 - "Deny-by-default. The receipt is bound to the hash of the *specific* action — one-time. Replay refused, forged sig fails. Run it yourself: `npx @emilia-protocol/issue demo`."
 - **Offer:** "Happy to have you try to break it live — fastest way to evaluate this."
 
-## 4 · SCITT composition — STOP 3  (2:05–2:45)  ← what matters most to you
+## §04 · SCITT composition  ·  nav: SCITT  (2:05–2:45)  ← what matters most to you
 - "Composition, not competition. Same canonical payload wraps as a COSE_Sign1 Signed Statement, registers via SCRAPI, inclusion verified in CI."
 - **Line:** "SCITT proves the statement was logged. EMILIA proves *who authorized* the action — and it rides on SCITT."
 
-## 5 · Higher-stakes surfaces — STOP 4  (2:45–3:05)
+## §05 · Higher-stakes surfaces  ·  nav: Surfaces  (2:45–3:05)
 - "Same receipt spine scales up: M-of-N / ordered two-person rule; a human-control profile mapped to DoD 3000.09, EU AI Act Art. 14, NIST AI RMF — scoped as authorization proof, *not* proof of wisdom."
 
-## 6 · The ask — STOP 5  (3:05–3:30)
+## §06 · The ask  ·  nav: Ask  (3:05–3:30)
 - "That's it. Non-binding read: if this is the missing human-authorization layer, where should it belong — and does AAIF see it composing with the surfaces you care about? Apache-2.0; composes with MCP, goose, AGENTS.md."
 
 ---

--- a/docs/marketing/aaif-speaker-notes-manik.md
+++ b/docs/marketing/aaif-speaker-notes-manik.md
@@ -1,0 +1,47 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# AAIF pitch — 3–4 min run-of-show (for Manik, CTO, AAIF)
+
+**Format:** present live off the page — https://www.emiliaprotocol.ai/aaif-video-pitch — scroll top-to-bottom; the page order *is* the pitch order. Use the top nav (Gap · Demo · SCITT · Surfaces · Ask) as your 5 stops.
+**Register:** engineer-to-engineer. Claims are checkable — say so.
+**Say once, out loud:** "It's an active *individual* Internet-Draft, not an IETF endorsement."
+**Total:** ~3.5 min at a brisk pace. Times are ceilings — if you're at 4:00, skip to the Ask.
+
+---
+
+## 0 · Hook — hero + film  (0:00–0:25)
+- Let the film run ~8s silent, then: "Agent stack's filling in fast — identity, tools, execution, logs. One primitive nobody produces: portable proof a *named human* authorized *this exact irreversible action* before it ran."
+- "Not a platform. A small artifact + a verifier. I want your read on whether it's real and where it belongs."
+
+## 1 · The gap — STOP 1 (0:25–1:00)
+- Point at the void map. "Each ring answers a different question — none answers *who authorized this*. Logs get close, but a log is the operator's own editable record."
+- **Line:** "Logs are testimony. Receipts are evidence."
+
+## 2 · Where it sits (0:55–1:20)
+- Stack: MCP → goose → AGENTS.md → EMILIA. "A thin layer between intent and mutation. Composes with what you run; replaces none of it."
+
+## 3 · The demo — STOP 2  (1:20–2:05)  ← the part a CTO trusts
+- Four states: missing → 428 · valid → runs once · replay → refused · forged → rejected.
+- "Deny-by-default. The receipt is bound to the hash of the *specific* action — one-time. Replay refused, forged sig fails. Run it yourself: `npx @emilia-protocol/issue demo`."
+- **Offer:** "Happy to have you try to break it live — fastest way to evaluate this."
+
+## 4 · SCITT composition — STOP 3  (2:05–2:45)  ← what matters most to you
+- "Composition, not competition. Same canonical payload wraps as a COSE_Sign1 Signed Statement, registers via SCRAPI, inclusion verified in CI."
+- **Line:** "SCITT proves the statement was logged. EMILIA proves *who authorized* the action — and it rides on SCITT."
+
+## 5 · Higher-stakes surfaces — STOP 4  (2:45–3:05)
+- "Same receipt spine scales up: M-of-N / ordered two-person rule; a human-control profile mapped to DoD 3000.09, EU AI Act Art. 14, NIST AI RMF — scoped as authorization proof, *not* proof of wisdom."
+
+## 6 · The ask — STOP 5  (3:05–3:30)
+- "That's it. Non-binding read: if this is the missing human-authorization layer, where should it belong — and does AAIF see it composing with the surfaces you care about? Apache-2.0; composes with MCP, goose, AGENTS.md."
+
+---
+
+## 5 questions to go through fast (rapid Q&A — one-breath answers)
+1. **"Isn't this just SCITT?"** → SCITT gives transparency/inclusion of a statement; it never asserts a named human authorized the action. EP is that assertion — and rides *as* a SCITT Signed Statement. Complementary, shown in CI.
+2. **"Isn't this OAuth / WIMSE / delegation?"** → Those say which machine/service may act. EP says a *named human* authorized *this exact action*. Above identity, not instead of it.
+3. **"Why not just log the approval?"** → A log is operator-editable — trustworthy only if you trust the operator. An EP receipt verifies offline, bound to the action hash, one-time. Testimony vs evidence.
+4. **"Human sign-off per action — latency / scale?"** → Only high-risk/irreversible actions, not every call. Pre-auth + scoped delegation + quorum cover throughput; honest story is pre-auth + post-hoc proof, not real-time human-in-loop.
+5. **"Where should it be standardized?"** → Individual IETF I-D cluster today (receipts, quorum, evidence-chain); composes with SCITT / RFC 9943. That's exactly what I'm bringing to you.
+
+## Repeat 3× (positioning)
+> "Identity says which machine acts. Tool-auth says which tools it may call. **EMILIA is the proof a named human authorized this exact action** — verifiable offline, composes with everything, competes with nothing."


### PR DESCRIPTION
Makes `/aaif-video-pitch` presentable live: a top-to-bottom scroll now *is* the pitch order, one section per screen.

- Moved the "Real and small" credibility panel out of the **Demo → SCITT** spine down with the other proof panels. New order: **Gap → Where it sits → Demo → SCITT → Surfaces → Proof → Ecosystem → Ask**.
- Top nav (Gap · Demo · SCITT · Surfaces · Ask) = the 5 presentation stops.
- Sections badged **01–06** to match the speaker-notes run-of-show 1:1 (`docs/marketing/aaif-speaker-notes-manik.md`, tight ~3.5-min version + 5 rapid-fire Q&A).
- **Deck-style presentation**: each section now fills its own viewport (`scroll-snap-type: y mandatory`) instead of a packed multi-column grid — presenting live shows exactly one slide at a time. Nav clicks and scroll both land cleanly on a single full section. Mobile uses softer proximity snap.

Verified: `npm run build` clean; rendered the page via Playwright against the production build (desktop wheel-scroll, nav-click-to-section, and mobile viewport all confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)