### PR TITLE
docs(security): transparency-layer design (consistency proofs + witness cosign) for the trust-receipt log

### DIFF
--- a/docs/security/TRANSPARENCY-LAYER-DESIGN.md
+++ b/docs/security/TRANSPARENCY-LAYER-DESIGN.md
@@ -1,0 +1,293 @@
+# Transparency-Layer Design — Consistency Proofs + Witness Cosignatures for the Trust-Receipt Log
+
+**Status:** Design (accepted threat, staged fix). Optional experimental scaffold shipped alongside.
+**Audit finding:** MED-HIGH — "The trust-receipt log has no transparency mechanism."
+**Owner:** EP protocol / verify.
+**Related standards:** RFC 6962 (Certificate Transparency), RFC 9162 (CT 2.0), IETF SCITT (Transparency Service / Registration Policy), the Sigsum/Go-checkpoint witness-cosignature model.
+**Non-goal of this doc:** re-architecting the Merkle-v2 leaf/branch construction (owned separately). This layer sits *above* the tree and constrains the *log operator*.
+
+---
+
+## 1. The threat, precisely
+
+EP's offline verifier establishes six properties for a Trust Receipt
+(`packages/verify/index.js`, `verifyTrustReceipt`, Step 5 at
+`packages/verify/index.js:911-935`). Two of those — `inclusion` and
+`checkpoint_signature` — are the *only* things standing between a relying party
+and the log operator. Today they reduce to **"the operator's signed word about a
+single point in time."** That is exactly the party the transparency layer must
+constrain, and it is currently unconstrained in three concrete ways.
+
+### 1.1 Single-signer checkpoint — no independent attestation
+
+A checkpoint is `{ log_key_id, root_hash, tree_size, log_signature }`
+(documented at `packages/verify/index.js:464-465`; produced in the fixture at
+`packages/verify/trust-receipt.test.js:129`). Verification is a single Ed25519
+check against **one** pinned log key:
+
+```
+// packages/verify/index.js:921-932
+if (logPublicKey && lp.checkpoint.log_signature) {
+  const signedCheckpoint = { ...lp.checkpoint };
+  delete signedCheckpoint.log_signature;
+  checks.checkpoint_signature = verifyEd25519OverDigest(
+    String(lp.checkpoint.log_signature).replace(/^b64u:/, ''),
+    sha256Bytes(canonicalize(signedCheckpoint)),
+    logPublicKey,
+  );
+}
+```
+
+The operator holds `log_key`. Nothing else co-attests the checkpoint. If the key
+is compromised or the operator is malicious, a valid `log_signature` can be
+minted over **any** `(root_hash, tree_size)` pair the operator likes.
+
+### 1.2 No consistency proof between checkpoints — undetectable equivocation / split view
+
+There is no notion of "checkpoint B is an append-only extension of checkpoint A"
+anywhere in the verify packages. `grep -riE
+'consistency|witness|cosign|gossip|split-view|equivocat' packages/verify/
+go-verify/ python-verify/` returns **zero** functional hits (only an unrelated
+`inconsistency` mention in a doc comment at `packages/verify/index.d.ts:190`).
+
+Consequence: a malicious operator can maintain **two forked histories** and
+present each to a different audience. Verifier A is shown a tree in which
+receipt R was committed; verifier B is shown a same-size or larger tree in which
+R never existed (or was replaced). Both trees are internally valid — each has a
+correctly-signed checkpoint and a correct inclusion proof for whatever the
+operator wants that verifier to believe. Because no verifier ever demands proof
+that one checkpoint *extends* another, the fork is invisible offline. This is
+the classic **split-view / equivocation** attack that RFC 6962 consistency
+proofs exist to make detectable.
+
+### 1.3 Empty `inclusion_path` accepted as a single-leaf tree
+
+`verifyMerkleAnchor` (`packages/verify/index.js:235-250`) walks the proof steps
+and returns `current === expectedRoot`. With an **empty** `inclusion_path`, the
+loop body never runs and it collapses to `leafHash === expectedRoot`:
+
+```
+// packages/verify/index.js:242-249
+let current = leafHash;
+for (const step of proof) { ... }   // skipped when proof == []
+return current === expectedRoot;
+```
+
+Step 5 reaches this whenever `Array.isArray(lp.inclusion_path)` is true
+(`packages/verify/index.js:913`) — and `[]` **is** an array. So an operator can
+publish a checkpoint whose `root_hash` equals a single receipt's `leaf_hash`
+(`root_hash = leaf_hash`, `tree_size = 1`), sign it, and the receipt verifies
+against a **degenerate one-leaf tree** with no siblings and no witnesses. This
+is the cheapest form of the §1.1/§1.2 attack: a per-receipt tree of size 1 has
+no history to be consistent with and nothing to gossip, so it *maximally*
+reduces the log to "the operator's signature." Strict mode requires
+`inclusion_path` to be *present* (`packages/verify/index.js:671-674`) but not
+*non-empty*, so it does not close this.
+
+### 1.4 Net effect
+
+`inclusion proof + one operator signature ≈ the operator's word`. This directly
+undercuts EP's headline offline/trustless claim *against the single party the
+claim most needs to bind* — the log operator. A relying party who verifies a
+receipt "fully offline, no EP infrastructure" today is still trusting the
+operator not to equivocate. The audit is correct to rate this MED-HIGH.
+
+---
+
+## 2. The fix
+
+Four mechanisms, layered. (a) and (c) are cheap and local to the verifier; (b)
+is the decisive control against equivocation; (d) is operational hardening.
+
+### 2.1 (a) RFC 6962-style checkpoint CONSISTENCY proofs
+
+Add an append-only proof between any two checkpoints of the same log. A
+consistency proof between `(oldRoot, oldSize)` and `(newRoot, newSize)` proves
+that the newer tree is a **prefix-preserving extension** of the older one —
+nothing already committed was removed or rewritten (RFC 6962 §2.1.2, RFC 9162
+§2.1.4).
+
+- **Verifier:** `verifyCheckpointConsistency(oldRoot, oldSize, newRoot, newSize,
+  proof)` — shipped as an experimental standalone module in this PR
+  (`packages/verify/consistency.js`), using the same EP-MERKLE-v2
+  domain-separated branch hash (`0x01 || left || right`) as `hashPairV2` in
+  `index.js` so proofs compose with the existing v2 inclusion proofs.
+- **What it buys:** if a relying party pins *any* prior honest checkpoint (or
+  obtains one from a witness / gossip peer), it can demand that every later
+  checkpoint be consistent with it. A forked history cannot produce a valid
+  consistency proof to a checkpoint it forked away from — the fork becomes
+  detectable with pure math, offline. This is the primitive that makes §1.2
+  detectable rather than invisible.
+- **Wire format (proposed):** add to `log_proof`:
+  ```jsonc
+  "consistency": {
+    "from": { "tree_size": 1024, "root_hash": "sha256:...", "log_signature": "b64u:..." },
+    "proof": ["sha256:...", "sha256:..."]   // ordered RFC 6962 nodes
+  }
+  ```
+  `from` is a previously-published, signed checkpoint (ideally one the verifier
+  or a witness already holds). `proof` verifies `from → checkpoint`.
+
+### 2.2 (b) WITNESS cosignature model — the decisive control against split-view
+
+Consistency proofs prove append-only **relative to a checkpoint the verifier
+trusts**; they do not, by themselves, stop an operator who shows *every* verifier
+its own private consistent chain. The fix for equivocation is **independent
+witnesses**.
+
+- **Model (Sigsum / Go-checkpoint / IETF Networking):** N independent witness
+  operators each (i) hold the log's public key, (ii) receive each new
+  checkpoint, (iii) verify it is consistent with the last checkpoint *they*
+  cosigned, and (iv) emit a cosignature over the checkpoint. A witness will only
+  ever cosign **one** checkpoint per tree size, because it enforces consistency
+  against its own view. Therefore, if the operator equivocates (two checkpoints
+  at the same or overlapping size that are not consistent), it cannot get the
+  **same** witness to cosign both.
+- **Verifier rule:** require `≥ k` distinct valid witness cosignatures (k-of-N)
+  on the checkpoint, in addition to the operator's `log_signature`. A split view
+  now requires corrupting ≥ k independent witnesses simultaneously, not just the
+  operator's one key.
+- **Wire format (proposed):** add to `checkpoint`:
+  ```jsonc
+  "witness_cosignatures": [
+    { "witness_key_id": "ep:witness:a#1", "signature": "b64u:..." },
+    { "witness_key_id": "ep:witness:b#1", "signature": "b64u:..." }
+  ]
+  ```
+  Each cosignature is Ed25519 over the **same** canonical checkpoint bytes the
+  operator signed (`canonicalize({log_key_id, root_hash, tree_size})`), against a
+  witness key the verifier pins the same way it pins `logPublicKey`. A verifier
+  is configured with a witness set + threshold `k`.
+
+### 2.3 (c) Reject empty / degenerate inclusion paths
+
+Independent of (a)/(b), the verifier must stop treating `inclusion_path === []`
+as a valid single-leaf tree (§1.3). Proposed rule for a *future, additive*
+strict-plus mode (not a silent change to the frozen Section 6.3 checks):
+
+- Reject `inclusion_path.length === 0` **unless** `checkpoint.tree_size === 1`
+  **and** that size-1 checkpoint carries the required witness cosignatures. A
+  size-1 tree is legitimate only for the very first entry; requiring witnesses
+  removes its value as an equivocation shortcut.
+- More conservatively for high-assurance receipts: **require a non-empty
+  inclusion path** (i.e. `tree_size ≥ 2`), forcing every anchored receipt to
+  live in a shared tree with real siblings and a real history.
+
+This is a behavioral change to acceptance criteria and therefore belongs behind
+an opt-in flag / new check name, not inside the existing `checks.inclusion`.
+
+### 2.4 (d) Gossip and checkpoint pinning
+
+Operational layer that makes (a)/(b) effective in practice:
+
+- **Checkpoint pinning:** relying parties persist the highest checkpoint they
+  have verified (per log) and refuse any later checkpoint that is not consistent
+  with it (uses (a)). This gives *each* verifier a personal append-only guarantee
+  even without witnesses.
+- **Gossip:** verifiers, witnesses, and monitors exchange checkpoints
+  out-of-band (e.g. a public checkpoint feed, or piggy-backed on unrelated
+  traffic). If any two participants ever hold two inconsistent checkpoints for
+  the same log, the fork is exposed. Gossip turns a *local* pin into a *global*
+  equivocation detector.
+- **Monitors:** long-running third parties that fetch every checkpoint, verify
+  consistency, and raise an alarm on any gap or fork (the CT "monitor" role).
+
+---
+
+## 3. Recommended minimum viable design (what to ship first)
+
+Ship in this order; each step is independently valuable and additive.
+
+1. **MVP-1 — Consistency-proof verify (this PR, experimental):**
+   `verifyCheckpointConsistency()` lands standalone in
+   `packages/verify/consistency.js` with tests. Not wired into the main verifier
+   yet. This gives tooling, witnesses, and monitors the primitive immediately and
+   lets us pin checkpoints (§2.4) in relying-party code with zero risk to the
+   frozen Section 6.3 algorithm.
+
+2. **MVP-2 — Require witness cosignatures on high-assurance receipts:** add
+   `witness_cosignatures` to the checkpoint and a `k-of-N` witness check to an
+   **opt-in** verifier mode (`opts.witnessKeys`, `opts.witnessThreshold`),
+   surfaced as a new check name (e.g. `checks.witness_quorum`) — never a silent
+   reinterpretation of `checkpoint_signature`. Gate it on assurance tier so
+   low-stakes receipts are unaffected during rollout. **This is the decisive
+   control** and is the reason (b) is prioritized over (c)/(d) once the primitive
+   from MVP-1 exists.
+
+3. **MVP-3 — Reject degenerate inclusion paths** (§2.3) behind the same opt-in
+   high-assurance mode, once witnesses are available to legitimize the rare
+   real size-1 case.
+
+4. **MVP-4 — Gossip / monitor tooling** (§2.4): a checkpoint feed + a monitor
+   that verifies consistency continuously. Operational, not on the verifier's
+   critical path.
+
+**Rationale for the ordering:** consistency verify (MVP-1) is the reusable
+primitive everything else needs and carries no behavioral risk, so it ships
+first. Witness cosignatures (MVP-2) are what actually defeat equivocation, so
+they are the first *enforcement* change. Empty-path rejection (MVP-3) depends on
+witnesses to avoid breaking the legitimate first-entry case. Gossip (MVP-4) is
+defense-in-depth that amplifies the earlier layers.
+
+---
+
+## 4. Migration path
+
+- **Additive, versioned, opt-in.** The frozen Section 6.3 `checks`
+  (`packages/verify/index.js:797-805`) are **not** renamed or reinterpreted. New
+  guarantees appear as *new* checks and *new* opt-in verifier options, exactly
+  like `strict` mode (`packages/verify/index.js:964-969`) and the advisory
+  `attestation` report were added.
+- **Backward compatibility.** Receipts without `consistency` /
+  `witness_cosignatures` continue to verify under the existing checks. A relying
+  party opts into the stronger guarantees by pinning a witness set + threshold;
+  until then behavior is unchanged. "Receipts verify forever" is preserved.
+- **Issuer rollout.** (1) Stand up N witnesses and a checkpoint feed. (2) Issuer
+  starts emitting `consistency` proofs and gathering witness cosignatures. (3)
+  High-assurance policies flip on `witnessThreshold` and empty-path rejection.
+  (4) Monitors run continuously. Each stage is independently deployable.
+- **Ownership note.** MVP-2/3 touch `verifyTrustReceipt`, which is owned by the
+  Merkle-v2 track. This doc + MVP-1 are the additive, non-conflicting first step;
+  wiring is a follow-up coordinated with that owner.
+
+---
+
+## 5. Standards mapping (credibility)
+
+| EP mechanism | Standard / prior art | Notes |
+| --- | --- | --- |
+| Merkle inclusion proof | RFC 6962 §2.1.1 / RFC 9162 §2.1.3 | Already present (`verifyMerkleAnchor`). |
+| Checkpoint consistency proof | **RFC 6962 §2.1.2 / RFC 9162 §2.1.4** | Implemented in `consistency.js` (this PR). |
+| Signed checkpoint / signed tree head | RFC 6962 STH; Sigsum/Go "checkpoint" | EP `checkpoint` + `log_signature`. |
+| Witness cosignatures (k-of-N) | Sigsum witness model; Go-checkpoint cosigned notes; IETF witness drafts | Proposed §2.2. Defeats split-view. |
+| Gossip / monitors | RFC 6962 gossip; CT monitors | Proposed §2.4. |
+| Transparency Service as a whole | **IETF SCITT** (Transparency Service, Registration Policy, Receipt) | EP's log is a SCITT-style Transparency Service; a witness-cosigned, consistency-proven checkpoint is a stronger SCITT Receipt. See `docs/EP-RECEIPT-SCITT-PROFILE.md`. |
+
+Positioning: EP already claims a SCITT-aligned receipt profile. SCITT's value
+proposition is a *verifiable, non-equivocating* Transparency Service; without
+consistency proofs + witnesses, EP's log meets the *format* but not the
+*non-equivocation* bar. This design closes that gap and lets EP say — credibly,
+to a DoD auditor — that the offline verifier constrains the log operator with
+the same mechanisms CT uses to constrain CAs.
+
+---
+
+## 6. Appendix — experimental scaffold shipped with this design
+
+`packages/verify/consistency.js` (EXPERIMENTAL, not wired into
+`verifyTrustReceipt`):
+
+- `verifyCheckpointConsistency(oldRoot, oldSize, newRoot, newSize, proof)` —
+  RFC 6962 §2.1.2 verifier over EP-MERKLE-v2 branch hashing; fail-closed on
+  malformed input; accepts `sha256:`-prefixed hashes.
+- `buildConsistencyProof(m, n, leaves)` / `merkleRoot(leaves)` — reference
+  prover + root for tests, tooling, and witnesses.
+
+Tests: `packages/verify/consistency.test.js` (run `node --test
+consistency.test.js`) — exhaustive round-trip for all `1 ≤ m ≤ n ≤ 16`, plus
+explicit **rejection** of a rewritten prefix (split-view), tampered proof nodes,
+wrong old root, and malformed inputs.
+
+The module is intentionally **not** re-exported from `packages/verify/index.js`
+and **not** added to the `package.json` test script — it is design-stage
+reference code, gated behind the MVP-2 coordination described in §4.

