### PR TITLE
fix(security): federation verify must not trust receipt-supplied signer/key_discovery; pin issuers, guard SSRF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         # issuer round-trip suite (a locally-issued receipt proven to pass all
         # seven §6.3 checks under @emilia-protocol/verify, plus negative and CLI
         # smoke tests). "issue locally, verify anywhere", enforced every push.
-        run: node --test packages/verify/test.js packages/verify/web.test.js packages/issue/test.js packages/attest/test.js
+        run: node --test packages/verify/test.js packages/verify/web.test.js packages/verify/federation.test.js packages/issue/test.js packages/attest/test.js
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/conformance/federation.mjs
+++ b/conformance/federation.mjs
@@ -92,7 +92,10 @@ void B;
 
 // 1. Valid cross-redemption.
 const r1 = issueReceipt(A, { receipt_id: 'fed_001', '@version': 'EP-RECEIPT-v1', amount: 82000, currency: 'USD' });
-check('B accepts a valid receipt issued by A', verifyFederatedReceiptOffline(r1, discoveryDoc(A)).accepted === true);
+// B pins A's operator id out-of-band (PIP-006: trust comes from the relying
+// party's allowlist, never from the receipt-carried signer). Without a pin a
+// cryptographically-valid receipt stays accepted:false — fail closed.
+check('B accepts a valid receipt issued by A', verifyFederatedReceiptOffline(r1, discoveryDoc(A), { trustedIssuers: ['ep_operator_a'] }).accepted === true);
 
 // 2. Tamper rejection.
 const r2 = issueReceipt(A, { receipt_id: 'fed_002', '@version': 'EP-RECEIPT-v1', amount: 82000, currency: 'USD' });
@@ -109,12 +112,12 @@ const oldPair = crypto.generateKeyPairSync('ed25519');
 const oldOp = { operatorId: 'ep_operator_a', privateKey: oldPair.privateKey, publicKeyB64u: oldPair.publicKey.export({ type: 'spki', format: 'der' }).toString('base64url') };
 const Anew = makeOperator('ep_operator_a');
 const r4 = issueReceipt(oldOp, { receipt_id: 'fed_004', '@version': 'EP-RECEIPT-v1', amount: 7 }, oldPair.privateKey);
-const v4 = verifyFederatedReceiptOffline(r4, discoveryDoc(Anew, [oldOp]));
+const v4 = verifyFederatedReceiptOffline(r4, discoveryDoc(Anew, [oldOp]), { trustedIssuers: ['ep_operator_a'] });
 check('B verifies a pre-rotation receipt against an advertised historical key', v4.accepted === true && v4.keyMatched === 'historical');
 
 // 5. Revocation: valid signature, but not accepted.
 const r5 = issueReceipt(A, { receipt_id: 'fed_005', '@version': 'EP-RECEIPT-v1', amount: 9 });
-const v5 = verifyFederatedReceiptOffline(r5, discoveryDoc(A), { revokedReceiptIds: new Set(['fed_005']) });
+const v5 = verifyFederatedReceiptOffline(r5, discoveryDoc(A), { revokedReceiptIds: new Set(['fed_005']), trustedIssuers: ['ep_operator_a'] });
 check('B rejects a revoked receipt (verified but not accepted)', v5.verified === true && v5.accepted === false);
 
 // 6. Non-federated receipt (no signer).

--- a/conformance/operator2/verify-live.mjs
+++ b/conformance/operator2/verify-live.mjs
@@ -21,6 +21,12 @@ import { verifyFederatedReceipt } from '../../packages/verify/federation.js';
 
 const BASE = process.argv[2] || 'https://kgknhhdqsykxcwzdfeim.supabase.co/functions/v1/operator2';
 
+// Out-of-band trust anchor: the relying party pins Operator 2's known operator
+// id (PIP-006 — trust must be pinned by the verifier, never taken from the
+// receipt-carried signer). Without this pin, verifyFederatedReceipt refuses to
+// fetch a receipt-supplied key_discovery URL and returns accepted:false.
+const OPERATOR2_ID = 'ep_operator_2_supabase_edge';
+
 let fail = 0;
 const check = (name, ok) => { if (!ok) fail++; console.log(`  ${ok ? '✓' : '✗'} ${name}`); };
 
@@ -38,7 +44,7 @@ check('fetched a receipt Operator 2 issued', receipt?.signature?.signer);
 // Verify it — the online path fetches Operator 2's ep-keys.json (from the
 // receipt's key_discovery) and its verify-of-record (from the discovery doc's
 // verify_url_template), all on Operator 2's own origin.
-const r = await verifyFederatedReceipt(receipt, { fetchImpl: fetch, timeoutMs: 15000 });
+const r = await verifyFederatedReceipt(receipt, { fetchImpl: fetch, timeoutMs: 15000, trustedIssuers: [OPERATOR2_ID] });
 check('receipt verifies against Operator 2\'s published keys', r.verified === true);
 check('signer is Operator 2', r.signer === receipt?.signature?.signer);
 check('Operator 2\'s revocation surface was consulted', r.revocation_confirmed === true);
@@ -47,7 +53,7 @@ check('verdict = accepted (verified + not revoked)', r.accepted === true);
 // Negative control: tamper the amount. A live-key fetch must NOT save a forgery.
 const tampered = JSON.parse(JSON.stringify(receipt));
 tampered.payload.action.amount = 999_999_999;
