### PR TITLE
EMILIA↔Capsule who→what seam vector (shared digest, testable)

### DIFF
--- a/docs/EP-CAPSULE-SEAM.md
+++ b/docs/EP-CAPSULE-SEAM.md
@@ -1,0 +1,47 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# EMILIA ↔ Agent Action Capsule — the who → what seam
+
+A shared, byte-reproducible interop vector that threads **one action's digest**
+through the seam between an EMILIA authorization receipt (**WHO** approved) and
+Steven Mih's Agent Action Capsule (**WHAT** was done). The linkage is
+composed **by digest, not containment**: the Capsule commits to the approval
+without restating it; the approval evidence lives in the EMILIA receipt.
+
+- Generator + verifier: [`examples/scitt/capsule-seam-vector.mjs`](../examples/scitt/capsule-seam-vector.mjs) — `node examples/scitt/capsule-seam-vector.mjs`
+- Frozen vector: [`examples/scitt/capsule-seam-vector.json`](../examples/scitt/capsule-seam-vector.json)
+- EP receipt as a SCITT Signed Statement: [`EP-RECEIPT-SCITT-PROFILE.md`](./EP-RECEIPT-SCITT-PROFILE.md)
+
+## The chain
+`permit / agentroa (CAN)` → **EMILIA receipt (WHO approved)** → `Capsule (WHAT was done)` → `GAR (audit log)` — complementary SCITT statement profiles over one transparency service, each independently verifiable, composed by shared digest.
+
+## Two digests — keep them distinct
+Everything is **RFC 8785 (JCS)** canonical + **SHA-256**, so both are recomputable in any language.
+
+1. **`subject_digest` — the exact action both statements are ABOUT.**
+   `subject_digest = SHA-256( JCS(action) )`.
+   The Capsule's subject and the EMILIA receipt's claim are over the **same** action; matching this digest proves both refer to the same operation.
+
+2. **`authority_reference_digest` — the WHO evidence the Capsule points at.**
+   The Capsule embeds this in its **opaque authority reference** to commit to the approval:
+   - `receipt_payload_digest = SHA-256( JCS(receipt.payload) )` — offline composition.
+   - `statement_digest = SHA-256( COSE_Sign1 bytes )` — when the receipt is registered as a SCITT Signed Statement (recommended in a transparency deployment).
+
+   Pin **one** of these per deployment so both implementations bind identical bytes. The vector supplies both.
+
+## Verdict-complete (the case auditors care about)
+A **denied / absent** human approval is itself a signed EP event. The vector ships an `approved` and a `denied` receipt; a Capsule can commit to a denied receipt's digest exactly as it commits to an approved one, so the who → what linkage holds for refusals too.
+
+## What the vector gives the Capsule side
+From `capsule-seam-vector.json`:
+- `issuer.spki_der_b64` + `issuer.kid_hex` — verify the EP Ed25519 signature offline.
+- `action` + `subject_digest` — the shared subject.
+- `approved` / `denied`: `payload_canonical` (exact JCS bytes), `native_signature_b64`, `cose_sign1_b64`, `receipt_payload_digest`, `statement_digest`.
+
+**Capsule-side test:** build a Capsule over the same `subject_digest`, put the chosen `authority_reference_digest` in the opaque authority reference, and confirm a verifier can (a) recompute `subject_digest` from the action, (b) resolve the authority reference to this EP receipt, and (c) verify the EP signature over `payload_canonical`. That closes who → what **testably**, not by assertion.
+
+## Three questions "authorization" blurs
+Agent identity/discovery ("which agent, where") ≠ machine/scope permission (permit/agentroa, **CAN**) ≠ accountable-human approval of the exact action (**EMILIA, WHO**). This seam is only the WHO → WHAT edge.
+
+## Notes
+- The vector's issuer key is derived from a **fixed seed** for reproducibility — a demo/interop key, **not** a production issuer.
+- Standards context: SCITT (COSE_Sign1 Signed Statements, SCRAPI), RFC 8785 (JCS), RFC 9162 / RFC 6962 (transparency).