--- a/packages/verify/consistency.js
+++ b/packages/verify/consistency.js
@@ -1,0 +1,189 @@
+/**
+ * @emilia-protocol/verify — Checkpoint CONSISTENCY proofs (EXPERIMENTAL)
+ *
+ * ⚠️  DESIGN-STAGE / EXPERIMENTAL — NOT wired into verifyTrustReceipt() yet.
+ *
+ * This module addresses the DoD-audit MED-HIGH transparency finding: a trust
+ * receipt today carries a SINGLE-signer checkpoint {log_key_id, root_hash,
+ * tree_size, log_signature} and NO append-only (consistency) proof between
+ * checkpoints. A malicious log operator can therefore present two different,
+ * internally-consistent histories to two verifiers (a "split view" /
+ * equivocation) and neither can detect it offline. See
+ * docs/security/TRANSPARENCY-LAYER-DESIGN.md for the full threat + fix design.
+ *
+ * A consistency proof (RFC 6962 §2.1.2 / RFC 9162 §2.1.4) proves that the log
+ * of size `newSize` with root `newRoot` is an APPEND-ONLY extension of the log
+ * of size `oldSize` with root `oldRoot` — i.e. nothing already committed was
+ * removed or rewritten. Combined with witness cosignatures + gossip (see the
+ * design doc), it converts "the operator's word" into a cryptographically
+ * enforced, non-equivocable history.
+ *
+ * DOMAIN SEPARATION: this uses the EP-MERKLE-v2 branch construction
+ * (SHA-256(0x01 || left || right), hex) so it composes with the v2 inclusion
+ * proofs already verified by verifyMerkleAnchor(..., { v2: true }) in index.js.
+ * It is intentionally standalone and additive — index.js is unchanged.
+ *
+ * @license Apache-2.0
+ */
+
+import crypto from 'crypto';
+
+export const CONSISTENCY_ALG = 'EP-MERKLE-v2';
+
+const HASH_PREFIX = /^sha256:/i;
+
+function hexOf(h) {
+  return String(h || '').replace(HASH_PREFIX, '').toLowerCase();
+}
+
+// EP-MERKLE-v2 branch hash: SHA-256(0x01 || leftHex || rightHex) -> hex.
+// Byte-identical to hashPairV2() in index.js (kept in sync deliberately; this
+// module does not import it, to remain standalone and additive).
+function hashChildrenV2(left, right) {
+  return crypto
+    .createHash('sha256')
+    .update(Buffer.concat([Buffer.from([0x01]), Buffer.from(left, 'utf8'), Buffer.from(right, 'utf8')]))
+    .digest('hex');
+}
+
+function isPowerOfTwo(n) {
+  return n > 0 && (n & (n - 1)) === 0;
+}
+
+// Largest power of two strictly less than n (RFC 6962 helper). n >= 2.
+function largestPowerOfTwoLessThan(n) {
+  let k = 1;
+  while (k * 2 < n) k *= 2;
+  return k;
+}
+
+/**
+ * Verify an RFC 6962 §2.1.2 checkpoint consistency proof between two tree
+ * states of the SAME append-only log.
+ *
+ * Proves: the size-`newSize` tree (root `newRoot`) is a prefix-preserving
+ * append-only extension of the size-`oldSize` tree (root `oldRoot`).
+ *
+ * @param {string} oldRoot  hex (or "sha256:"-prefixed hex) root at oldSize
+ * @param {number} oldSize  tree size m, 0 < oldSize <= newSize
+ * @param {string} newRoot  hex (or "sha256:"-prefixed hex) root at newSize
+ * @param {number} newSize  tree size n
+ * @param {string[]} proof  ordered consistency-proof node hashes (hex or
+ *                          "sha256:"-prefixed). Empty iff oldSize === newSize.
+ * @returns {boolean} true iff the proof shows an append-only extension.
+ */
+export function verifyCheckpointConsistency(oldRoot, oldSize, newRoot, newSize, proof) {
+  // ── Input validation (fail-closed) ─────────────────────────────────────────
+  if (!Number.isInteger(oldSize) || !Number.isInteger(newSize)) return false;
+  if (oldSize < 0 || newSize < 0 || oldSize > newSize) return false;
+  if (!Array.isArray(proof)) return false;
+  if (proof.length > 64) return false; // 2^64 leaves is far beyond any real log
+  const oldR = hexOf(oldRoot);
+  const newR = hexOf(newRoot);
+  if (!oldR || !newR) return false;
+
+  // Equal sizes: the only consistent proof is the empty one, and roots must match.
+  if (oldSize === newSize) {
+    return proof.length === 0 && oldR === newR;
+  }
+  // The empty tree is a prefix of everything and RFC 6962 emits no proof, but
+  // its root is undefined. EP checkpoints never start below size 1, so treat
+  // oldSize 0 as a caller error to stay fail-closed.
+  if (oldSize === 0) return false;
+  if (proof.length === 0) return false;
+
+  const path = proof.map(hexOf);
+  if (path.some((h) => !h)) return false;
+
+  // ── RFC 6962 §2.1.2 verification algorithm ──────────────────────────────────
+  // If oldSize is an exact power of two, the reference algorithm implicitly
+  // seeds both hash chains with the old root; otherwise the first proof node is
+  // the shared seed.
+  let node = path;
+  let seed;
+  if (isPowerOfTwo(oldSize)) {
+    seed = oldR;
+  } else {
+    seed = node[0];
+    node = node.slice(1);
+  }
+
+  let fn = oldSize - 1;
+  let sn = newSize - 1;
+  // Shift out the common lower bits (identical right-spine structure).
+  while (fn % 2 === 1) {
+    fn = Math.floor(fn / 2);
+    sn = Math.floor(sn / 2);
+  }
+
+  let fr = seed; // running hash toward oldRoot
+  let sr = seed; // running hash toward newRoot
+
+  for (const c of node) {
+    if (sn === 0) return false; // proof longer than the tree geometry allows
+    if (fn % 2 === 1 || fn === sn) {
+      fr = hashChildrenV2(c, fr);
+      sr = hashChildrenV2(c, sr);
+      while (fn % 2 === 0 && fn !== 0) {
+        fn = Math.floor(fn / 2);
+        sn = Math.floor(sn / 2);
+      }
+    } else {
+      sr = hashChildrenV2(sr, c);
+    }
+    fn = Math.floor(fn / 2);
+    sn = Math.floor(sn / 2);
+  }
+
+  // Both reconstructed roots must match their claimed values, and the proof
+  // must have exactly consumed the tree (sn drained to 0).
+  return sn === 0 && fr === oldR && sr === newR;
+}
+
+/**
+ * Reference PROVER (test/tooling helper): build the RFC 6962 consistency proof
+ * between two sizes of a log given all its leaf hashes. EXPERIMENTAL. Not used
+ * by any verifier — provided so the verifier can be tested against a
+ * spec-faithful prover, and so tooling/witnesses can generate proofs.
+ *
+ * @param {number} m  old size (1 <= m <= n)
+ * @param {number} n  new size
+ * @param {string[]} leaves  at least n leaf hashes (hex), index 0..n-1
+ * @returns {string[]} ordered proof node hashes (hex)
+ */
+export function buildConsistencyProof(m, n, leaves) {
+  if (!Array.isArray(leaves) || leaves.length < n) {
+    throw new Error('buildConsistencyProof: need at least n leaf hashes');
+  }
+  if (!(m >= 1 && m <= n)) throw new Error('buildConsistencyProof: require 1 <= m <= n');
+  if (m === n) return [];
+  return subproof(m, leaves.slice(0, n).map(hexOf), true);
+}
+
+// RFC 6962 §2.1.2 SUBPROOF(m, D[0:n], b).
+function subproof(m, d, b) {
+  const n = d.length;
+  if (m === n) {
+    return b ? [] : [merkleRoot(d)];
+  }
+  const k = largestPowerOfTwoLessThan(n);
+  if (m <= k) {
+    return [...subproof(m, d.slice(0, k), b), merkleRoot(d.slice(k, n))];
+  }
+  return [...subproof(m - k, d.slice(k, n), false), merkleRoot(d.slice(0, k))];
+}
+
+/**
+ * Reference MERKLE ROOT over EP-MERKLE-v2 branch hashing (test/tooling helper).
+ * Leaves are assumed to already be leaf hashes (hex). EXPERIMENTAL.
+ *
+ * @param {string[]} leaves  leaf hashes (hex)
+ * @returns {string} root hash (hex)
+ */
+export function merkleRoot(leaves) {
+  const d = leaves.map(hexOf);
+  if (d.length === 0) throw new Error('merkleRoot: empty tree has no defined EP root');
+  if (d.length === 1) return d[0];
+  const k = largestPowerOfTwoLessThan(d.length);
+  return hashChildrenV2(merkleRoot(d.slice(0, k)), merkleRoot(d.slice(k)));
+}