-const t = await verifyFederatedReceipt(tampered, { fetchImpl: fetch, timeoutMs: 15000 });
+const t = await verifyFederatedReceipt(tampered, { fetchImpl: fetch, timeoutMs: 15000, trustedIssuers: [OPERATOR2_ID] });
 check('a tampered receipt is rejected (no trust laundering)', t.accepted === false);
 
 console.log('');

--- a/packages/verify/federation.js
+++ b/packages/verify/federation.js
@@ -17,9 +17,27 @@
  *   3. Confirm the receipt is not in A's revocation set.
  *   4. Apply B's *local* trust policy to the verified receipt.
  *
- * This module performs steps 1–3 and returns the evidence. Step 4 is the
- * caller's: `accepted` is the default verified-and-not-revoked verdict, but a
- * relying party is free to ignore it and apply stricter local policy.
+ * This module performs steps 1–3 and returns the evidence, and it enforces the
+ * decisive part of step 4: a receipt is only ever `accepted` when the relying
+ * party has independently, out-of-band, pinned the issuing operator.
+ *
+ * TRUST ANCHOR — fail closed. `verified` and `accepted` are DIFFERENT verdicts:
+ *   - `verified` = the signature checks out against a key the receipt's own
+ *     discovery surface advertises. This proves the payload was signed by
+ *     whoever controls `signature.signer`'s key — nothing more.
+ *   - `accepted` = the relying party trusts that signer. This decision MUST be
+ *     anchored in a caller-supplied, out-of-band trust source (a pinned issuer
+ *     allowlist and/or an expectedSigner and/or a pinned key set). It is NEVER
+ *     derived solely from fields the receipt carries.
+ *
+ * The receipt-carried `signature.signer` and `signature.key_discovery` are
+ * ATTACKER-CONTROLLED. An attacker can mint a receipt with their own key, host
+ * a matching ep-keys.json at a URL they control, and point key_discovery there.
+ * Such a receipt will `verify` (its signature is internally consistent) but it
+ * must NEVER `accept` unless the relying party has already pinned that issuer.
+ * A receipt-carried key_discovery URL is at most a *hint*: it is only fetched
+ * when the resolved signer is already in the caller's pinned set, and every
+ * such fetch is routed through an SSRF guard (see assertSafeFetchUrl).
  *
  * "Federation enables receipt portability. It does not enable trust
  * laundering." — PIP-006.