--- a/examples/scitt/capsule-seam-vector.json
+++ b/examples/scitt/capsule-seam-vector.json
@@ -1,0 +1,69 @@
+{
+  "vector": "EP<->Capsule seam vector v1",
+  "spec": "docs/EP-CAPSULE-SEAM.md",
+  "canonicalization": "RFC 8785 (JCS) over the EP I-JSON value subset; SHA-256 for all digests",
+  "issuer": {
+    "alg": "Ed25519 (COSE EdDSA -8)",
+    "spki_der_b64": "MCowBQYDK2VwAyEAmz+PjEC2DzV6Y0PuLdnyzHwPA+HcgJ48EORHo57k8aE=",
+    "kid_hex": "fc75a255e78f5b4371376b76ce813cd8",
+    "note": "demo/interop vector key derived from a fixed seed — NOT a production issuer"
+  },
+  "action": {
+    "action_type": "payment.release",
+    "target": "wire:vendor-acme-250000",
+    "amount": "250000.00",
+    "currency": "USD"
+  },
+  "subject_digest": "fd7887f2f7b0ec9c9ed06ef42f62e21b3b119bdfb13728b9eaea6e5ef28273b3",
+  "authority_reference": {
+    "rule": "A Capsule commits to the approval by embedding one of these digests in its opaque authority reference. Recommend statement_digest when the receipt is registered as a SCITT Signed Statement; receipt_payload_digest for offline composition.",
+    "approved": {
+      "receipt_payload_digest": "e37000ae3366ce7d9ccddcce1e2fe8cc658339ef7e1a0e9d9f6aac86281580d7",
+      "statement_digest": "141ea80006127f57d10c0b5104cfae1bfce52d851d8c9c8faae4fcf38b4e988f"
+    },
+    "denied": {
+      "receipt_payload_digest": "3ec7b1742fa887d9fff06b06142298aaace5481d01b623bd3fa27c1a7f641020",
+      "statement_digest": "5cd060174152a5e86a50184b431c976e52c9e2f67175d8bf8a61ba6c7466aa7e"
+    }
+  },
+  "approved": {
+    "payload": {
+      "receipt_id": "ep:receipt:seam-vector-approved-0001",
+      "subject": "agent:autonomous:treasury-bot",
+      "created_at": "2026-07-02T00:00:00Z",
+      "claim": {
+        "action_type": "payment.release",
+        "target": "wire:vendor-acme-250000",
+        "subject_digest": "fd7887f2f7b0ec9c9ed06ef42f62e21b3b119bdfb13728b9eaea6e5ef28273b3",
+        "outcome": "allow_with_signoff",
+        "approver": "jane.doe@yourco.example",
+        "assurance": "class_a"
+      }
+    },
+    "payload_canonical": "{\"claim\":{\"action_type\":\"payment.release\",\"approver\":\"jane.doe@yourco.example\",\"assurance\":\"class_a\",\"outcome\":\"allow_with_signoff\",\"subject_digest\":\"fd7887f2f7b0ec9c9ed06ef42f62e21b3b119bdfb13728b9eaea6e5ef28273b3\",\"target\":\"wire:vendor-acme-250000\"},\"created_at\":\"2026-07-02T00:00:00Z\",\"receipt_id\":\"ep:receipt:seam-vector-approved-0001\",\"subject\":\"agent:autonomous:treasury-bot\"}",
+    "native_signature_b64": "KaXQX6CVuwY/A6zedpKKNj1F6pMljHO53+SSHTRcRqZyPAkoJdeGiERdLeVv8doPWWHqpDCV2PyZDdaYGQ1mAQ==",
+    "cose_sign1_b64": "0oRYM6MBJwN4G2FwcGxpY2F0aW9uL2VwLXJlY2VpcHQranNvbgRQ/HWiVeePW0NxN2t2zoE82KBZAX57ImNsYWltIjp7ImFjdGlvbl90eXBlIjoicGF5bWVudC5yZWxlYXNlIiwiYXBwcm92ZXIiOiJqYW5lLmRvZUB5b3VyY28uZXhhbXBsZSIsImFzc3VyYW5jZSI6ImNsYXNzX2EiLCJvdXRjb21lIjoiYWxsb3dfd2l0aF9zaWdub2ZmIiwic3ViamVjdF9kaWdlc3QiOiJmZDc4ODdmMmY3YjBlYzljOWVkMDZlZjQyZjYyZTIxYjNiMTE5YmRmYjEzNzI4YjllYWVhNmU1ZWYyODI3M2IzIiwidGFyZ2V0Ijoid2lyZTp2ZW5kb3ItYWNtZS0yNTAwMDAifSwiY3JlYXRlZF9hdCI6IjIwMjYtMDctMDJUMDA6MDA6MDBaIiwicmVjZWlwdF9pZCI6ImVwOnJlY2VpcHQ6c2VhbS12ZWN0b3ItYXBwcm92ZWQtMDAwMSIsInN1YmplY3QiOiJhZ2VudDphdXRvbm9tb3VzOnRyZWFzdXJ5LWJvdCJ9WEBfph7f5DLXLDlAOh9oqa/jMsT0VYiM+LRAvZ7c4/2KOS1GviGECGKC+7g5DN0GH0OYFl7ZMw2MSLfBdn/7JjYO",
+    "receipt_payload_digest": "e37000ae3366ce7d9ccddcce1e2fe8cc658339ef7e1a0e9d9f6aac86281580d7",
+    "statement_digest": "141ea80006127f57d10c0b5104cfae1bfce52d851d8c9c8faae4fcf38b4e988f"
+  },
+  "denied": {
+    "payload": {
+      "receipt_id": "ep:receipt:seam-vector-denied-0001",
+      "subject": "agent:autonomous:treasury-bot",
+      "created_at": "2026-07-02T00:00:00Z",
+      "claim": {
+        "action_type": "payment.release",
+        "target": "wire:vendor-acme-250000",
+        "subject_digest": "fd7887f2f7b0ec9c9ed06ef42f62e21b3b119bdfb13728b9eaea6e5ef28273b3",
+        "outcome": "deny",
+        "approver": null,
+        "reason": "no_human_authorizer"
+      }
+    },
+    "payload_canonical": "{\"claim\":{\"action_type\":\"payment.release\",\"approver\":null,\"outcome\":\"deny\",\"reason\":\"no_human_authorizer\",\"subject_digest\":\"fd7887f2f7b0ec9c9ed06ef42f62e21b3b119bdfb13728b9eaea6e5ef28273b3\",\"target\":\"wire:vendor-acme-250000\"},\"created_at\":\"2026-07-02T00:00:00Z\",\"receipt_id\":\"ep:receipt:seam-vector-denied-0001\",\"subject\":\"agent:autonomous:treasury-bot\"}",
+    "native_signature_b64": "NNsbkI9k3C4EqHlncIkIbIAnB6D4WB15+ZQWAFA1K5b59PAf3e2NaoWc3GX8FvZI3JXg7lML3hzIfu11TlahAw==",
+    "cose_sign1_b64": "0oRYM6MBJwN4G2FwcGxpY2F0aW9uL2VwLXJlY2VpcHQranNvbgRQ/HWiVeePW0NxN2t2zoE82KBZAWJ7ImNsYWltIjp7ImFjdGlvbl90eXBlIjoicGF5bWVudC5yZWxlYXNlIiwiYXBwcm92ZXIiOm51bGwsIm91dGNvbWUiOiJkZW55IiwicmVhc29uIjoibm9faHVtYW5fYXV0aG9yaXplciIsInN1YmplY3RfZGlnZXN0IjoiZmQ3ODg3ZjJmN2IwZWM5YzllZDA2ZWY0MmY2MmUyMWIzYjExOWJkZmIxMzcyOGI5ZWFlYTZlNWVmMjgyNzNiMyIsInRhcmdldCI6IndpcmU6dmVuZG9yLWFjbWUtMjUwMDAwIn0sImNyZWF0ZWRfYXQiOiIyMDI2LTA3LTAyVDAwOjAwOjAwWiIsInJlY2VpcHRfaWQiOiJlcDpyZWNlaXB0OnNlYW0tdmVjdG9yLWRlbmllZC0wMDAxIiwic3ViamVjdCI6ImFnZW50OmF1dG9ub21vdXM6dHJlYXN1cnktYm90In1YQIPUa+9dacUbhBlHuju9TSjcL6FGoUW1vp8BRbIRkZa3iuMCUp8JFOwm6RSs5EuBnPGbPd2wEFQjoASy4J3dhAY=",
+    "receipt_payload_digest": "3ec7b1742fa887d9fff06b06142298aaace5481d01b623bd3fa27c1a7f641020",
+    "statement_digest": "5cd060174152a5e86a50184b431c976e52c9e2f67175d8bf8a61ba6c7466aa7e"
+  }
+}