--- a/packages/verify/consistency.test.js
+++ b/packages/verify/consistency.test.js
@@ -1,0 +1,117 @@
+/**
+ * Tests for the EXPERIMENTAL checkpoint consistency verifier (RFC 6962 §2.1.2).
+ *
+ * These prove the verifier accepts genuine append-only extensions and REJECTS
+ * the equivocation / history-rewrite attacks described in
+ * docs/security/TRANSPARENCY-LAYER-DESIGN.md. Run:  node --test consistency.test.js
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'crypto';
+import {
+  verifyCheckpointConsistency,
+  buildConsistencyProof,
+  merkleRoot,
+} from './consistency.js';
+
+// Deterministic v2 leaf hashes (0x00 || content) — matches leafHashV2 in index.js.
+function leaf(content) {
+  return crypto
+    .createHash('sha256')
+    .update(Buffer.concat([Buffer.from([0x00]), Buffer.from(content, 'utf8')]))
+    .digest('hex');
+}
+
+function leaves(n) {
+  return Array.from({ length: n }, (_, i) => leaf(`receipt-${i}`));
+}
+
+// Exhaustive round-trip: for every 1 <= m <= n <= 16, a genuine extension verifies.
+test('genuine append-only extensions verify for all 1<=m<=n<=16', () => {
+  for (let n = 1; n <= 16; n++) {
+    const all = leaves(n);
+    const newRoot = merkleRoot(all);
+    for (let m = 1; m <= n; m++) {
+      const oldRoot = merkleRoot(all.slice(0, m));
+      const proof = buildConsistencyProof(m, n, all);
+      assert.equal(
+        verifyCheckpointConsistency(oldRoot, m, newRoot, n, proof),
+        true,
+        `expected consistent proof to verify for m=${m}, n=${n}`,
+      );
+    }
+  }
+});
+
+test('equal sizes: empty proof + equal roots verifies; mismatched roots fail', () => {
+  const all = leaves(5);
+  const root = merkleRoot(all);
+  assert.equal(verifyCheckpointConsistency(root, 5, root, 5, []), true);
+  assert.equal(verifyCheckpointConsistency(root, 5, merkleRoot(leaves(6)), 5, []), false);
+  // Equal size but a non-empty proof is illegal.
+  assert.equal(verifyCheckpointConsistency(root, 5, root, 5, [leaf('x')]), false);
+});
+
+test('accepts sha256: hash prefixes on roots and proof nodes', () => {
+  const all = leaves(7);
+  const oldRoot = merkleRoot(all.slice(0, 3));
+  const newRoot = merkleRoot(all);
+  const proof = buildConsistencyProof(3, 7, all).map((h) => `sha256:${h}`);
+  assert.equal(
+    verifyCheckpointConsistency(`sha256:${oldRoot}`, 3, `SHA256:${newRoot}`, 7, proof),
+    true,
+  );
+});
+
+// ── ATTACK: history rewrite / split view ────────────────────────────────────
+// The core threat. Operator shows verifier A a size-3 log, then to verifier B a
+// size-6 log whose first 3 leaves DIFFER. No consistency proof can bridge them.
+test('rejects a rewritten prefix (split-view / equivocation)', () => {
+  const honest = leaves(6);
+  const oldRoot = merkleRoot(honest.slice(0, 3));
+
+  // Fork: same length, but leaf 1 was swapped out — a different history.
+  const forked = [...honest];
+  forked[1] = leaf('rewritten-receipt-1');
+  const forkedNewRoot = merkleRoot(forked);
+
+  // Try every proof the honest prover could produce; none should validate the fork.
+  const honestProof = buildConsistencyProof(3, 6, honest);
+  assert.equal(verifyCheckpointConsistency(oldRoot, 3, forkedNewRoot, 6, honestProof), false);
+
+  // And the honest new root cannot be reached from the forked old prefix root.
+  const forkedOldRoot = merkleRoot(forked.slice(0, 3));
+  const honestNewRoot = merkleRoot(honest);
+  assert.equal(verifyCheckpointConsistency(forkedOldRoot, 3, honestNewRoot, 6, honestProof), false);
+});
+
+test('rejects a tampered proof node', () => {
+  const all = leaves(9);
+  const oldRoot = merkleRoot(all.slice(0, 4));
+  const newRoot = merkleRoot(all);
+  const proof = buildConsistencyProof(4, 9, all);
+  const tampered = [...proof];
+  tampered[0] = leaf('not-the-node');
+  assert.equal(verifyCheckpointConsistency(oldRoot, 4, newRoot, 9, tampered), false);
+});
+
+test('rejects a proof for the wrong old root', () => {
+  const all = leaves(8);
+  const newRoot = merkleRoot(all);
+  const proof = buildConsistencyProof(5, 8, all);
+  const wrongOld = merkleRoot(leaves(5).map((h, i) => (i === 0 ? leaf('different') : h)));
+  assert.equal(verifyCheckpointConsistency(wrongOld, 5, newRoot, 8, proof), false);
+});
+
+// ── Fail-closed input validation ────────────────────────────────────────────
+test('fail-closed on malformed inputs', () => {
+  const all = leaves(4);
+  const root = merkleRoot(all);
+  assert.equal(verifyCheckpointConsistency(root, 5, root, 4, []), false, 'oldSize > newSize');
+  assert.equal(verifyCheckpointConsistency(root, 1.5, root, 4, []), false, 'non-integer size');
+  assert.equal(verifyCheckpointConsistency(root, 0, root, 4, []), false, 'oldSize 0 rejected');
+  assert.equal(verifyCheckpointConsistency('', 1, root, 4, []), false, 'empty old root');
+  assert.equal(verifyCheckpointConsistency(root, 2, root, 4, 'nope'), false, 'proof not array');
+  assert.equal(verifyCheckpointConsistency(root, 2, root, 4, []), false, 'growth with empty proof');
+});


### PR DESCRIPTION
## DoD audit — MED-HIGH transparency finding

The trust-receipt log has **no transparency mechanism**: no consistency proof between checkpoints, no witness cosignature, no split-view/equivocation detection. A malicious log operator holding the log key can sign a single-leaf checkpoint (`root_hash = leaf_hash`) for any receipt and show different verifiers different histories. `inclusion proof + one operator signature ≈ "the operator's word"` — which undercuts the offline/trustless claim against the one party it must constrain.

`grep -riE 'consistency|witness|cosign|gossip|split-view|equivocat'` over the verify packages returns 0 functional hits.

## What this delivers (design + optional experimental scaffold)

**Design doc — `docs/security/TRANSPARENCY-LAYER-DESIGN.md`:**
- The threat precisely, with exact `file:line` loci:
  - single-signer checkpoint (`packages/verify/index.js:921-932`, `:464-465`)
  - empty `inclusion_path` accepted as a single-leaf tree (`verifyMerkleAnchor`, `packages/verify/index.js:235-250`; reached at `:913`)
  - no consistency proof anywhere → undetectable equivocation
- The fix: (a) RFC 6962 consistency proofs + verifier, (b) k-of-N **witness cosignature** model (the decisive split-view control), (c) reject degenerate inclusion paths, (d) gossip / checkpoint-pinning.
- **Recommended MVP** + migration path (additive, opt-in, frozen Section 6.3 checks untouched — same pattern as `strict` mode).
- Standards mapping to RFC 6962 / RFC 9162 / IETF SCITT for credibility.

**Experimental scaffold (additive, NOT wired into the main verifier):**
- `packages/verify/consistency.js` — standalone `verifyCheckpointConsistency(oldRoot, oldSize, newRoot, newSize, proof)` (RFC 6962 §2.1.2) over the same EP-MERKLE-v2 domain-separated branch hashing as `hashPairV2`; plus reference prover/root helpers. Marked EXPERIMENTAL, not re-exported from `index.js`, not in the `package.json` test script.
- `packages/verify/consistency.test.js` — 7 tests, all green: exhaustive round-trip for all `1 ≤ m ≤ n ≤ 16`, and explicit **rejection** of split-view / rewritten-prefix, tampered proof nodes, wrong old root, and malformed inputs.

## Scope discipline
`packages/verify/index.js`, `packages/issue`, `go-verify`, and `python-verify` are **untouched** (Merkle-v2 agent owns those). This is purely additive.

## Verification
- `npm run build` (next build) — passes (exit 0).
- `node --test packages/verify/consistency.test.js` — 7/7 pass.
- Full existing verify suite (`npm test` in `packages/verify`) — 99/99 pass, unchanged.

## Recommended MVP
1. **MVP-1 (this PR):** ship the consistency-proof verifier standalone — the primitive witnesses/monitors/pinning all need, zero behavioral risk.
2. **MVP-2:** require **k-of-N witness cosignatures** on high-assurance checkpoints (new opt-in check `witness_quorum`) — the decisive equivocation defense.
3. **MVP-3:** reject empty/degenerate inclusion paths behind the same high-assurance mode.
4. **MVP-4:** gossip + monitor tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>