@@ -93,16 +111,27 @@ export function resolveOperatorKeys(discoveryDoc, signerId) {
  * access is performed. This is the deterministic core that the online path and
  * the conformance harness both build on.
  *
+ * TRUST IS OUT-OF-BAND. `accepted` is only ever true when the caller has pinned
+ * the issuing operator via `opts.trustedIssuers` and/or `opts.expectedSigner`.
+ * With no pin supplied, a cryptographically-`verified` receipt is still
+ * `accepted: false` — the receipt's own `signature.signer` can be anything an
+ * attacker chooses, so it can never, by itself, establish trust.
+ *
  * @param {object} receipt - EP-RECEIPT-v1 document. MUST carry
  *   `signature.signer` (issuing operator entity_id) per PIP-006.
  * @param {object} discoveryDoc - the issuing operator's parsed ep-keys.json
  * @param {object} [opts]
  * @param {Set<string>|string[]} [opts.revokedReceiptIds] - operator A's revocation set
  * @param {string} [opts.expectedSigner] - if set, the receipt's signer MUST equal this
+ *   (this is itself a pin: matching it authorizes acceptance)
+ * @param {Set<string>|string[]} [opts.trustedIssuers] - out-of-band allowlist of
+ *   federation issuer entity_ids the relying party trusts. Acceptance REQUIRES
+ *   the signer to be in this set (or to equal expectedSigner).
  * @returns {{
  *   accepted: boolean,
  *   verified: boolean,
  *   revoked: boolean,
+ *   trusted: boolean,
  *   signer: string|null,
  *   keyMatched: 'current'|'historical'|null,
  *   checks: object,
@@ -114,9 +143,10 @@ export function verifyFederatedReceiptOffline(receipt, discoveryDoc, opts = {}) 
     accepted: false,
     verified: false,
     revoked: false,
+    trusted: false,
     signer: null,
     keyMatched: null,
-    checks: { version: false, signer_present: false, signature: false, not_revoked: false },
+    checks: { version: false, signer_present: false, signature: false, not_revoked: false, issuer_pinned: false },
   };
 
   const signer = receipt?.signature?.signer;
@@ -171,16 +201,38 @@ export function verifyFederatedReceiptOffline(receipt, discoveryDoc, opts = {}) 
   // arrives after the action executed is a dispute, not a verification failure
   // (§"Security considerations" → Revocation) — but for the purpose of *now*
   // accepting the receipt as live evidence, a revoked receipt is not accepted.
-  const revokedSet = normalizeRevocationSet(opts.revokedReceiptIds);
+  const revokedSet = normalizeStringSet(opts.revokedReceiptIds);
   const receiptId = receipt.payload?.receipt_id || receipt.receipt_id;
   result.revoked = Boolean(receiptId && revokedSet.has(receiptId));
   result.checks.not_revoked = !result.revoked;
 
-  result.accepted = result.verified && !result.revoked;
+  // TRUST DECISION — fail closed. Acceptance requires an out-of-band pin
+  // supplied by the RELYING PARTY: an allowlisted issuer or a matching
+  // expectedSigner. The receipt's own signer is attacker-controlled and can
+  // never, by itself, authorize acceptance. `verified` (above) stands on its
+  // own; `accepted` layers this trust decision on top.
+  result.trusted = isIssuerPinned(signer, opts);
+  result.checks.issuer_pinned = result.trusted;
+
+  result.accepted = result.verified && !result.revoked && result.trusted;
+  if (result.verified && !result.trusted && !result.error) {
+    result.error =
+      `Signature verifies but signer ${signer} is not pinned by the relying party ` +
+      `(supply opts.trustedIssuers or opts.expectedSigner); a receipt-supplied signer cannot establish trust`;
+  }
   return result;
 }
 
-function normalizeRevocationSet(input) {
+// A signer is pinned when the relying party has authorized it out-of-band:
+// either it is on the trustedIssuers allowlist, or it equals expectedSigner.
+// With neither supplied, no signer is pinned — acceptance fails closed.
+function isIssuerPinned(signer, opts) {
+  if (opts.expectedSigner) return signer === opts.expectedSigner;
+  const trusted = normalizeStringSet(opts.trustedIssuers);
+  return trusted.has(signer);
+}
+
+function normalizeStringSet(input) {
   if (input instanceof Set) return input;
   if (Array.isArray(input)) return new Set(input);
   return new Set();
@@ -202,31 +254,64 @@ function normalizeRevocationSet(input) {
  * revocation feed must not block verification of an otherwise-valid receipt;
  * the converse — a present `revoked: true` — is honored).
  *
+ * FAIL CLOSED + SSRF-GUARDED. The receipt-supplied `key_discovery` URL is
+ * attacker-controlled. It is fetched ONLY when the relying party has pinned the
+ * signer (opts.trustedIssuers / opts.expectedSigner) — otherwise the receipt
+ * could point us at an attacker-hosted ep-keys.json to launder trust, and the
+ * fetch itself would be an SSRF primitive. A caller-supplied opts.keyDiscovery
+ * Url override is the relying party's own choice and is always honored. Every
+ * fetch of a URL that could be influenced by the receipt (key discovery,
+ * discovery-advertised verify_url_template) is routed through assertSafeFetchUrl:
+ * https-only, no embedded credentials, and private / loopback / link-local /
+ * cloud-metadata targets are blocked, with redirects disabled (redirect:manual).
+ *
  * @param {object} receipt - EP-RECEIPT-v1 with signature.signer + signature.key_discovery
  * @param {object} [opts]
  * @param {typeof fetch} [opts.fetchImpl] - injectable fetch (defaults to global fetch)
  * @param {number} [opts.timeoutMs=5000]
- * @param {string} [opts.keyDiscoveryUrl] - override the receipt's key_discovery URL
- * @param {string} [opts.verifyUrlBase] - override base for the revocation check
+ * @param {string} [opts.keyDiscoveryUrl] - relying-party override of the key_discovery URL
+ * @param {string} [opts.verifyUrlBase] - relying-party override base for the revocation check
+ * @param {Set<string>|string[]} [opts.trustedIssuers] - out-of-band issuer allowlist (required for acceptance)
+ * @param {string} [opts.expectedSigner] - out-of-band single-issuer pin (required for acceptance)
+ * @param {boolean} [opts.allowInsecureFetch=false] - test-only escape hatch to skip the SSRF guard
  * @returns {Promise<ReturnType<typeof verifyFederatedReceiptOffline> & { fetched: object }>}
  */
 export async function verifyFederatedReceipt(receipt, opts = {}) {
+  const signer = receipt?.signature?.signer || null;
+  const bail = (fetched, error) => ({
+    accepted: false, verified: false, revoked: false, trusted: false, signer,
+    keyMatched: null, checks: {}, fetched, error,
+  });
+
   const fetchImpl = opts.fetchImpl || (typeof fetch !== 'undefined' ? fetch : null);
   if (!fetchImpl) {
-    return {
-      accepted: false, verified: false, revoked: false, signer: receipt?.signature?.signer || null,
-      keyMatched: null, checks: {}, fetched: {},
-      error: 'No fetch implementation available; use verifyFederatedReceiptOffline instead',
-    };
+    return bail({}, 'No fetch implementation available; use verifyFederatedReceiptOffline instead');
+  }
+
+  // The receipt's own key_discovery is only honored when the signer is pinned
+  // out-of-band. A caller-supplied override is the relying party's own choice
+  // and is always honored. Fail closed: no pin + no override = no fetch.
+  const callerOverride = Boolean(opts.keyDiscoveryUrl);
+  if (!callerOverride && !isIssuerPinned(signer, opts)) {
+    return bail(
+      {},
+      `Refusing to fetch a receipt-supplied key_discovery URL for unpinned signer ${signer || '(none)'}: ` +
+      `supply opts.trustedIssuers/opts.expectedSigner, or a caller-controlled opts.keyDiscoveryUrl`,
+    );
   }
 
   const keyDiscoveryUrl = opts.keyDiscoveryUrl || receipt?.signature?.key_discovery;
   if (!keyDiscoveryUrl) {
-    return {
-      accepted: false, verified: false, revoked: false, signer: receipt?.signature?.signer || null,
-      keyMatched: null, checks: {}, fetched: {},
-      error: 'Receipt is missing signature.key_discovery and no keyDiscoveryUrl override given',
-    };
+    return bail({}, 'Receipt is missing signature.key_discovery and no keyDiscoveryUrl override given');
+  }
+
+  // SSRF guard on the (potentially receipt-supplied) discovery URL.
+  const discoverySafe = assertSafeFetchUrl(keyDiscoveryUrl, opts);
+  if (!discoverySafe.ok) {
+    return bail(
+      { keyDiscoveryUrl, discovery: { ok: false, blocked: true } },
+      `Blocked unsafe key_discovery URL: ${discoverySafe.error}`,
+    );
   }
 
   const fetched = { keyDiscoveryUrl, discovery: null, revocation: null };
@@ -235,11 +320,7 @@ export async function verifyFederatedReceipt(receipt, opts = {}) {
     discoveryDoc = await fetchJson(fetchImpl, keyDiscoveryUrl, opts.timeoutMs);
     fetched.discovery = { ok: true };
   } catch (e) {
-    return {
-      accepted: false, verified: false, revoked: false, signer: receipt?.signature?.signer || null,
-      keyMatched: null, checks: {}, fetched,
-      error: `Failed to fetch operator key discovery: ${e.message}`,
-    };
+    return bail(fetched, `Failed to fetch operator key discovery: ${e.message}`);
   }
 
   // Resolve revocation from the operator's verifier-of-record, when reachable.
@@ -251,7 +332,9 @@ export async function verifyFederatedReceipt(receipt, opts = {}) {
     // {origin}/api/verify. Fall back to origin-derivation for operators that
     // don't advertise it.
     const verifyUrl = resolveVerifyUrl(discoveryDoc, opts.verifyUrlBase, keyDiscoveryUrl, receiptId);
-    if (verifyUrl) {
+    // The verify URL can come from a discovery doc we fetched over an
+    // attacker-influenced hop, so it too must clear the SSRF guard.
+    if (verifyUrl && assertSafeFetchUrl(verifyUrl, opts).ok) {
       try {
         const v = await fetchJson(fetchImpl, verifyUrl, opts.timeoutMs);
         fetched.revocation = { ok: true, revoked: v?.revoked === true };
@@ -262,12 +345,15 @@ export async function verifyFederatedReceipt(receipt, opts = {}) {
         // verdict notes that revocation could not be confirmed.
         fetched.revocation = { ok: false };
       }
+    } else if (verifyUrl) {
+      fetched.revocation = { ok: false, blocked: true };
     }
   }
 
   const offline = verifyFederatedReceiptOffline(receipt, discoveryDoc, {
     revokedReceiptIds,
     expectedSigner: opts.expectedSigner,
+    trustedIssuers: opts.trustedIssuers,
   });
   return { ...offline, fetched, revocation_confirmed: fetched.revocation?.ok === true };
 }
@@ -291,7 +377,17 @@ async function fetchJson(fetchImpl, url, timeoutMs = 5000) {
   const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
   const timer = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
   try {
-    const res = await fetchImpl(url, controller ? { signal: controller.signal } : {});
+    // redirect:'manual' — a 3xx to a private/link-local host would bypass the
+    // pre-flight SSRF guard, so we refuse to follow redirects at all. An
+    // operator's discovery surface is expected to be served directly.
+    const init = { redirect: 'manual' };
+    if (controller) init.signal = controller.signal;
+    const res = await fetchImpl(url, init);
+    if (res && res.type === 'opaqueredirect') throw new Error('refusing to follow redirect');
+    const status = res?.status;
+    if (typeof status === 'number' && status >= 300 && status < 400) {
+      throw new Error(`refusing to follow redirect (HTTP ${status})`);
+    }
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return await res.json();
   } finally {
@@ -309,3 +405,115 @@ function deriveVerifyBase(keyDiscoveryUrl) {
     return null;
   }
 }
+
+// =============================================================================
+// SSRF GUARD
+// =============================================================================
+
+// Any server-side fetch of a URL that a receipt (or a receipt-reachable
+// discovery document) can influence is an SSRF primitive. This guard is a
+// pre-flight, string-only check — zero dependencies, safe in browsers/edge —
+// that rejects the classic SSRF targets before a request is ever issued:
+//   - non-https schemes (http/file/gopher/data/…),
+//   - embedded credentials (user:pass@host),
+//   - loopback / private / link-local / unique-local / cloud-metadata hosts.
+// It is deliberately conservative: literal IPs in private ranges and the
+// well-known metadata hostnames are blocked outright. Callers that must reach a
+// private host (tests) can pass opts.allowInsecureFetch to bypass it.
+//
+// Note: this is a name/literal check, not a resolve-and-pin. It cannot stop DNS
+// rebinding to a private address on its own; redirect:'manual' in fetchJson
+// closes the redirect-to-private vector, and deployments that need full
+// resolve-time pinning should layer a resolving guard (e.g. lib/sso/url-policy)
+// in front. Kept dependency-free so /web and offline builds stay portable.
+export function assertSafeFetchUrl(value, opts = {}) {
+  if (opts.allowInsecureFetch) return { ok: true };
+  let url;
+  try {
+    url = new URL(String(value || ''));
+  } catch {
+    return { ok: false, error: 'not a valid URL' };
+  }
+  if (url.protocol !== 'https:') {
+    return { ok: false, error: `scheme ${url.protocol} is not https` };
+  }
+  if (url.username || url.password) {
+    return { ok: false, error: 'URL must not embed credentials' };
+  }
+  const host = normalizeHost(url.hostname);
+  if (!host) return { ok: false, error: 'URL has no hostname' };
+  if (isBlockedHostname(host) || isPrivateOrReservedAddress(host)) {
+    return { ok: false, error: `host ${host} is private, loopback, link-local, or metadata` };
+  }
+  return { ok: true };
+}
+
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  'ip6-localhost',
+  'ip6-loopback',
+  'metadata.google.internal',
+]);
+
+function normalizeHost(hostname) {
+  return String(hostname || '')
+    .trim()
+    .replace(/^\[(.*)\]$/, '$1') // strip IPv6 brackets
+    .replace(/\.$/, '')          // strip trailing dot (FQDN root)
+    .toLowerCase();
+}
+
+function isBlockedHostname(host) {
+  if (BLOCKED_HOSTNAMES.has(host)) return true;
+  return host === 'localhost' || host.endsWith('.localhost');
+}
+
+function isPrivateOrReservedAddress(host) {
+  if (isIPv4(host)) return isPrivateIPv4(host);
+  if (host.includes(':')) return isPrivateIPv6(host);
+  return false;
+}
+
+function isIPv4(host) {
+  const parts = host.split('.');
+  return parts.length === 4 && parts.every((p) => /^\d{1,3}$/.test(p) && Number(p) <= 255);
+}
+
+function isPrivateIPv4(host) {
+  const [a, b] = host.split('.').map(Number);
+  return (
+    a === 0 ||                       // "this" network
+    a === 10 ||                      // private
+    a === 127 ||                     // loopback
+    (a === 169 && b === 254) ||      // link-local (incl. 169.254.169.254 metadata)
+    (a === 172 && b >= 16 && b <= 31) || // private
+    (a === 192 && b === 168) ||      // private
+    (a === 100 && b >= 64 && b <= 127) || // carrier-grade NAT
+    (a === 198 && (b === 18 || b === 19)) || // benchmarking
+    a >= 224                         // multicast / reserved
+  );
+}
+
+function isPrivateIPv6(host) {
+  const h = host.toLowerCase();
+  if (h === '::1' || h === '::') return true;
+  // IPv4-mapped (::ffff:a.b.c.d, or normalized ::ffff:7f00:1) — unwrap the
+  // trailing 32 bits and re-check as IPv4.
+  const mappedDotted = h.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mappedDotted && isIPv4(mappedDotted[1])) return isPrivateIPv4(mappedDotted[1]);
+  const mappedHex = h.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (mappedHex) {
+    const hi = parseInt(mappedHex[1], 16);
+    const lo = parseInt(mappedHex[2], 16);
+    const dotted = `${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`;
+    return isPrivateIPv4(dotted);
+  }
+  return (
+    h.startsWith('fc') ||   // unique local
+    h.startsWith('fd') ||   // unique local
+    h.startsWith('fe80') || // link-local
+    h.startsWith('ff')      // multicast
+  );
+}
+
+export const _internals = { assertSafeFetchUrl, isPrivateIPv4, isPrivateIPv6, isBlockedHostname };

--- a/packages/verify/federation.test.js
+++ b/packages/verify/federation.test.js
@@ -25,6 +25,7 @@ import {
   resolveOperatorKeys,
   verifyFederatedReceiptOffline,
   verifyFederatedReceipt,
+  _internals,
 } from './federation.js';
 
 // ── Canonicalization (must match packages/verify/index.js canonicalize) ──────
@@ -98,21 +99,26 @@ const samplePayload = (receiptId) => ({
 
 // ── 1. Happy path: cross-operator redemption ─────────────────────────────────
 
-test('Operator B accepts a valid receipt issued by Operator A', () => {
+test('Operator B accepts a valid receipt issued by a PINNED Operator A', () => {
   const A = makeOperator('ep_operator_a');
   const B = makeOperator('ep_operator_b'); // B is independent; never sees A's private key
   void B;
 
   const receipt = issueReceipt(A, samplePayload('ep_receipt_001'));
-  const result = verifyFederatedReceiptOffline(receipt, discoveryDoc(A));
+  // B has pinned A out-of-band as a trusted federation issuer.
+  const result = verifyFederatedReceiptOffline(receipt, discoveryDoc(A), {
+    trustedIssuers: ['ep_operator_a'],
+  });
 
-  assert.equal(result.accepted, true, 'a valid cross-operator receipt must be accepted');
+  assert.equal(result.accepted, true, 'a valid, pinned cross-operator receipt must be accepted');
   assert.equal(result.verified, true);
+  assert.equal(result.trusted, true);
   assert.equal(result.revoked, false);
   assert.equal(result.signer, 'ep_operator_a');
   assert.equal(result.keyMatched, 'current');
   assert.equal(result.checks.signature, true);
   assert.equal(result.checks.not_revoked, true);
+  assert.equal(result.checks.issuer_pinned, true);
 });
 
 // ── 2. Tamper rejection ──────────────────────────────────────────────────────
@@ -171,7 +177,7 @@ test('a pre-rotation receipt verifies against an advertised historical key', () 
   const oldReceipt = issueReceipt(oldOp, samplePayload('ep_receipt_004'), { signingKey: oldKeyPair.privateKey });
   const doc = discoveryDoc(A, { historical: [oldOp] });
 
-  const result = verifyFederatedReceiptOffline(oldReceipt, doc);
+  const result = verifyFederatedReceiptOffline(oldReceipt, doc, { trustedIssuers: ['ep_operator_a'] });
   assert.equal(result.verified, true, 'pre-rotation receipt must verify against historical key');
   assert.equal(result.accepted, true);
   assert.equal(result.keyMatched, 'historical');
@@ -198,6 +204,7 @@ test('a revoked receipt verifies cryptographically but is not accepted', () => {
 
   const result = verifyFederatedReceiptOffline(receipt, discoveryDoc(A), {
     revokedReceiptIds: new Set(['ep_receipt_005']),
+    trustedIssuers: ['ep_operator_a'],
   });
 
   // The signature is still valid — revocation is a policy/dispute signal, not a
@@ -247,7 +254,7 @@ test('online verifyFederatedReceipt resolves keys + revocation via injected fetc
     return { ok: false, status: 404, json: async () => ({}) };
   };
 
-  const result = await verifyFederatedReceipt(receipt, { fetchImpl });
+  const result = await verifyFederatedReceipt(receipt, { fetchImpl, trustedIssuers: ['ep_operator_a'] });
   assert.equal(result.verified, true);
   assert.equal(result.accepted, true);
   assert.equal(result.revocation_confirmed, true);
@@ -271,7 +278,7 @@ test('online path uses the discovery doc verify_url_template for revocation', as
     return { ok: false, status: 404, json: async () => ({}) };
   };
 
-  const result = await verifyFederatedReceipt(receipt, { fetchImpl });
+  const result = await verifyFederatedReceipt(receipt, { fetchImpl, trustedIssuers: ['ep_operator_a'] });
   assert.equal(result.accepted, true);
   assert.equal(result.revocation_confirmed, true);
   assert.equal(revocationUrlHit, 'https://op.example/fn/op/api/verify/ep_receipt_008b');
@@ -290,7 +297,7 @@ test('online path honors an operator revocation verdict', async () => {
     return { ok: false, status: 404, json: async () => ({}) };
   };
 
-  const result = await verifyFederatedReceipt(receipt, { fetchImpl });
+  const result = await verifyFederatedReceipt(receipt, { fetchImpl, trustedIssuers: ['ep_operator_a'] });
   assert.equal(result.verified, true);
   assert.equal(result.revoked, true);
   assert.equal(result.accepted, false);
@@ -300,7 +307,7 @@ test('online path fails closed when key discovery is unreachable', async () => {
   const A = makeOperator('ep_operator_a');
   const receipt = issueReceipt(A, samplePayload('ep_receipt_010'));
   const fetchImpl = async () => { throw new Error('network down'); };
-  const result = await verifyFederatedReceipt(receipt, { fetchImpl });
+  const result = await verifyFederatedReceipt(receipt, { fetchImpl, trustedIssuers: ['ep_operator_a'] });
   assert.equal(result.verified, false);
   assert.equal(result.accepted, false);
   assert.match(result.error || '', /Failed to fetch operator key discovery/);
@@ -315,8 +322,152 @@ test('online path fails open on revocation lookup but still verifies signature',
     if (url.endsWith('/ep-keys.json')) return { ok: true, status: 200, json: async () => doc };
     throw new Error('revocation feed down');
   };
-  const result = await verifyFederatedReceipt(receipt, { fetchImpl });
+  const result = await verifyFederatedReceipt(receipt, { fetchImpl, trustedIssuers: ['ep_operator_a'] });
   assert.equal(result.verified, true);
   assert.equal(result.accepted, true, 'an unreachable revocation feed must not fail a valid receipt');
   assert.equal(result.revocation_confirmed, false);
+});
+
+// ── 8. Trust-anchor injection — the DoD-audit finding ─────────────────────────
+// The core attack: a receipt's signature.signer and signature.key_discovery are
+// attacker-controlled. An attacker mints a receipt with THEIR OWN key and hosts
+// a matching ep-keys.json at THEIR OWN URL. The signature is internally
+// consistent (it "verifies"), but the relying party never pinned this signer,
+// so it must NEVER be accepted. Trust must come from out-of-band pinning, never
+// from fields the receipt carries.
+
+test('OFFLINE: attacker-controlled signer + self-hosted key does NOT accept without a pin', () => {
+  // "Attacker" is a fully valid, self-consistent operator identity the relying
+  // party has never heard of — exactly what an attacker can always produce.
+  const Attacker = makeOperator('ep_operator_attacker');
+  const receipt = issueReceipt(Attacker, samplePayload('ep_receipt_atk_001'));
+  // The attacker also supplies the discovery doc that matches their own key.
+  const result = verifyFederatedReceiptOffline(receipt, discoveryDoc(Attacker));
+
+  assert.equal(result.verified, true, 'the signature is internally consistent, so it verifies');
+  assert.equal(result.trusted, false, 'but the signer was never pinned by the relying party');
+  assert.equal(result.accepted, false, 'so the receipt must NOT be accepted (fail closed)');
+  assert.equal(result.checks.issuer_pinned, false);
+  assert.match(result.error || '', /not pinned/);
+});
+
+test('OFFLINE: a pinned allowlist that does NOT include the attacker still refuses acceptance', () => {
+  const Attacker = makeOperator('ep_operator_attacker');
+  const receipt = issueReceipt(Attacker, samplePayload('ep_receipt_atk_002'));
+  const result = verifyFederatedReceiptOffline(receipt, discoveryDoc(Attacker), {
+    trustedIssuers: ['ep_operator_a', 'ep_operator_b'], // attacker not on the list
+  });
+  assert.equal(result.verified, true);
+  assert.equal(result.accepted, false);
+});
+
+test('OFFLINE: expectedSigner acts as a single-issuer pin (matching → accepted)', () => {
+  const A = makeOperator('ep_operator_a');
+  const receipt = issueReceipt(A, samplePayload('ep_receipt_atk_003'));
+  const ok = verifyFederatedReceiptOffline(receipt, discoveryDoc(A), { expectedSigner: 'ep_operator_a' });
+  assert.equal(ok.accepted, true);
+  assert.equal(ok.trusted, true);
+});
+
+test('ONLINE: unpinned receipt is refused BEFORE any fetch (no SSRF, no trust laundering)', async () => {
+  const Attacker = makeOperator('ep_operator_attacker');
+  const receipt = issueReceipt(Attacker, samplePayload('ep_receipt_atk_004'));
+  let fetchCalled = false;
+  const fetchImpl = async () => { fetchCalled = true; return { ok: true, status: 200, json: async () => discoveryDoc(Attacker) }; };
+
+  // No trustedIssuers / expectedSigner supplied → the receipt's own
+  // key_discovery URL must not be fetched at all.
+  const result = await verifyFederatedReceipt(receipt, { fetchImpl });
+  assert.equal(fetchCalled, false, 'must not fetch a receipt-supplied URL for an unpinned signer');
+  assert.equal(result.accepted, false);
+  assert.equal(result.verified, false);
+  assert.match(result.error || '', /Refusing to fetch/);
+});
+
+test('ONLINE: even a "verifying" attacker receipt is not accepted when signer is not pinned', async () => {
+  // Pin a DIFFERENT operator; the attacker's own key_discovery would verify its
+  // signature, but the signer is not the pinned one, so acceptance fails closed.
+  const Attacker = makeOperator('ep_operator_attacker');
+  const receipt = issueReceipt(Attacker, samplePayload('ep_receipt_atk_005'));
+  const fetchImpl = async (url) => {
+    if (url.endsWith('/ep-keys.json')) return { ok: true, status: 200, json: async () => discoveryDoc(Attacker) };
+    return { ok: false, status: 404, json: async () => ({}) };
+  };
+  const result = await verifyFederatedReceipt(receipt, { fetchImpl, trustedIssuers: ['ep_operator_a'] });
+  // Signer mismatch is caught before key resolution; either way, not accepted.
+  assert.equal(result.accepted, false);
+});
+
+// ── 9. SSRF guard on receipt-supplied fetch URLs ─────────────────────────────
+// The receipt supplies the key_discovery URL. A pinned signer is necessary but
+// not sufficient: the URL itself must be a safe public https target, or the
+// fetch is an SSRF primitive against the verifier's network.
+
+const PRIVATE_KEY_DISCOVERY_URLS = [
+  'http://ep_operator_a.example/.well-known/ep-keys.json',       // not https
+  'https://169.254.169.254/.well-known/ep-keys.json',            // cloud metadata (link-local)
+  'https://127.0.0.1/.well-known/ep-keys.json',                  // loopback
+  'https://localhost/.well-known/ep-keys.json',                  // loopback name
+  'https://10.0.0.5/.well-known/ep-keys.json',                   // RFC1918 private
+  'https://192.168.1.1/.well-known/ep-keys.json',                // RFC1918 private
+  'https://[::1]/.well-known/ep-keys.json',                      // IPv6 loopback
+  'https://[fd00::1]/.well-known/ep-keys.json',                  // IPv6 unique-local
+  'https://user:pass@op.example/.well-known/ep-keys.json',       // embedded credentials
+  'https://metadata.google.internal/computeMetadata/v1/',        // GCP metadata host
+];
+
+for (const badUrl of PRIVATE_KEY_DISCOVERY_URLS) {
+  test(`ONLINE: SSRF attempt is blocked, no request issued — ${badUrl}`, async () => {
+    const A = makeOperator('ep_operator_a');
+    const receipt = issueReceipt(A, samplePayload('ep_receipt_ssrf'));
+    // Attacker points a PINNED operator's key_discovery at an internal target.
+    receipt.signature.key_discovery = badUrl;
+
+    let fetchCalled = false;
+    const fetchImpl = async () => { fetchCalled = true; return { ok: true, status: 200, json: async () => discoveryDoc(A) }; };
+
+    const result = await verifyFederatedReceipt(receipt, {
+      fetchImpl,
+      trustedIssuers: ['ep_operator_a'], // signer IS pinned; URL is still unsafe
+    });
+
+    assert.equal(fetchCalled, false, 'the server must not issue a request to a private/unsafe URL');
+    assert.equal(result.accepted, false);
+    assert.equal(result.verified, false);
+    assert.match(result.error || '', /Blocked unsafe key_discovery URL|Refusing to fetch/);
+  });
+}
+
+test('assertSafeFetchUrl allows a normal public https URL and blocks private ones', () => {
+  assert.equal(_internals.assertSafeFetchUrl('https://op.example/.well-known/ep-keys.json').ok, true);
+  assert.equal(_internals.assertSafeFetchUrl('https://169.254.169.254/').ok, false);
+  assert.equal(_internals.assertSafeFetchUrl('https://10.1.2.3/').ok, false);
+  assert.equal(_internals.assertSafeFetchUrl('http://op.example/').ok, false);
+  // IPv4-mapped IPv6 to a private address must also be blocked.
+  assert.equal(_internals.assertSafeFetchUrl('https://[::ffff:127.0.0.1]/').ok, false);
+});
+
+test('ONLINE: a caller-supplied keyDiscoveryUrl override is still SSRF-guarded', async () => {
+  const A = makeOperator('ep_operator_a');
+  const receipt = issueReceipt(A, samplePayload('ep_receipt_ssrf_override'));
+  let fetchCalled = false;
+  const fetchImpl = async () => { fetchCalled = true; return { ok: true, status: 200, json: async () => discoveryDoc(A) }; };
+
+  const result = await verifyFederatedReceipt(receipt, {
+    fetchImpl,
+    keyDiscoveryUrl: 'https://169.254.169.254/.well-known/ep-keys.json',
+  });
+  assert.equal(fetchCalled, false);
+  assert.equal(result.accepted, false);
+  assert.match(result.error || '', /Blocked unsafe key_discovery URL/);
+});
+
+test('ONLINE: redirect responses are refused (redirect:manual closes rebind-via-redirect)', async () => {
+  const A = makeOperator('ep_operator_a');
+  const receipt = issueReceipt(A, samplePayload('ep_receipt_redirect'));
+  const fetchImpl = async () => ({ ok: false, status: 302, type: 'opaqueredirect', json: async () => ({}) });
+  const result = await verifyFederatedReceipt(receipt, { fetchImpl, trustedIssuers: ['ep_operator_a'] });
+  assert.equal(result.verified, false);
+  assert.equal(result.accepted, false);
+  assert.match(result.error || '', /Failed to fetch operator key discovery|redirect/);
 });


### PR DESCRIPTION
## DoD audit finding (HIGH): trust-anchor injection + SSRF in federated receipt verification

`verifyFederatedReceipt` / `verifyFederatedReceiptOffline` resolved the trust anchor **entirely from attacker-controlled receipt fields** (`signature.signer` + `signature.key_discovery`) and defaulted to `accepted: true` for any verified, not-revoked receipt.

**Attack:** an attacker mints a receipt with their own Ed25519 key, hosts a matching `ep-keys.json` at a URL they control, points `signature.key_discovery` at it. The signature is internally consistent, so it `verifies` — and under the old default it was `accepted`. That is trust laundering. The online path also fetched the receipt-supplied URL server-side: an SSRF primitive (e.g. `https://169.254.169.254/...`).

## Fix (fail closed)

- **Trust is out-of-band.** `accepted` now REQUIRES a relying-party-supplied pin: `opts.trustedIssuers` (issuer allowlist) and/or `opts.expectedSigner`. With no pin, a cryptographically `verified` receipt stays `accepted: false`. The receipt's own `signer` can never, by itself, establish trust.
- **`verified` vs `accepted` preserved.** `verified` = signature checks out; `accepted` = the relying party trusts that signer. Only `accepted`'s default flips to false. New fields: `trusted`, `checks.issuer_pinned`.
- **Online path won't fetch an unpinned receipt's `key_discovery` URL** at all (no SSRF, no laundering) unless the signer is pinned or the caller supplied its own `keyDiscoveryUrl`.
- **SSRF guard** (`assertSafeFetchUrl`) on every receipt-influenced fetch (discovery + advertised `verify_url_template`): https-only, no embedded credentials, blocks loopback / private / link-local / unique-local / cloud-metadata targets (including IPv4-mapped IPv6). `fetchJson` uses `redirect: 'manual'` to close the redirect-to-private vector. Zero-dependency, string-only — safe in `/web`, edge, and offline builds. A resolve-time pinning guard can still be layered in front for DNS-rebinding-hardened deployments.

## Tests (`packages/verify/federation.test.js`, `node --test`)

- attacker-controlled signer + self-hosted key **without a caller pin → `accepted: false`** (still `verified: true`)
- correctly pinned issuer allowlist / matching `expectedSigner` → `accepted: true`
- unpinned online path issues **no fetch** (refused before any request)
- SSRF attempts (metadata, loopback, RFC1918, IPv6 ULA/loopback, credentialed, non-https, GCP metadata host) → **blocked, no request issued**
- caller `keyDiscoveryUrl` override is still SSRF-guarded; redirect responses refused
- existing accept-path tests updated to supply an out-of-band pin

## Verification

- `packages/verify` federation suite: **32/32 pass** (`node --test federation.test.js`)
- full `packages/verify` suite: **117/117 pass** (`npm test`)
- root `npx vitest run`: **4535 passed, 29 skipped, 0 failed**
- `npm run build` fails in this worktree due to a pre-existing corrupted `node_modules/next` install (missing `next/dist/shared/lib/*`), unrelated to this zero-dependency library change.

## Follow-up (out of this PR's domain)

`conformance/federation.mjs` asserts `.accepted === true` without supplying a pin and will need `trustedIssuers` added to match the new fail-closed contract.

🤖 Generated with Claude Code