--- a/examples/scitt/capsule-seam-vector.mjs
+++ b/examples/scitt/capsule-seam-vector.mjs
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// EMILIA <-> Agent Action Capsule SEAM VECTOR (who -> what, by shared digest)
+//
+//   node examples/scitt/capsule-seam-vector.mjs           # verify + print
+//   node examples/scitt/capsule-seam-vector.mjs --emit    # (re)write capsule-seam-vector.json
+//
+// Purpose (per the SCITT thread with Steven Mih / Tom Sato): thread a SINGLE
+// action's digest through the who->what seam so the linkage is TESTABLE, not
+// asserted. This file is the EMILIA side:
+//
+//   - subject_digest         = SHA-256( JCS(action) )      -- the exact action both
+//                              statements are ABOUT (recomputable on either side).
+//   - EP authorization receipt over that action (APPROVED and DENIED variants),
+//     natively Ed25519-signed and wrapped as a COSE_Sign1 SCITT Signed Statement.
+//   - authority_reference_digest = the digest a Capsule's *opaque authority
+//     reference* embeds to commit to the approval WITHOUT restating it:
+//       * receipt_payload_digest = SHA-256( JCS(receipt.payload) )  (offline)
+//       * statement_digest       = SHA-256( COSE_Sign1 bytes )      (when registered)
+//
+// Composition rule: authorization -> record, BY DIGEST, not containment. The
+// Capsule records subject_digest (same action) and carries authority_reference_
+// digest (this receipt). who (EMILIA) -> what (Capsule) is then verifiable
+// end-to-end across independent implementations.
+//
+// Determinism: a FIXED Ed25519 issuer seed + fixed receipt fields, so every run
+// (and every implementation) reproduces byte-identical payloads and digests.
+// This is a demo/interop vector key — NOT a production issuer key.
+
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { writeFileSync } from 'node:fs';
+import { canonicalize } from './ep-receipt-scitt-conformance.mjs';
+
+const sha256hex = (b) => crypto.createHash('sha256').update(b).digest('hex');
+
+// --- Deterministic Ed25519 issuer key from a fixed 32-byte seed ---------------
+// PKCS#8 prefix for an Ed25519 private key, followed by the 32-byte seed.
+const PKCS8_ED25519_PREFIX = Buffer.from('302e020100300506032b657004220420', 'hex');
+const SEED = crypto.createHash('sha256').update('ep:capsule-seam-vector:v1:issuer-seed').digest(); // fixed 32B
+const privateKey = crypto.createPrivateKey({
+  key: Buffer.concat([PKCS8_ED25519_PREFIX, SEED]),
+  format: 'der',
+  type: 'pkcs8',
+});
+const publicKey = crypto.createPublicKey(privateKey);
+const spkiDer = publicKey.export({ type: 'spki', format: 'der' });
+const kid = crypto.createHash('sha256').update(spkiDer).digest().subarray(0, 16);
+
+// --- Minimal deterministic CBOR (only what COSE_Sign1 needs; mirrors the profile)
+const U = (n) => Buffer.from([n]);
+const head = (major, len) => {
+  const m = major << 5;
+  if (len < 24) return U(m | len);
+  if (len < 256) return Buffer.from([m | 24, len]);
+  if (len < 65536) return Buffer.from([m | 25, len >> 8, len & 0xff]);
+  throw new Error('length out of range');
+};
+const cbBstr = (buf) => Buffer.concat([head(2, buf.length), buf]);
+const cbTstr = (s) => { const b = Buffer.from(s, 'utf8'); return Buffer.concat([head(3, b.length), b]); };
+const cbUint = (n) => head(0, n);
+const cbNint = (n) => head(1, -1 - n);
+const cbArr = (items) => Buffer.concat([head(4, items.length), ...items]);
+const cbMap = (pairs) => Buffer.concat([head(5, pairs.length), ...pairs.flat()]);
+const tagCoseSign1 = (buf) => Buffer.concat([Buffer.from([0xd2]), buf]); // tag(18)
+const CTY = 'application/ep-receipt+json';
+
+// The single action both statements are ABOUT.
+const ACTION = { action_type: 'payment.release', target: 'wire:vendor-acme-250000', amount: '250000.00', currency: 'USD' };
+const SUBJECT_DIGEST = sha256hex(Buffer.from(canonicalize(ACTION), 'utf8'));
+
+function buildReceiptStatement(payload) {
+  const payloadBytes = Buffer.from(canonicalize(payload), 'utf8');
+  const nativeSig = crypto.sign(null, payloadBytes, privateKey);
+
+  const protectedMap = cbMap([
+    [cbUint(1), cbNint(-8)],        // alg = EdDSA (-8)
+    [cbUint(3), cbTstr(CTY)],       // content type
+    [cbUint(4), cbBstr(kid)],       // kid
+  ]);
+  const protectedBstr = cbBstr(protectedMap);
+  const sigStructure = cbArr([cbTstr('Signature1'), protectedBstr, cbBstr(Buffer.alloc(0)), cbBstr(payloadBytes)]);
+  const coseSig = crypto.sign(null, sigStructure, privateKey);
+  const coseSign1 = tagCoseSign1(cbArr([protectedBstr, cbMap([]), cbBstr(payloadBytes), cbBstr(coseSig)]));
+
+  return {
+    payload,
+    payload_canonical: payloadBytes.toString('utf8'),
+    native_signature_b64: nativeSig.toString('base64'),
+    cose_sign1_b64: coseSign1.toString('base64'),
+    receipt_payload_digest: sha256hex(payloadBytes),   // authority-ref (offline)
+    statement_digest: sha256hex(coseSign1),             // authority-ref (registered)
+    _payloadBytes: payloadBytes,
+    _coseSign1: coseSign1,
+    _sigStructure: sigStructure,
+    _nativeSig: nativeSig,
+    _coseSig: coseSig,
+  };
+}
+
+// APPROVED: a named human authorized this exact action.
+const approved = buildReceiptStatement({
+  receipt_id: 'ep:receipt:seam-vector-approved-0001',
+  subject: 'agent:autonomous:treasury-bot',
+  created_at: '2026-07-02T00:00:00Z',
+  claim: {
+    action_type: ACTION.action_type,
+    target: ACTION.target,
+    subject_digest: SUBJECT_DIGEST,
+    outcome: 'allow_with_signoff',
+    approver: 'jane.doe@yourco.example',
+    assurance: 'class_a',
+  },
+});
+
+// DENIED (verdict-complete): no valid human authorizer -> a SIGNED refusal event.
+const denied = buildReceiptStatement({
+  receipt_id: 'ep:receipt:seam-vector-denied-0001',
+  subject: 'agent:autonomous:treasury-bot',
+  created_at: '2026-07-02T00:00:00Z',
+  claim: {
+    action_type: ACTION.action_type,
+    target: ACTION.target,
+    subject_digest: SUBJECT_DIGEST,
+    outcome: 'deny',
+    approver: null,
+    reason: 'no_human_authorizer',
+  },
+});
+
+function verifyStatement(s) {
+  const nativeOk = crypto.verify(null, s._payloadBytes, publicKey, s._nativeSig);
+  const coseOk = crypto.verify(null, s._sigStructure, publicKey, s._coseSig);
+  const canonicalStable = canonicalize(s.payload) === s.payload_canonical;
+  return { nativeOk, coseOk, canonicalStable, ok: nativeOk && coseOk && canonicalStable };
+}
+
+function vectorJson() {
+  const strip = ({ _payloadBytes, _coseSign1, _sigStructure, _nativeSig, _coseSig, ...rest }) => rest;
+  return {
+    vector: 'EP<->Capsule seam vector v1',
+    spec: 'docs/EP-CAPSULE-SEAM.md',
+    canonicalization: 'RFC 8785 (JCS) over the EP I-JSON value subset; SHA-256 for all digests',
+    issuer: {
+      alg: 'Ed25519 (COSE EdDSA -8)',
+      spki_der_b64: spkiDer.toString('base64'),
+      kid_hex: kid.toString('hex'),
+      note: 'demo/interop vector key derived from a fixed seed — NOT a production issuer',
+    },
+    action: ACTION,
+    subject_digest: SUBJECT_DIGEST,
+    authority_reference: {
+      rule: 'A Capsule commits to the approval by embedding one of these digests in its opaque authority reference. Recommend statement_digest when the receipt is registered as a SCITT Signed Statement; receipt_payload_digest for offline composition.',
+      approved: { receipt_payload_digest: approved.receipt_payload_digest, statement_digest: approved.statement_digest },
+      denied: { receipt_payload_digest: denied.receipt_payload_digest, statement_digest: denied.statement_digest },
+    },
+    approved: strip(approved),
+    denied: strip(denied),
+  };
+}
+
+function main() {
+  const emit = process.argv.includes('--emit');
+  const a = verifyStatement(approved);
+  const d = verifyStatement(denied);
+
+  console.log('EMILIA <-> Capsule seam vector');
+  console.log(`  action              = ${JSON.stringify(ACTION)}`);
+  console.log(`  subject_digest      = ${SUBJECT_DIGEST}`);
+  console.log(`  issuer kid          = ${kid.toString('hex')}`);
+  console.log('\n  APPROVED');
+  console.log(`    receipt_payload_digest (authority-ref, offline)   = ${approved.receipt_payload_digest}`);
+  console.log(`    statement_digest       (authority-ref, registered)= ${approved.statement_digest}`);
+  console.log(`    native_sig=${a.nativeOk ? 'OK' : 'FAIL'} cose_sig=${a.coseOk ? 'OK' : 'FAIL'} canonical_stable=${a.canonicalStable ? 'OK' : 'FAIL'}`);
+  console.log('\n  DENIED (verdict-complete)');
+  console.log(`    receipt_payload_digest = ${denied.receipt_payload_digest}`);
+  console.log(`    statement_digest       = ${denied.statement_digest}`);
+  console.log(`    native_sig=${d.nativeOk ? 'OK' : 'FAIL'} cose_sig=${d.coseOk ? 'OK' : 'FAIL'} canonical_stable=${d.canonicalStable ? 'OK' : 'FAIL'}`);
+
+  if (emit) {
+    const path = fileURLToPath(new URL('./capsule-seam-vector.json', import.meta.url));
+    writeFileSync(path, JSON.stringify(vectorJson(), null, 2) + '\n');
+    console.log(`\n  wrote ${path}`);
+  }
+
+  const ok = a.ok && d.ok;
+  console.log(`\n${ok ? 'SEAM VECTOR OK' : 'SEAM VECTOR FAIL'} — who(EMILIA) -> what(Capsule) linkage is byte-reproducible across implementations.`);
+  if (!ok) process.exit(1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();
+
+export { ACTION, SUBJECT_DIGEST, approved, denied, verifyStatement, vectorJson };


### PR DESCRIPTION
The EP side of the shared cross-implementation vector from the SCITT thread with Steven Mih — threads one action's digest through the who→what seam so it's **testable, not asserted**.

- `examples/scitt/capsule-seam-vector.mjs` — deterministic generator + offline verifier (native Ed25519 + COSE_Sign1 verify; JCS canonicalization stable across runs).
- `examples/scitt/capsule-seam-vector.json` — frozen vector: **approved** + **denied** (verdict-complete) EP receipts, both digests, SPKI/kid to verify offline.
- `docs/EP-CAPSULE-SEAM.md` — the seam spec (subject_digest vs authority_reference_digest; the Capsule-side test recipe).

Verified: `node examples/scitt/capsule-seam-vector.mjs` → SEAM VECTOR OK, digests deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)