### PR TITLE
Security hardening: enforce assurance tier, fail-closed hook, tenant-scoping (red-team fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 .next/
 .env
 .env.local
+.env.production
 .env*.local
 .stripe-vars.json
 .emilia/

--- a/app/api/cloud/policies/[policyId]/diff/route.js
+++ b/app/api/cloud/policies/[policyId]/diff/route.js
@@ -34,7 +34,7 @@ export async function GET(request, { params }) {
     const supabase = getGuardedClient();
 
     // Resolve the route policyId to its policy_key; versions are keyed by it.
-    const policy = await loadPolicyById(supabase, policyId);
+    const policy = await loadPolicyById(supabase, policyId, { tenantId: auth.tenantId });
     if (!policy) {
       return EP_ERRORS.NOT_FOUND('Policy');
     }

--- a/app/api/cloud/policies/[policyId]/rollout/route.js
+++ b/app/api/cloud/policies/[policyId]/rollout/route.js
@@ -56,7 +56,7 @@ export async function POST(request, { params }) {
 
     // Resolve the route policyId to its policy_key; the version to roll out is
     // the handshake_policies row with this key and body.version.
-    const policy = await loadPolicyById(supabase, policyId);
+    const policy = await loadPolicyById(supabase, policyId, { tenantId: auth.tenantId });
     if (!policy) {
       return EP_ERRORS.NOT_FOUND('Policy');
     }

--- a/app/api/cloud/policies/[policyId]/versions/route.js
+++ b/app/api/cloud/policies/[policyId]/versions/route.js
@@ -26,7 +26,7 @@ export async function GET(request, { params }) {
 
     // Resolve the route policyId to its policy_key. Versions are keyed by
     // policy_key in handshake_policies (UNIQUE(policy_key, version)).
-    const policy = await loadPolicyById(supabase, policyId);
+    const policy = await loadPolicyById(supabase, policyId, { tenantId: auth.tenantId });
     if (!policy) {
       return EP_ERRORS.NOT_FOUND('Policy');
     }

--- a/app/api/demo/require-receipt/route.js
+++ b/app/api/demo/require-receipt/route.js
@@ -166,6 +166,10 @@ function receiptOptions(demo) {
 function signDemoReceipt(demo, approver) {
   const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
   const publicKeyB64u = publicKey.export({ type: 'spki', format: 'der' }).toString('base64url');
+  const signer = approver || 'ep:approver:demo-human';
+  const quorumClaim = demo.assurance_class === 'quorum'
+    ? { quorum: { signers: [signer, 'ep:approver:demo-second-human'], threshold: 2 } }
+    : {};
   const payload = {
     receipt_id: `rcpt_demo_${crypto.randomBytes(8).toString('hex')}`,
     subject: 'agent:demo-breaker',
@@ -173,9 +177,10 @@ function signDemoReceipt(demo, approver) {
     claim: {
       action_type: boundActionFor(demo),
       outcome: 'allow_with_signoff',
-      approver: approver || 'ep:approver:demo-human',
+      approver: signer,
       policy_id: demo.policy_id,
       assurance_class: demo.assurance_class,
+      ...quorumClaim,
     },
   };
   const value = crypto

--- a/docs/BUILD_SPEC.md
+++ b/docs/BUILD_SPEC.md
@@ -36,7 +36,7 @@ Emilia Protocol (EP) is a **trust enforcement infrastructure layer** for AI agen
 |-------|-----------|-------|
 | Framework | Next.js (App Router) | All routes under `app/api/` |
 | Runtime | Node.js 20 LTS | Edge runtime not used (crypto deps) |
-| Database | Supabase (Postgres 15) | Project: `xmiiwehtivksdjbultym` |
+| Database | Supabase (Postgres 15) | Project ref configured per environment |
 | Deployment | Vercel | Production branch: `main` |
 | Blockchain | Base L2 (Coinbase) | Merkle root anchoring, ~$0.60/mo |
 | Auth | Custom API key scheme | `ep_live_*` / `ep_test_*` prefixed keys |
@@ -204,7 +204,7 @@ Vercel (auto-deploy on push)
          ├── /api/disputes/resolve — every hour
          └── /api/disputes/appeal/resolve — every hour
 
-Supabase (xmiiwehtivksdjbultym)
+Supabase (`<project-ref>`)
     ├── Postgres 15 (primary)
     ├── Realtime (not used)
     └── Storage (not used)

--- a/docs/DB-ISOLATION-PLAN.md
+++ b/docs/DB-ISOLATION-PLAN.md
@@ -13,7 +13,7 @@ Earlier work raised "EP's prod DB is shared across products." Investigation
 
 - **Each product has its own Supabase project** (sidekick, echo, redflag, rekkn,
   unihodl, dorea, coyl, elvera, …). EP runs on its own dedicated project
-  `xmiiwehtivksdjbultym` (`emilia-protocol`), region us-west-2.
+  the current shared production project, region us-west-2.
 - **Zero non-EP base tables exist in EP's project.** EP does not share table data
   with any other product. The data layer is already isolated.
 - The only co-mingling was **~22 orphaned functions** from other products

--- a/docs/operations/CREDENTIAL-ROTATION-CHECKLIST.md
+++ b/docs/operations/CREDENTIAL-ROTATION-CHECKLIST.md
@@ -14,10 +14,10 @@ transcript when the Supabase wipe + re-migration was being driven via
 the CLI. The literal value is **NOT** stored in this file. Pull it
 from your password manager or the original transcript if you need to
 identify which credential to revoke.
-**Project:** `xmiiwehtivksdjbultym` (EMILIA Protocol production)
+**Project:** EMILIA Protocol production Supabase project (`<project-ref>`)
 
 ### Steps
-1. Open https://supabase.com/dashboard/project/xmiiwehtivksdjbultym/settings/database
+1. Open `https://supabase.com/dashboard/project/<project-ref>/settings/database`
 2. Click "Reset database password"
 3. Generate a new password using a password manager (≥24 chars, no
    reused fragments). Store in 1Password under "EMILIA Protocol — DB".
@@ -31,7 +31,7 @@ identify which credential to revoke.
    password directly:
    ```bash
    # If using a URL with embedded password, regenerate it
-   echo "postgres://postgres.xmiiwehtivksdjbultym:NEW_PW@aws-...:5432/postgres" \
+   echo "postgres://postgres.<project-ref>:NEW_PW@aws-...:5432/postgres" \
      | vercel env add POSTGRES_URL production
    ```
 6. Trigger a redeploy to pick up the new env var:

--- a/docs/operations/DISASTER_RECOVERY_RUNBOOK.md
+++ b/docs/operations/DISASTER_RECOVERY_RUNBOOK.md
@@ -11,7 +11,7 @@
 
 This runbook covers full and partial disaster recovery for the Emilia Protocol infrastructure:
 - Vercel deployment (Next.js app)
-- Supabase database (Postgres 15, project `xmiiwehtivksdjbultym`)
+- Supabase database (Postgres 15, production project ref stored outside public docs)
 - Base L2 anchoring wallet
 
 It does **not** cover user data breach response (see `INCIDENT_RESPONSE.md`).
@@ -33,7 +33,7 @@ It does **not** cover user data breach response (see `INCIDENT_RESPONSE.md`).
 
 Before any DR action, confirm you have access to:
 - [ ] Vercel dashboard (vercel.com/team)
-- [ ] Supabase dashboard (`xmiiwehtivksdjbultym`)
+- [ ] Supabase dashboard (`<project-ref>`)
 - [ ] GitHub repo (emilia-protocol)
 - [ ] Environment variable store (Vercel env settings)
 - [ ] Basescan (basescan.org) to verify anchor transactions
@@ -222,7 +222,7 @@ vercel logs [deployment-url] --since 1h
 ### Manual backup command (schema + data)
 ```bash
 pg_dump \
-  "postgresql://postgres:[SERVICE_ROLE_KEY]@db.xmiiwehtivksdjbultym.supabase.co:5432/postgres" \
+  "postgresql://postgres:[SERVICE_ROLE_KEY]@db.<project-ref>.supabase.co:5432/postgres" \
   --no-owner \
   --no-acl \
   -F c \

--- a/examples/eve-receipt-required/lib/emilia-gate.mjs
+++ b/examples/eve-receipt-required/lib/emilia-gate.mjs
@@ -27,7 +27,7 @@
 //
 //   GENERATED — do not edit by hand. Regenerate with:
 //     npx @emilia-protocol/require-receipt   (or: node build-drop-in.mjs)
-//   source: @emilia-protocol/require-receipt@0.4.1  ·  content-sha256:655027fbb947f466
+//   source: @emilia-protocol/require-receipt@0.4.1  ·  content-sha256:c3c4951a5d9b8c37
 //   docs: https://www.emiliaprotocol.ai/gate   spec: draft-schrock-ep-authorization-receipts
 
 /**
@@ -62,6 +62,21 @@ function canonicalize(v) {
   if (Array.isArray(v)) return `[${v.map(canonicalize).join(',')}]`;
   if (typeof v === 'object') return `{${Object.keys(v).sort().map((k) => JSON.stringify(k) + ':' + canonicalize(v[k])).join(',')}}`;
   return JSON.stringify(v);
+}
+
+/**
+ * EP canonicalization profile: JCS over an I-JSON value subset. Signed receipt
+ * payloads must contain only strings, booleans, null, arrays, objects, and safe
+ * integers. Non-finite numbers, floats, BigInt, undefined, functions, and
+ * symbols are rejected before signature verification so implementations never
+ * diverge on canonical bytes.
+ */
+export function isCanonicalizable(value) {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return true;
+  if (typeof value === 'number') return Number.isInteger(value) && Number.isSafeInteger(value);
+  if (Array.isArray(value)) return value.every(isCanonicalizable);
+  if (typeof value === 'object') return Object.values(value).every(isCanonicalizable);
+  return false;
 }
 
 /**
@@ -142,6 +157,9 @@ export function verifyEmiliaReceipt(doc, opts = {}) {
     return { ok: false, reason: 'malformed_receipt' };
   }
   const payload = doc.payload;
+  if (!isCanonicalizable(payload)) {
+    return { ok: false, reason: 'payload_outside_ijson_profile' };
+  }
 
   const candidates = [...trustedKeys];
   if (allowInlineKey && doc.public_key) candidates.push(doc.public_key);
@@ -409,6 +427,47 @@ function normalizeTarget(target) {
   return String(target);
 }
 
+export const ASSURANCE_TIERS = ['software', 'class_a', 'quorum'];
+const TIER_RANK = {
+  software: 0,
+  class_c: 0,
+  c: 0,
+  class_b: 0,
+  b: 0,
+  class_a: 1,
+  a: 1,
+  quorum: 2,
+  dual: 2,
+  '2-of-n': 2,
+  '2_of_n': 2,
+};
+
+function normalizeAssuranceTier(tier) {
+  if (!tier) return 'software';
+  return String(tier).trim().toLowerCase().replace(/\s+/g, '_');
+}
+
+function tierRank(tier) {
+  return TIER_RANK[normalizeAssuranceTier(tier)] ?? 0;
+}
+
+/**
+ * The assurance tier a valid EP-RECEIPT-v1 claims. This package verifies the
+ * receipt issuer signature first; tier fields are then treated as issuer
+ * attestations. Use @emilia-protocol/verify for full EP §6.2 multi-signature
+ * trust-receipt verification.
+ */
+export function receiptAssuranceTier(doc) {
+  const p = doc?.payload || {};
+  const q = p.quorum || p.claim?.quorum;
+  const signers = q && (q.signers || q.approvers || q.approvals);
+  const distinct = Array.isArray(signers) ? new Set(signers.map((s) => typeof s === 'string' ? s : (s?.approver || s?.id || JSON.stringify(s)))).size : 0;
+  const threshold = q && (q.m ?? q.threshold ?? q.required ?? (Array.isArray(signers) ? signers.length : 0));
+  if (q && distinct >= 2 && Number(threshold) >= 2) return 'quorum';
+  if (p.signoff || p.claim?.signoff || p.claim?.outcome === 'allow_with_signoff') return 'class_a';
+  return 'software';
+}
+
 /**
  * Build a hardened Receipt-Required gate for one action type.
  *
@@ -481,6 +540,10 @@ export function makeReceiptGate(opts = {}) {
 
     const v = verifyEmiliaReceipt(receipt, { trustedKeys, allowInlineKey, action: boundAction, maxAgeSec, allowedOutcomes });
     if (!v.ok) return refuse(boundAction, v.reason); // sanitized: reason code only
+
+    if (assuranceClass && tierRank(receiptAssuranceTier(receipt)) < tierRank(assuranceClass)) {
+      return refuse(boundAction, 'assurance_too_low');
+    }
 
     if (store.has(v.receipt_id) || inflight.has(v.receipt_id)) return refuse(boundAction, 'replay_refused');
 

--- a/examples/mcp/_kit.mjs
+++ b/examples/mcp/_kit.mjs
@@ -41,14 +41,22 @@ const canonicalize = (v) => (v === null || v === undefined ? JSON.stringify(v)
 
 // A named human's device signs the EXACT action. Minted locally here so the
 // demo is self-contained; in production it's a real Face ID / passkey signoff.
-export function signAction(action, { approver, tamper = false } = {}) {
+export function signAction(action, { approver, quorum = null, tamper = false } = {}) {
   const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
   const pub = publicKey.export({ type: 'spki', format: 'der' }).toString('base64url');
+  const quorumClaim = quorum?.required
+    ? {
+        quorum: {
+          signers: [approver, 'ep:approver:second-human'],
+          threshold: quorum.m || quorum.required || 2,
+        },
+      }
+    : {};
   const payload = {
     receipt_id: 'rcpt_' + crypto.randomBytes(6).toString('hex'),
     subject: 'agent:autonomous',
     created_at: new Date().toISOString(),
-    claim: { action_type: action, outcome: 'allow_with_signoff', approver },
+    claim: { action_type: action, outcome: 'allow_with_signoff', approver, ...quorumClaim },
   };
   const value = crypto.sign(null, Buffer.from(canonicalize(payload), 'utf8'), privateKey).toString('base64url');
   const doc = { '@version': 'EP-RECEIPT-v1', payload, signature: { algorithm: 'Ed25519', value }, public_key: pub };
@@ -149,7 +157,7 @@ export async function runDemo({ title, tool, args, approver, agentLine }) {
   // The signoff is bound to the SPECIFIC target (action_type:<resource>), so it
   // authorizes exactly this resource — not any other repo/payment/deploy.
   const boundAction = actionForCall(tool, action, args);
-  const receipt = signAction(boundAction, { approver });
+  const receipt = signAction(boundAction, { approver, quorum: req.quorum });
   line(`     receipt_id ${receipt.payload.receipt_id} · outcome ${receipt.payload.claim.outcome}`);
   line('     agent retries WITH the receipt:');
   res = await server(tool, args, receipt);
@@ -167,8 +175,8 @@ export async function runDemo({ title, tool, args, approver, agentLine }) {
   show(res);
 
   if (req.quorum?.required) {
-    line(`\n  note: the manifest escalates ${tool} to a ${req.quorum.m}-of-N quorum (EP-QUORUM-v1);`);
-    line('        this shows the single-signoff base rail — the quorum path adds distinct human #2.');
+    line(`\n  note: the manifest escalates ${tool} to a ${req.quorum.m}-of-N quorum;`);
+    line('        the demo receipt carries two distinct approvers and the gate refuses a lower tier.');
   }
   line('\n  No receipt, no irreversible action. If it ran, anyone can verify who authorized exactly what.');
   line();

--- a/lib/handshake/policy.js
+++ b/lib/handshake/policy.js
@@ -174,13 +174,22 @@ export async function loadPolicy(supabase, policyKey, version) {
 
 /**
  * Load a policy by its primary ID.
+ *
+ * Pass `{ tenantId }` on authenticated cloud routes. Without it, policy IDs are
+ * globally resolvable for legacy/internal callers; with it, a foreign policy ID
+ * is indistinguishable from a missing one.
  */
-export async function loadPolicyById(supabase, policyId) {
-  const { data, error } = await supabase
+export async function loadPolicyById(supabase, policyId, opts = {}) {
+  let query = supabase
     .from('handshake_policies')
     .select('*')
-    .eq('policy_id', policyId)
-    .maybeSingle();
+    .eq('policy_id', policyId);
+
+  if (opts.tenantId) {
+    query = query.eq('tenant_id', opts.tenantId);
+  }
+
+  const { data, error } = await query.maybeSingle();
 
   if (error) {
     throw new Error(`Failed to load policy by ID: ${error.message}`);

--- a/packages/gate/README.md
+++ b/packages/gate/README.md
@@ -210,6 +210,10 @@ challenge. The Gate composes that and adds the three things a firewall needs:
 
 - **Assurance tiers** — `software` < `class_a` (device signoff) < `quorum` (m-of-n). A `critical`
   action can demand `class_a` or `quorum`; a lower-assurance receipt is refused (`assurance_too_low`).
+  In the lightweight EP-RECEIPT-v1 gate, the tier is an issuer-attested claim
+  inside a receipt signed by a pinned issuer key. For independent verification
+  of every embedded device/quorum signature, use the EP §6.2 trust-receipt
+  verifier in `@emilia-protocol/verify`.
 - **One-time consumption** — a receipt authorizes one action, once. Replays are refused
   (`replay_refused`). Default store is in-memory; swap in Redis/DB for a fleet.
 - **Evidence log** — every decision is hash-chained (`evidence.verify()` detects any alteration).

--- a/packages/gate/index.js
+++ b/packages/gate/index.js
@@ -54,9 +54,15 @@ export const ASSURANCE_TIERS = ['software', 'class_a', 'quorum'];
 const TIER_RANK = { software: 0, class_a: 1, quorum: 2 };
 
 /**
- * The assurance tier a receipt demonstrably meets. Conservative / fail-closed:
- * if a higher tier's structure is not present, the receipt only earns the lower
- * tier, and a guard that needs more will refuse it.
+ * The assurance tier a verified EP-RECEIPT-v1 issuer attests. Conservative /
+ * fail-closed: if a higher tier's signed structure is not present, the receipt
+ * only earns the lower tier, and a guard that needs more will refuse it.
+ *
+ * Trust boundary: this lightweight action gate verifies the pinned issuer's
+ * Ed25519 signature over the receipt. It does not re-run a full EP §6.2
+ * multi-signature trust-receipt verifier here; the tier is therefore an
+ * issuer-attested fact. Use @emilia-protocol/verify verifyTrustReceipt for
+ * independent proof of embedded signoff/quorum signatures.
  *   quorum   — a quorum block with >= 2 distinct signers and threshold >= 2.
  *   class_a  — a device signoff (or claim.outcome === 'allow_with_signoff').
  *   software — any otherwise-valid receipt (a software-held key).
@@ -183,14 +189,14 @@ export function createGate({ manifest = null, trustedKeys = [], maxAgeSec = 900,
     // Assurance tier.
     const have = receiptAssuranceTier(receipt);
     if ((TIER_RANK[have] ?? 0) < (TIER_RANK[requiredTier] ?? 0)) {
-      return decide(false, RECEIPT_REQUIRED_STATUS, 'assurance_too_low', { have_tier: have, need_tier: requiredTier });
+      return decide(false, RECEIPT_REQUIRED_STATUS, 'assurance_too_low', { have_tier: have, need_tier: requiredTier, assurance_tier_source: 'issuer_attestation' });
     }
     // The high-risk action packs define material fields that must be observed
     // by the executor from the system of record. A signed, harmless-looking
     // claim cannot authorize a different real mutation.
     const executionBinding = verifyExecutionBinding({ requirement, receipt, observedAction: observed });
     if (!executionBinding.ok) {
-      return decide(false, RECEIPT_REQUIRED_STATUS, 'execution_binding_failed', { execution_binding: executionBinding, have_tier: have });
+      return decide(false, RECEIPT_REQUIRED_STATUS, 'execution_binding_failed', { execution_binding: executionBinding, have_tier: have, assurance_tier_source: 'issuer_attestation' });
     }
     // One-time consumption (replay defense). Require a stable, issuer-generated
     // receipt_id — never fall back to a content hash, whose canonicalization can
@@ -214,7 +220,7 @@ export function createGate({ manifest = null, trustedKeys = [], maxAgeSec = 900,
     if (!fresh) {
       return decide(false, RECEIPT_REQUIRED_STATUS, 'replay_refused', { consumption_key: receiptId });
     }
-    return decide(true, 200, 'allow', { signer: v.signer, outcome: v.outcome, have_tier: have, execution_binding: executionBinding, consumption_mode: consumptionMode });
+    return decide(true, 200, 'allow', { signer: v.signer, outcome: v.outcome, have_tier: have, assurance_tier_source: 'issuer_attestation', execution_binding: executionBinding, consumption_mode: consumptionMode });
   }
 
   /** Express/Connect middleware: refuse the route unless a sufficient receipt is present. */

--- a/packages/go-verify/trust_receipt.go
+++ b/packages/go-verify/trust_receipt.go
@@ -59,7 +59,7 @@ func verifyClassAOverDigestGo(wa map[string]any, digest []byte, pubB64u string) 
 		return false
 	}
 	ad, err := b64urlDecode(getStr(wa, "authenticator_data"))
-	if err != nil || len(ad) < 37 || ad[32]&flagUV != flagUV {
+	if err != nil || len(ad) < 37 || ad[32]&flagUP != flagUP || ad[32]&flagUV != flagUV {
 		return false
 	}
 	signed := append(append([]byte{}, ad...), func() []byte { s := sha256.Sum256(cdBytes); return s[:] }()...)

--- a/packages/python-verify/emilia_verify/__init__.py
+++ b/packages/python-verify/emilia_verify/__init__.py
@@ -579,7 +579,7 @@ def _verify_class_a_over_digest(webauthn: dict, digest_bytes: bytes, pub_spki_b6
         if client.get("challenge") != base64.urlsafe_b64encode(digest_bytes).decode().rstrip("="):
             return False
         ad = _b64url_decode(webauthn["authenticator_data"])
-        if len(ad) < 37 or (ad[32] & _FLAG_UV) != _FLAG_UV:
+        if len(ad) < 37 or (ad[32] & _FLAG_UP) != _FLAG_UP or (ad[32] & _FLAG_UV) != _FLAG_UV:
             return False
         signed = ad + hashlib.sha256(cd).digest()
         pub = load_der_public_key(_b64url_decode(pub_spki_b64u))

--- a/packages/require-receipt/dist/emilia-gate.mjs
+++ b/packages/require-receipt/dist/emilia-gate.mjs
@@ -27,7 +27,7 @@
 //
 //   GENERATED — do not edit by hand. Regenerate with:
 //     npx @emilia-protocol/require-receipt   (or: node build-drop-in.mjs)
-//   source: @emilia-protocol/require-receipt@0.4.1  ·  content-sha256:655027fbb947f466
+//   source: @emilia-protocol/require-receipt@0.4.1  ·  content-sha256:c3c4951a5d9b8c37
 //   docs: https://www.emiliaprotocol.ai/gate   spec: draft-schrock-ep-authorization-receipts
 
 /**
@@ -62,6 +62,21 @@ function canonicalize(v) {
   if (Array.isArray(v)) return `[${v.map(canonicalize).join(',')}]`;
   if (typeof v === 'object') return `{${Object.keys(v).sort().map((k) => JSON.stringify(k) + ':' + canonicalize(v[k])).join(',')}}`;
   return JSON.stringify(v);
+}
+
+/**
+ * EP canonicalization profile: JCS over an I-JSON value subset. Signed receipt
+ * payloads must contain only strings, booleans, null, arrays, objects, and safe
+ * integers. Non-finite numbers, floats, BigInt, undefined, functions, and
+ * symbols are rejected before signature verification so implementations never
+ * diverge on canonical bytes.
+ */
+export function isCanonicalizable(value) {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return true;
+  if (typeof value === 'number') return Number.isInteger(value) && Number.isSafeInteger(value);
+  if (Array.isArray(value)) return value.every(isCanonicalizable);
+  if (typeof value === 'object') return Object.values(value).every(isCanonicalizable);
+  return false;
 }
 
 /**
@@ -142,6 +157,9 @@ export function verifyEmiliaReceipt(doc, opts = {}) {
     return { ok: false, reason: 'malformed_receipt' };
   }
   const payload = doc.payload;
+  if (!isCanonicalizable(payload)) {
+    return { ok: false, reason: 'payload_outside_ijson_profile' };
+  }
 
   const candidates = [...trustedKeys];
   if (allowInlineKey && doc.public_key) candidates.push(doc.public_key);
@@ -409,6 +427,47 @@ function normalizeTarget(target) {
   return String(target);
 }
 
+export const ASSURANCE_TIERS = ['software', 'class_a', 'quorum'];
+const TIER_RANK = {
+  software: 0,
+  class_c: 0,
+  c: 0,
+  class_b: 0,
+  b: 0,
+  class_a: 1,
+  a: 1,
+  quorum: 2,
+  dual: 2,
+  '2-of-n': 2,
+  '2_of_n': 2,
+};
+
+function normalizeAssuranceTier(tier) {
+  if (!tier) return 'software';
+  return String(tier).trim().toLowerCase().replace(/\s+/g, '_');
+}
+
+function tierRank(tier) {
+  return TIER_RANK[normalizeAssuranceTier(tier)] ?? 0;
+}
+
+/**
+ * The assurance tier a valid EP-RECEIPT-v1 claims. This package verifies the
+ * receipt issuer signature first; tier fields are then treated as issuer
+ * attestations. Use @emilia-protocol/verify for full EP §6.2 multi-signature
+ * trust-receipt verification.
+ */
+export function receiptAssuranceTier(doc) {
+  const p = doc?.payload || {};
+  const q = p.quorum || p.claim?.quorum;
+  const signers = q && (q.signers || q.approvers || q.approvals);
+  const distinct = Array.isArray(signers) ? new Set(signers.map((s) => typeof s === 'string' ? s : (s?.approver || s?.id || JSON.stringify(s)))).size : 0;
+  const threshold = q && (q.m ?? q.threshold ?? q.required ?? (Array.isArray(signers) ? signers.length : 0));
+  if (q && distinct >= 2 && Number(threshold) >= 2) return 'quorum';
+  if (p.signoff || p.claim?.signoff || p.claim?.outcome === 'allow_with_signoff') return 'class_a';
+  return 'software';
+}
+
 /**
  * Build a hardened Receipt-Required gate for one action type.
  *
@@ -481,6 +540,10 @@ export function makeReceiptGate(opts = {}) {
 
     const v = verifyEmiliaReceipt(receipt, { trustedKeys, allowInlineKey, action: boundAction, maxAgeSec, allowedOutcomes });
     if (!v.ok) return refuse(boundAction, v.reason); // sanitized: reason code only
+
+    if (assuranceClass && tierRank(receiptAssuranceTier(receipt)) < tierRank(assuranceClass)) {
+      return refuse(boundAction, 'assurance_too_low');
+    }
 
     if (store.has(v.receipt_id) || inflight.has(v.receipt_id)) return refuse(boundAction, 'replay_refused');
 

--- a/packages/require-receipt/gate.js
+++ b/packages/require-receipt/gate.js
@@ -38,6 +38,47 @@ function normalizeTarget(target) {
   return String(target);
 }
 
+export const ASSURANCE_TIERS = ['software', 'class_a', 'quorum'];
+const TIER_RANK = {
+  software: 0,
+  class_c: 0,
+  c: 0,
+  class_b: 0,
+  b: 0,
+  class_a: 1,
+  a: 1,
+  quorum: 2,
+  dual: 2,
+  '2-of-n': 2,
+  '2_of_n': 2,
+};
+
+function normalizeAssuranceTier(tier) {
+  if (!tier) return 'software';
+  return String(tier).trim().toLowerCase().replace(/\s+/g, '_');
+}
+
+function tierRank(tier) {
+  return TIER_RANK[normalizeAssuranceTier(tier)] ?? 0;
+}
+
+/**
+ * The assurance tier a valid EP-RECEIPT-v1 claims. This package verifies the
+ * receipt issuer signature first; tier fields are then treated as issuer
+ * attestations. Use @emilia-protocol/verify for full EP §6.2 multi-signature
+ * trust-receipt verification.
+ */
+export function receiptAssuranceTier(doc) {
+  const p = doc?.payload || {};
+  const q = p.quorum || p.claim?.quorum;
+  const signers = q && (q.signers || q.approvers || q.approvals);
+  const distinct = Array.isArray(signers) ? new Set(signers.map((s) => typeof s === 'string' ? s : (s?.approver || s?.id || JSON.stringify(s)))).size : 0;
+  const threshold = q && (q.m ?? q.threshold ?? q.required ?? (Array.isArray(signers) ? signers.length : 0));
+  if (q && distinct >= 2 && Number(threshold) >= 2) return 'quorum';
+  if (p.signoff || p.claim?.signoff || p.claim?.outcome === 'allow_with_signoff') return 'class_a';
+  return 'software';
+}
+
 /**
  * Build a hardened Receipt-Required gate for one action type.
  *
@@ -110,6 +151,10 @@ export function makeReceiptGate(opts = {}) {
 
     const v = verifyEmiliaReceipt(receipt, { trustedKeys, allowInlineKey, action: boundAction, maxAgeSec, allowedOutcomes });
     if (!v.ok) return refuse(boundAction, v.reason); // sanitized: reason code only
+
+    if (assuranceClass && tierRank(receiptAssuranceTier(receipt)) < tierRank(assuranceClass)) {
+      return refuse(boundAction, 'assurance_too_low');
+    }
 
     if (store.has(v.receipt_id) || inflight.has(v.receipt_id)) return refuse(boundAction, 'replay_refused');
 

--- a/packages/require-receipt/gate.test.js
+++ b/packages/require-receipt/gate.test.js
@@ -13,14 +13,14 @@ const canon = (v) => (v === null || v === undefined ? JSON.stringify(v)
       : JSON.stringify(v));
 
 // Mint a valid EP-RECEIPT-v1 bound to exactly `actionType`.
-function mint(actionType) {
+function mint(actionType, { outcome = 'allow_with_signoff', extra = {} } = {}) {
   const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
   const pub = publicKey.export({ type: 'spki', format: 'der' }).toString('base64url');
   const payload = {
     receipt_id: 'rcpt_' + crypto.randomBytes(6).toString('hex'),
     subject: 'agent:autonomous',
     created_at: new Date().toISOString(),
-    claim: { action_type: actionType, outcome: 'allow_with_signoff', approver: 'jane@yourco.example' },
+    claim: { action_type: actionType, outcome, approver: 'jane@yourco.example', ...extra },
   };
   const value = crypto.sign(null, Buffer.from(canon(payload), 'utf8'), privateKey).toString('base64url');
   return { '@version': 'EP-RECEIPT-v1', payload, signature: { algorithm: 'Ed25519', value }, public_key: pub };
@@ -71,6 +71,15 @@ test('forged receipt -> refused, sanitized (no signer/subject leak)', async () =
   assert.deepEqual(Object.keys(r.body.rejected), ['reason']);
 });
 
+test('payload outside the I-JSON profile -> refused before canonicalization can diverge', async () => {
+  const g = gate();
+  const rc = mint('db.records.delete:customers');
+  rc.payload.claim.amount = Number.NaN;
+  const r = await g.run(rc, { target: 'customers' }, async () => 'should-not-run');
+  assert.equal(r.ok, false);
+  assert.equal(r.body.rejected.reason, 'payload_outside_ijson_profile');
+});
+
 test('cross-target -> a receipt for customers cannot delete orders', async () => {
   const g = gate();
   const rc = mint('db.records.delete:customers');
@@ -112,4 +121,33 @@ test('target binding via action function', async () => {
   const rc = mint('block.delete:abc123');
   const r = await g.run(rc, { target: 'abc123' }, async () => 'gone');
   assert.equal(r.ok, true);
+});
+
+test('assuranceClass: software receipt cannot satisfy Class-A requirement', async () => {
+  const g = makeReceiptGate({ action: 'payment.release', allowInlineKey: true, assuranceClass: 'class_a' });
+  const rc = mint('payment.release', { outcome: 'allow' });
+  let ran = false;
+  const r = await g.run(rc, {}, async () => { ran = true; });
+  assert.equal(r.ok, false);
+  assert.equal(r.body.rejected.reason, 'assurance_too_low');
+  assert.equal(ran, false);
+});
+
+test('assuranceClass: Class-A receipt cannot satisfy quorum requirement', async () => {
+  const g = makeReceiptGate({ action: 'deploy.production', allowInlineKey: true, assuranceClass: 'quorum' });
+  const rc = mint('deploy.production', { outcome: 'allow_with_signoff' });
+  const r = await g.run(rc, {}, async () => 'deployed');
+  assert.equal(r.ok, false);
+  assert.equal(r.body.rejected.reason, 'assurance_too_low');
+});
+
+test('assuranceClass: signed quorum claim satisfies quorum requirement', async () => {
+  const g = makeReceiptGate({ action: 'deploy.production', allowInlineKey: true, assuranceClass: 'quorum' });
+  const rc = mint('deploy.production', {
+    outcome: 'allow_with_signoff',
+    extra: { quorum: { signers: ['ep:alice', 'ep:bob'], threshold: 2 } },
+  });
+  const r = await g.run(rc, {}, async () => 'deployed');
+  assert.equal(r.ok, true);
+  assert.equal(r.result, 'deployed');
 });

--- a/packages/require-receipt/index.js
+++ b/packages/require-receipt/index.js
@@ -33,6 +33,21 @@ function canonicalize(v) {
 }
 
 /**
+ * EP canonicalization profile: JCS over an I-JSON value subset. Signed receipt
+ * payloads must contain only strings, booleans, null, arrays, objects, and safe
+ * integers. Non-finite numbers, floats, BigInt, undefined, functions, and
+ * symbols are rejected before signature verification so implementations never
+ * diverge on canonical bytes.
+ */
+export function isCanonicalizable(value) {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return true;
+  if (typeof value === 'number') return Number.isInteger(value) && Number.isSafeInteger(value);
+  if (Array.isArray(value)) return value.every(isCanonicalizable);
+  if (typeof value === 'object') return Object.values(value).every(isCanonicalizable);
+  return false;
+}
+
+/**
  * Parse a base64url SPKI-DER public key into a KeyObject, cached by string so a
  * given key is parsed once (not once per verification). Beyond the perf win this
  * removes the per-key DER-parsing work from the verify loop, shrinking the timing
@@ -110,6 +125,9 @@ export function verifyEmiliaReceipt(doc, opts = {}) {
     return { ok: false, reason: 'malformed_receipt' };
   }
   const payload = doc.payload;
+  if (!isCanonicalizable(payload)) {
+    return { ok: false, reason: 'payload_outside_ijson_profile' };
+  }
 
   const candidates = [...trustedKeys];
   if (allowInlineKey && doc.public_key) candidates.push(doc.public_key);

--- a/scripts/emilia-gate.mjs
+++ b/scripts/emilia-gate.mjs
@@ -16,8 +16,8 @@
  *        node scripts/emilia-gate.mjs --hook    (reads the tool call on stdin)
  *      → the agent literally cannot run an irreversible command without EMILIA.
  *
- * Exit 0 = allow.   Exit 2 = blocked (human signoff required, or denied).
- * Kill switch:  EMILIA_GATE=off  → always allow.
+ * Exit 0 = allow.   Exit 2 = blocked (human signoff required, denied, or
+ * the gate cannot parse/classify the action safely).
  */
 import crypto from 'node:crypto';
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readFileSync as _r } from 'node:fs';
@@ -42,6 +42,12 @@ const INFRA_PATTERNS = [
   { re: /\b(drop\s+table|truncate\s+table|delete\s+from)\b/i, what: 'destructive SQL' },
   { re: /\bsupabase\b[\s\S]*\b(reset|delete|--force)\b/i, what: 'a destructive Supabase operation' },
 ];
+const SAFE_READ_ONLY_PATTERNS = [
+  /^\s*(pwd|date|whoami|id)(\s|$)/i,
+  /^\s*(ls|find|rg|grep|sed|cat|head|tail|wc)\b/i,
+  /^\s*git\s+(status|diff|log|show|branch|rev-parse|remote)(\s|$)/i,
+  /^\s*(node|npm|npx|python3?|go|cargo|gh)\s+(-v|--version|version)(\s|$)/i,
+];
 
 function classifyCommand(cmd) {
   for (const p of MONEY_PATTERNS) {
@@ -62,7 +68,19 @@ function classifyCommand(cmd) {
       };
     }
   }
-  return { actionType: 'low_risk', engine: 'agent-gate', what: 'a low-risk command', decision: GUARD_DECISIONS.ALLOW, reasons: ['No high-risk pattern matched.'], signoffRequired: false };
+  for (const p of SAFE_READ_ONLY_PATTERNS) {
+    if (p.test(cmd)) {
+      return { actionType: 'low_risk', engine: 'agent-gate', what: 'an explicitly read-only command', decision: GUARD_DECISIONS.ALLOW, reasons: ['Matched the read-only allowlist.'], signoffRequired: false };
+    }
+  }
+  return {
+    actionType: 'unclassified_agent_command',
+    engine: 'agent-gate',
+    what: 'an unclassified shell command',
+    decision: GUARD_DECISIONS.ALLOW_WITH_SIGNOFF,
+    reasons: ['Command did not match the read-only allowlist. Fail closed until a human signs off or the classifier is extended.'],
+    signoffRequired: true,
+  };
 }
 
 // ── Tiny canonical JSON (matches lib/guard-policies + @emilia-protocol/verify) ─
@@ -124,8 +142,20 @@ function blockedDecision(d) {
   return d === GUARD_DECISIONS.ALLOW_WITH_SIGNOFF || d === GUARD_DECISIONS.DENY;
 }
 
+function failClosed(message, detail = '') {
+  process.stderr.write(
+    `\n⛔ EMILIA gate: action HELD.\n` +
+    `   ${message}\n` +
+    (detail ? `   ${detail}\n` : '') +
+    `   Exit 2 blocks the tool call until a named human authorizes it.\n`,
+  );
+  process.exit(2);
+}
+
 async function main() {
-  if (process.env.EMILIA_GATE === 'off') process.exit(0);
+  if (process.env.EMILIA_GATE === 'off') {
+    failClosed('EMILIA_GATE=off was requested, but this hook is fail-closed by design.');
+  }
 
   const hookMode = process.argv.includes('--hook');
   let command = arg('--command');
@@ -134,11 +164,11 @@ async function main() {
 
   if (hookMode) {
     let evt = {};
-    try { evt = JSON.parse(readStdin() || '{}'); } catch { process.exit(0); } // fail-open on bad input
+    try { evt = JSON.parse(readStdin() || '{}'); } catch { failClosed('Could not parse the Claude Code hook event.'); }
     if (evt.tool_name && evt.tool_name !== 'Bash') process.exit(0);
     command = evt.tool_input?.command || '';
     subject = 'agent:claude-code';
-    if (!command) process.exit(0);
+    if (!command) failClosed('Bash hook event did not include a command.');
     verdict = classifyCommand(command);
     if (blockedDecision(verdict.decision)) {
       // stderr is fed back to the model; exit 2 blocks the tool call.
@@ -147,7 +177,7 @@ async function main() {
         `   Action:  ${verdict.what}\n` +
         `   Decision: ${verdict.decision} (${verdict.engine})\n` +
         `   ${verdict.reasons.join('\n   ')}\n` +
-        `   A named human must approve before this runs. (Override for this session: EMILIA_GATE=off)\n`,
+        `   A named human must approve before this runs.\n`,
       );
       process.exit(2);
     }
@@ -185,4 +215,4 @@ async function main() {
   process.exit(blockedDecision(verdict.decision) ? 2 : 0);
 }
 
-main().catch(() => process.exit(0)); // fail-open: never deadlock a harness
+main().catch((err) => failClosed('Unhandled gate error.', String(err?.message ?? err)));

--- a/tests/emilia-gate-hook.test.js
+++ b/tests/emilia-gate-hook.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const script = join(root, 'scripts', 'emilia-gate.mjs');
+
+function hook(input, env = {}) {
+  return spawnSync(process.execPath, [script, '--hook'], {
+    cwd: root,
+    input,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+}
+
+describe('scripts/emilia-gate.mjs hook fail-closed behavior', () => {
+  it('holds on malformed hook JSON', () => {
+    const r = hook('{not-json');
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('Could not parse');
+  });
+
+  it('holds when EMILIA_GATE=off is attempted', () => {
+    const r = hook(JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls' } }), { EMILIA_GATE: 'off' });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('fail-closed');
+  });
+
+  it('allows explicitly read-only shell commands', () => {
+    const r = hook(JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'git status --short' } }));
+    expect(r.status).toBe(0);
+  });
+
+  it('holds unclassified shell commands by default', () => {
+    const r = hook(JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'node deploy.js' } }));
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('unclassified shell command');
+  });
+});

--- a/tests/handshake-policy.test.js
+++ b/tests/handshake-policy.test.js
@@ -239,6 +239,15 @@ describe('loadPolicyById', () => {
     expect(result).toBeNull();
   });
 
+  it('scopes by tenant when tenantId is supplied', async () => {
+    const policyRow = { policy_id: 'pol-abc', policy_key: 'strict', tenant_id: 'tenant_1' };
+    const { from: supabaseFrom, chain } = makeSupabaseMock({ data: policyRow });
+    const result = await loadPolicyById({ from: supabaseFrom }, 'pol-abc', { tenantId: 'tenant_1' });
+    expect(result.policy_id).toBe('pol-abc');
+    expect(chain.eq).toHaveBeenCalledWith('policy_id', 'pol-abc');
+    expect(chain.eq).toHaveBeenCalledWith('tenant_id', 'tenant_1');
+  });
+
   it('throws when DB error occurs', async () => {
     const { from: supabaseFrom } = makeSupabaseMock({ error: { message: 'query failed' } });
     await expect(loadPolicyById({ from: supabaseFrom }, 'pol-1'))

--- a/tests/receipt-required-conformance.test.js
+++ b/tests/receipt-required-conformance.test.js
@@ -26,12 +26,13 @@ const TARGETS = [
 describe('Receipt Required conformance — example servers earn level RR-1', () => {
   for (const [tool, action] of TARGETS) {
     it(`${tool}: RR-1 (challenge -> runs -> replay refused -> forged refused)`, async () => {
+      const req = manifest.actions.find((a) => a.match?.protocol === 'mcp' && a.match?.tool === tool);
       const report = await receiptRequiredConformance({
         dispatch: makeGuardedServer({ tool }),
         tool,
         args: { demo: true },
         action,
-        issueReceipt: () => signAction(action, { approver: 'ep:approver:conformance-test' }),
+        issueReceipt: () => signAction(action, { approver: 'ep:approver:conformance-test', quorum: req?.quorum }),
         manifest,
       });
       expect(report.checks.manifest_valid).toBe(true);

--- a/tests/require-receipt-dropin.test.js
+++ b/tests/require-receipt-dropin.test.js
@@ -23,14 +23,14 @@ const canon = (v) => (v === null || v === undefined ? JSON.stringify(v)
     : typeof v === 'object' ? `{${Object.keys(v).sort().map((k) => JSON.stringify(k) + ':' + canon(v[k])).join(',')}}`
       : JSON.stringify(v));
 
-function mint(actionType) {
+function mint(actionType, { outcome = 'allow_with_signoff', extra = {} } = {}) {
   const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
   const pub = publicKey.export({ type: 'spki', format: 'der' }).toString('base64url');
   const payload = {
     receipt_id: 'rcpt_' + crypto.randomBytes(6).toString('hex'),
     subject: 'agent:autonomous',
     created_at: new Date().toISOString(),
-    claim: { action_type: actionType, outcome: 'allow_with_signoff', approver: 'jane@yourco.example' },
+    claim: { action_type: actionType, outcome, approver: 'jane@yourco.example', ...extra },
   };
   const value = crypto.sign(null, Buffer.from(canon(payload), 'utf8'), privateKey).toString('base64url');
   return { '@version': 'EP-RECEIPT-v1', payload, signature: { algorithm: 'Ed25519', value }, public_key: pub };
@@ -65,4 +65,13 @@ test('drop-in passes EMILIA RR-1 (challenge / runs / replay-refused / forged-ref
   expect(report.checks.forged_refused).toBe(true);
   expect(report.passed).toBe(true);
   expect(report.level).toBe('RR-1');
+});
+
+test('drop-in enforces assuranceClass, not only signature/action/replay', async () => {
+  const gate = makeReceiptGate({ action: 'payment.release', allowInlineKey: true, assuranceClass: 'class_a' });
+  let ran = false;
+  const r = await gate.run(mint('payment.release', { outcome: 'allow' }), {}, async () => { ran = true; });
+  expect(r.ok).toBe(false);
+  expect(r.body.rejected.reason).toBe('assurance_too_low');
+  expect(ran).toBe(false);
 });


### PR DESCRIPTION
Closes the findings from the internal red-team pass.

## P0
- **Drop-in gate enforces assurance tier.** `makeReceiptGate` (the zero-dep copy-in + the Eve copy) now derives the receipt's tier and refuses with `assurance_too_low` when it's below the required `assuranceClass`. A single-signer software receipt can no longer satisfy a Class-A / quorum gate.
- **Claude Code hook fails closed.** `scripts/emilia-gate.mjs` now exits 2 (blocks) on unhandled errors, hook-JSON parse failures, missing commands, `EMILIA_GATE=off`, and any command that doesn't match an explicit read-only allowlist — deny-by-default instead of the previous allow-by-default.

## P1
- Python/Go trust-receipt Class-A verification now requires WebAuthn UP+UV (matches JS).
- Cloud policy `diff` / `versions` / `rollout` tenant-scope the initial `policyId` lookup (no cross-tenant read).
- Lightweight gate records assurance tier as `issuer_attestation` rather than implying an independent quorum proof.
- Receipt-Required verifier rejects payloads outside the I-JSON canonicalization profile.
- Quorum demos/tests mint quorum-shaped receipts when the manifest demands quorum.

## Hygiene
- Scrubbed the production Supabase project ref from public docs.
- Added `.env.production` to `.gitignore`.

## Verification
`next build` clean · `npm test` 4516 passed / 29 skipped · lint clean · conformance JS/Python/Go green · pytest 12 · `go test ./...` · `node --test` 82 · changed test files re-run green (vitest 49, node:test 12). Untracked `public/hero/*` assets intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)