### PR TITLE
fix(security): Gate must cryptographically verify quorum/class_a, not infer tier from payload

### DIFF
--- a/packages/gate/demo.mjs
+++ b/packages/gate/demo.mjs
@@ -5,7 +5,7 @@
  * @license Apache-2.0
  */
 import crypto from 'node:crypto';
-import { createTrustedActionFirewall } from './index.js';
+import { createTrustedActionFirewall, mintDeviceSignoff } from './index.js';
 
 const canon = (v) => v == null ? JSON.stringify(v)
   : Array.isArray(v) ? `[${v.map(canon).join(',')}]`
@@ -21,8 +21,17 @@ const action = {
   payment_instruction_id: 'pi_demo_40000',
   beneficiary_account_hash: 'sha256:demo-beneficiary',
 };
+// action_hash the CFO's device assertion is bound to.
+const actionHash = crypto.createHash('sha256').update(canon(action), 'utf8').digest('hex');
 const receipt = (outcome, extra = {}) => {
   const payload = { receipt_id: `rcpt_${++n}`, subject: 'agent:finance-bot', issuer: 'ep:org:demo', created_at: new Date().toISOString(), claim: { ...action, outcome, approver: 'ep:approver:cfo', ...extra } };
+  // class_a is EARNED by a genuine WebAuthn device signoff, not by the outcome
+  // string. A software receipt (outcome 'allow') carries no signoff.
+  if (outcome === 'allow_with_signoff') {
+    const s = mintDeviceSignoff({ actionHash, approver: 'ep:approver:cfo' });
+    payload.signoff = s.signoff;
+    payload.approver_public_key = s.approver_public_key;
+  }
   return { '@version': 'EP-RECEIPT-v1', payload, signature: { algorithm: 'Ed25519', value: crypto.sign(null, Buffer.from(canon(payload), 'utf8'), privateKey).toString('base64url') } };
 };
 

--- a/packages/gate/eg1-conformance.js
+++ b/packages/gate/eg1-conformance.js
@@ -41,6 +41,80 @@ const canon = (v) => (v == null ? JSON.stringify(v)
     : typeof v === 'object' ? `{${Object.keys(v).sort().map((k) => JSON.stringify(k) + ':' + canon(v[k])).join(',')}}`
       : JSON.stringify(v));
 
+const RP_ID = 'emiliaprotocol.ai';
+
+/**
+ * Mint a GENUINE WebAuthn ECDSA-P256 device signoff over an authorization
+ * context — the same structure @emilia-protocol/verify verifyWebAuthnSignoff
+ * checks. This is what earns a receipt its class_a tier: a real per-signer
+ * assertion, not a self-asserted `outcome` string. Used to build the Class-A and
+ * quorum evidence the EG-1 harness embeds so the Gate can CRYPTOGRAPHICALLY
+ * credit the tier.
+ */
+export function mintDeviceSignoff({ actionHash, approver, issuedAtMs = Date.now(), nonce, prevContextHash = undefined } = {}) {
+  const signer = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+  const context = {
+    ep_version: '1.0', context_type: 'ep.signoff.v1',
+    action_hash: actionHash,
+    policy: 'policy_eg1',
+    nonce: nonce || ('sig_' + crypto.randomBytes(16).toString('hex')),
+    approver,
+    initiator: 'ent_agent_eg1',
+    issued_at: new Date(issuedAtMs).toISOString(),
+    expires_at: new Date(issuedAtMs + 5 * 60_000).toISOString(),
+    ...(prevContextHash !== undefined ? { prev_context_hash: prevContextHash } : {}),
+  };
+  const challenge = crypto.createHash('sha256').update(canon(context), 'utf8').digest().toString('base64url');
+  const clientData = Buffer.from(JSON.stringify({ type: 'webauthn.get', challenge, origin: `https://www.${RP_ID}` }), 'utf8');
+  const authData = Buffer.concat([
+    crypto.createHash('sha256').update(RP_ID, 'utf8').digest(),
+    Buffer.from([0x05]), // UP | UV
+    Buffer.from([0, 0, 0, 1]),
+  ]);
+  const signed = Buffer.concat([authData, crypto.createHash('sha256').update(clientData).digest()]);
+  const signature = crypto.sign('sha256', signed, signer.privateKey).toString('base64url');
+  return {
+    signoff: {
+      '@type': 'ep.signoff',
+      context,
+      webauthn: {
+        authenticator_data: authData.toString('base64url'),
+        client_data_json: clientData.toString('base64url'),
+        signature,
+      },
+      approver_public_key: signer.publicKey.export({ type: 'spki', format: 'der' }).toString('base64url'),
+    },
+    approver_public_key: signer.publicKey.export({ type: 'spki', format: 'der' }).toString('base64url'),
+    context,
+  };
+}
+
+/**
+ * Mint a GENUINE EP-QUORUM-v1 evidence document: N distinct humans, each on a
+ * distinct device key, each with a real WebAuthn assertion bound to the SAME
+ * action_hash, within a window. verifyQuorum returns valid for it. This is what
+ * earns a receipt its `quorum` tier — never a bare {signers,threshold} block.
+ */
+export function mintQuorumEvidence({ actionHash, threshold = 2, approvers, issuedAtMs = Date.now() } = {}) {
+  const people = approvers || Array.from({ length: threshold }, (_, i) => ({ role: `approver_${i + 1}`, approver: `ep:approver:eg1_${i + 1}` }));
+  const members = people.map((p, i) => {
+    const s = mintDeviceSignoff({ actionHash, approver: p.approver, issuedAtMs: issuedAtMs + i * 1000 });
+    return { role: p.role, approver_public_key: s.approver_public_key, signoff: { '@type': s.signoff['@type'], context: s.signoff.context, webauthn: s.signoff.webauthn } };
+  });
+  return {
+    '@type': 'ep.quorum',
+    action_hash: actionHash,
+    policy: {
+      mode: 'threshold',
+      required: threshold,
+      approvers: people,
+      distinct_humans: true,
+      window_sec: 900,
+    },
+    members,
+  };
+}
+
 // The default high-risk action EG-1 exercises: a Class-A money movement, which
 // the default gate manifest guards (selector { protocol:'mcp', tool:'release_payment' }).
 export const EG1_DEFAULT_SELECTOR = Object.freeze({ protocol: 'mcp', tool: 'release_payment' });
@@ -73,34 +147,55 @@ export function createEg1Harness({ now = Date.now, action = EG1_DEFAULT_ACTION, 
   let counter = 0;
   const nowMs = () => (typeof now === 'function' ? now() : now);
 
+  // The action_hash the human device assertions are bound to. Derived from the
+  // action so the signoff/quorum evidence is about THIS action, not arbitrary.
+  const actionHash = crypto.createHash('sha256').update(canon(action), 'utf8').digest('hex');
+
   /**
    * Mint a scenario receipt.
    * @param {object} o
-   * @param {'allow'|'allow_with_signoff'} [o.outcome] 'allow'=software, 'allow_with_signoff'=Class-A
-   * @param {object} [o.quorum] a quorum block (signers/threshold) -> quorum tier
+   * @param {'allow'|'allow_with_signoff'} [o.outcome] 'allow'=software; 'allow_with_signoff'
+   *   embeds a REAL WebAuthn device signoff so the receipt cryptographically earns class_a.
+   * @param {object|boolean} [o.quorum] request quorum-tier evidence. Truthy -> a REAL
+   *   EP-QUORUM-v1 doc (distinct humans + distinct keys + per-signer assertions). If an
+   *   object with `threshold`/`signers`, its size sets the quorum size.
+   * @param {boolean} [o.fakeQuorum] embed an UNVERIFIABLE self-asserted quorum block
+   *   ({signers,threshold}) with no per-signer signatures — used to prove the Gate
+   *   REFUSES it (must NOT be credited quorum). For adversarial tests only.
    * @param {object} [o.tamper] fields assigned to the claim AFTER signing (breaks the signature)
    */
-  function mint({ outcome = 'allow_with_signoff', quorum = null, tamper = null, extra = {} } = {}) {
+  function mint({ outcome = 'allow_with_signoff', quorum = null, fakeQuorum = false, tamper = null, extra = {} } = {}) {
+    const claim = { ...action, outcome, approver: 'ep:approver:eg1', ...extra };
     const payload = {
       receipt_id: `${idPrefix}_${++counter}`,
       subject: 'agent:eg1-conformance',
       issuer: 'ep:org:eg1',
       created_at: new Date(nowMs()).toISOString(),
-      claim: {
-        ...action,
-        outcome,
-        approver: 'ep:approver:eg1',
-        ...(quorum ? { quorum } : {}),
-        ...extra,
-      },
+      claim,
     };
+    if (quorum) {
+      // A real, per-signer-verifiable quorum. Size from an explicit threshold, or
+      // from the count of a provided signers[] list, defaulting to 2.
+      const threshold = Number.isInteger(quorum.threshold) ? quorum.threshold
+        : (Array.isArray(quorum.signers) ? quorum.signers.length : 2);
+      payload.quorum = mintQuorumEvidence({ actionHash, threshold, issuedAtMs: nowMs() });
+    } else if (fakeQuorum) {
+      // Self-asserted only — NO members / NO signatures. The Gate must refuse to
+      // credit this as quorum (assurance_too_low).
+      payload.quorum = { signers: ['ep:a', 'ep:b'], threshold: 2 };
+    } else if (outcome === 'allow_with_signoff') {
+      // A genuine Class-A WebAuthn device signoff.
+      const s = mintDeviceSignoff({ actionHash, approver: 'ep:approver:eg1', issuedAtMs: nowMs() });
+      payload.signoff = s.signoff;
+      payload.approver_public_key = s.approver_public_key;
+    }
     const value = crypto.sign(null, Buffer.from(canon(payload), 'utf8'), privateKey).toString('base64url');
     const receipt = { '@version': 'EP-RECEIPT-v1', payload, signature: { algorithm: 'Ed25519', value } };
     if (tamper) Object.assign(receipt.payload.claim, tamper); // tamper AFTER signing -> signature no longer binds
     return receipt;
   }
 
-  return { publicKey: pub, mint, action, now: nowMs };
+  return { publicKey: pub, mint, action, actionHash, now: nowMs };
 }
 
 /**
@@ -203,4 +298,4 @@ export async function runEg1({ invoke, harness, action } = {}) {
   };
 }
 
-export default { EG1_VERSION, EG1_CHECKS, EG1_DEFAULT_ACTION, EG1_DEFAULT_SELECTOR, createEg1Harness, makeGateInvoke, runEg1 };
+export default { EG1_VERSION, EG1_CHECKS, EG1_DEFAULT_ACTION, EG1_DEFAULT_SELECTOR, createEg1Harness, makeGateInvoke, runEg1, mintDeviceSignoff, mintQuorumEvidence };

--- a/packages/gate/gate.test.js
+++ b/packages/gate/gate.test.js
@@ -5,7 +5,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import crypto from 'node:crypto';
-import { createGate, createTrustedActionFirewall, DEFAULT_GATE_MANIFEST, HIGH_RISK_ACTION_PACKS, receiptAssuranceTier } from './index.js';
+import { createGate, createTrustedActionFirewall, DEFAULT_GATE_MANIFEST, HIGH_RISK_ACTION_PACKS, receiptAssuranceTier, mintDeviceSignoff, mintQuorumEvidence } from './index.js';
 
 function canon(v) {
   if (v === null || v === undefined) return JSON.stringify(v);
@@ -21,12 +21,26 @@ function mint(privateKey, payload) {
   const value = crypto.sign(null, Buffer.from(canon(payload), 'utf8'), privateKey).toString('base64url');
   return { '@version': 'EP-RECEIPT-v1', payload, signature: { algorithm: 'Ed25519', value } };
 }
+const HASH_FOR = (action) => crypto.createHash('sha256').update(canon({ action_type: action }), 'utf8').digest('hex');
 let n = 0;
-function receipt(privateKey, { action = 'payment.release', outcome = 'allow', extra = {} } = {}) {
-  return mint(privateKey, {
+// Mint a receipt. When outcome === 'allow_with_signoff', embed a GENUINE WebAuthn
+// device signoff so the receipt cryptographically earns class_a (post-audit: the
+// Gate no longer credits a bare outcome string). When quorum:true, embed a real
+// EP-QUORUM-v1 doc.
+function receipt(privateKey, { action = 'payment.release', outcome = 'allow', extra = {}, quorum = false } = {}) {
+  const claim = { action_type: action, outcome, ...extra };
+  const payload = {
     receipt_id: `rcpt_${++n}`, subject: 'agent:test', issuer: 'ep:org:test',
-    created_at: new Date().toISOString(), claim: { action_type: action, outcome, ...extra },
-  });
+    created_at: new Date().toISOString(), claim,
+  };
+  if (quorum) {
+    payload.quorum = mintQuorumEvidence({ actionHash: HASH_FOR(action), threshold: 2 });
+  } else if (outcome === 'allow_with_signoff') {
+    const s = mintDeviceSignoff({ actionHash: HASH_FOR(action), approver: 'ep:approver:test' });
+    payload.signoff = s.signoff;
+    payload.approver_public_key = s.approver_public_key;
+  }
+  return mint(privateKey, payload);
 }
 
 const MANIFEST = {
@@ -167,10 +181,26 @@ test('run() releases a reserved receipt when the side effect fails before mutati
   assert.equal(retry.result, 'sent');
 });
 
-test('receiptAssuranceTier classification', () => {
-  assert.equal(receiptAssuranceTier({ payload: { quorum: { m: 2, signers: ['a', 'b'] } } }), 'quorum');
-  assert.equal(receiptAssuranceTier({ payload: { claim: { outcome: 'allow_with_signoff' } } }), 'class_a');
+test('receiptAssuranceTier is cryptographically verified, not payload-inferred (DoD audit)', () => {
+  // A fabricated quorum block with NO per-signer signatures earns only software.
+  assert.equal(receiptAssuranceTier({ payload: { quorum: { m: 2, signers: ['a', 'b'], threshold: 2 } } }), 'software');
+  // A self-asserted outcome string with NO WebAuthn device signoff earns only software.
+  assert.equal(receiptAssuranceTier({ payload: { claim: { outcome: 'allow_with_signoff' } } }), 'software');
+  // A plain software receipt is software.
   assert.equal(receiptAssuranceTier({ payload: { claim: { outcome: 'allow' } } }), 'software');
+
+  // A GENUINE device signoff earns class_a.
+  const s = mintDeviceSignoff({ actionHash: HASH_FOR('payment.release'), approver: 'ep:approver:test' });
+  assert.equal(receiptAssuranceTier({ payload: { signoff: s.signoff, approver_public_key: s.approver_public_key } }), 'class_a');
+
+  // A GENUINE quorum (real per-signer assertions) earns quorum.
+  const q = mintQuorumEvidence({ actionHash: HASH_FOR('payment.release'), threshold: 2 });
+  assert.equal(receiptAssuranceTier({ payload: { quorum: q } }), 'quorum');
+
+  // A quorum evidence doc with a broken (tampered) member signature is NOT credited quorum.
+  const tampered = mintQuorumEvidence({ actionHash: HASH_FOR('payment.release'), threshold: 2 });
+  tampered.members[0].signoff.context.approver = 'ep:approver:someone_else'; // breaks challenge binding
+  assert.equal(receiptAssuranceTier({ payload: { quorum: tampered } }), 'software');
 });
 
 test('default product pack guards the seven high-risk action families', () => {
@@ -253,4 +283,121 @@ test('reliance packet ties allow decision, execution attestation, field binding,
   assert.equal(packet.checks.find((c) => c.id === 'execution_fields_bound').ok, true);
   assert.equal(packet.checks.find((c) => c.id === 'execution_attests_decision').ok, true);
   assert.equal(packet.checks.find((c) => c.id === 'evidence_log_intact').ok, true);
+});
+
+// =============================================================================
+// DoD AUDIT: the credited tier MUST be cryptographically verified, not inferred
+// from self-asserted payload content. These prove the deeper hole is closed.
+// =============================================================================
+
+const QUORUM_MANIFEST = {
+  '@version': 'EP-ACTION-RISK-MANIFEST-v0.1',
+  actions: [
+    { id: 'grant_admin', action_type: 'permission.admin.change', receipt_required: true, risk: 'critical', assurance_class: 'quorum', match: { protocol: 'mcp', tool: 'grant_admin' } },
+  ],
+};
+const GRANT = { protocol: 'mcp', tool: 'grant_admin' };
+
+test('AUDIT: a fabricated quorum block (no per-signer signatures) is REFUSED', async () => {
+  const { pub, privateKey } = makeKey();
+  const g = createGate({ manifest: QUORUM_MANIFEST, trustedKeys: [pub] });
+  // A receipt that merely CLAIMS quorum — signers + threshold, but no members,
+  // no WebAuthn assertions. Signed by a trusted issuer, so the Ed25519 check
+  // passes; the fraud is that the quorum is self-asserted.
+  const resigned = mint(privateKey, {
+    receipt_id: 'rcpt_fabquorum', subject: 'agent:test', issuer: 'ep:org:test',
+    created_at: new Date().toISOString(),
+    claim: { action_type: 'permission.admin.change', outcome: 'allow' },
+    quorum: { signers: ['ep:a', 'ep:b'], threshold: 2 }, // fabricated: no members, no signatures
+  });
+  const out = await g.check({ selector: GRANT, receipt: resigned });
+  assert.equal(out.allow, false);
+  assert.equal(out.reason, 'assurance_too_low');
+  assert.equal(out.evidence.have_tier, 'software'); // fabricated quorum earns nothing above software
+  assert.equal(out.evidence.need_tier, 'quorum');
+  assert.equal(out.evidence.assurance_tier_source, 'cryptographic_verification');
+});
+
+test('AUDIT: a single-issuer software receipt does NOT satisfy class_a', async () => {
+  const { pub, privateKey } = makeKey();
+  const g = createGate({ manifest: MANIFEST, trustedKeys: [pub] }); // class_a required
+  const r = receipt(privateKey, { action: 'payment.release', outcome: 'allow' }); // software only
+  const out = await g.check({ selector: PAY, receipt: r });
+  assert.equal(out.allow, false);
+  assert.equal(out.reason, 'assurance_too_low');
+  assert.equal(out.evidence.have_tier, 'software');
+});
+
+test('AUDIT: outcome:allow_with_signoff string WITHOUT WebAuthn evidence does NOT satisfy class_a', async () => {
+  const { pub, privateKey } = makeKey();
+  const g = createGate({ manifest: MANIFEST, trustedKeys: [pub] });
+  // Self-asserted outcome string, but NO signoff evidence attached.
+  const r = mint(privateKey, {
+    receipt_id: 'rcpt_selfassert', subject: 'agent:test', issuer: 'ep:org:test',
+    created_at: new Date().toISOString(),
+    claim: { action_type: 'payment.release', outcome: 'allow_with_signoff' },
+  });
+  const out = await g.check({ selector: PAY, receipt: r });
+  assert.equal(out.allow, false);
+  assert.equal(out.reason, 'assurance_too_low');
+  assert.equal(out.evidence.have_tier, 'software');
+});
+
+test('AUDIT: a single-issuer software receipt does NOT satisfy quorum', async () => {
+  const { pub, privateKey } = makeKey();
+  const g = createGate({ manifest: QUORUM_MANIFEST, trustedKeys: [pub] });
+  const r = receipt(privateKey, { action: 'permission.admin.change', outcome: 'allow_with_signoff' }); // class_a at best
+  const out = await g.check({ selector: GRANT, receipt: r });
+  assert.equal(out.allow, false);
+  assert.equal(out.reason, 'assurance_too_low');
+  assert.equal(out.evidence.have_tier, 'class_a'); // genuine signoff, but quorum needs more
+  assert.equal(out.evidence.need_tier, 'quorum');
+});
+
+test('AUDIT: a genuinely quorum-verified receipt PASSES a quorum gate', async () => {
+  const { pub, privateKey } = makeKey();
+  const g = createGate({ manifest: QUORUM_MANIFEST, trustedKeys: [pub] });
+  const r = receipt(privateKey, { action: 'permission.admin.change', quorum: true });
+  const out = await g.check({ selector: GRANT, receipt: r });
+  assert.equal(out.allow, true, out.reason);
+  assert.equal(out.evidence.have_tier, 'quorum');
+  assert.equal(out.evidence.assurance_tier_source, 'cryptographic_verification');
+});
+
+test('AUDIT: a genuine WebAuthn device signoff PASSES a class_a gate', async () => {
+  const { pub, privateKey } = makeKey();
+  const g = createGate({ manifest: MANIFEST, trustedKeys: [pub] });
+  const r = receipt(privateKey, { action: 'payment.release', outcome: 'allow_with_signoff' });
+  const out = await g.check({ selector: PAY, receipt: r });
+  assert.equal(out.allow, true, out.reason);
+  assert.equal(out.evidence.have_tier, 'class_a');
+});
+
+test('AUDIT: a quorum receipt whose one member signature is broken is NOT credited quorum', async () => {
+  const { pub, privateKey } = makeKey();
+  const g = createGate({ manifest: QUORUM_MANIFEST, trustedKeys: [pub] });
+  const q = mintQuorumEvidence({ actionHash: HASH_FOR('permission.admin.change'), threshold: 2 });
+  q.members[1].signoff.webauthn.signature = Buffer.from('forged').toString('base64url'); // break one signer
+  const r = mint(privateKey, {
+    receipt_id: 'rcpt_brokenquorum', subject: 'agent:test', issuer: 'ep:org:test',
+    created_at: new Date().toISOString(),
+    claim: { action_type: 'permission.admin.change', outcome: 'allow_with_signoff' },
+    quorum: q,
+  });
+  const out = await g.check({ selector: GRANT, receipt: r });
+  assert.equal(out.allow, false);
+  assert.equal(out.reason, 'assurance_too_low');
+  assert.equal(out.evidence.have_tier, 'software');
+});
+
+test('AUDIT: an unknown / mis-cased required tier fails CLOSED (no silent downgrade to software)', async () => {
+  const { pub, privateKey } = makeKey();
+  // No manifest: the required tier comes from the selector, which is NOT run
+  // through the manifest validator — a mis-cased 'Class_A' reaches the tier check.
+  const g = createGate({ trustedKeys: [pub] });
+  // Even a genuine class_a signoff must not satisfy a tier the gate does not model.
+  const r = receipt(privateKey, { action: 'payment.release', outcome: 'allow_with_signoff' });
+  const out = await g.check({ selector: { action_type: 'payment.release', assurance_class: 'Class_A' }, receipt: r });
+  assert.equal(out.allow, false);
+  assert.equal(out.reason, 'unknown_required_tier');
 });

--- a/packages/gate/index.js
+++ b/packages/gate/index.js
@@ -6,8 +6,12 @@
  * action runs ONLY if it arrives with a receipt that is:
  *   1. valid          — Ed25519 over canonical JSON, signed by a pinned issuer;
  *   2. in-scope       — bound to the exact action the manifest guards;
- *   3. sufficiently   — meets the action's required assurance tier
- *      assured           (software / class_a device signoff / quorum);
+ *   3. sufficiently   — meets the action's required assurance tier, and the
+ *      assured           credited tier is CRYPTOGRAPHICALLY VERIFIED, not read
+ *                        from self-asserted payload fields: class_a requires a
+ *                        valid WebAuthn device signoff, quorum requires a valid
+ *                        EP-QUORUM-v1 (distinct humans + distinct keys +
+ *                        threshold + per-signer assertions);
  *   4. fresh          — within max age; and
  *   5. unused         — not a replay (one-time consumption).
  * Otherwise it is refused with a machine-readable Receipt-Required challenge
@@ -30,12 +34,19 @@ const {
   RECEIPT_REQUIRED_STATUS,
   RECEIPT_REQUIRED_HEADER,
 } = await import('@emilia-protocol/require-receipt').catch(() => import('../require-receipt/index.js'));
+// The real per-signer verifiers (WebAuthn device-signoff + M-of-N quorum). The
+// Gate MUST use these to CREDIT class_a / quorum — a receipt's self-asserted
+// outcome string or a fabricated quorum block is NOT proof. Same resolution
+// pattern as require-receipt: prefer the published package, fall back to the
+// in-repo source so the monorepo test/build works without a node_modules link.
+const { verifyWebAuthnSignoff, verifyQuorum } = await import('@emilia-protocol/verify')
+  .catch(() => import('../verify/index.js'));
 import { MemoryConsumptionStore } from './store.js';
 import { createEvidenceLog } from './evidence.js';
 import { DEFAULT_GATE_MANIFEST, HIGH_RISK_ACTION_PACKS, createDefaultActionRiskManifest } from './action-packs.js';
 import { hashCanonical, verifyExecutionBinding } from './execution-binding.js';
 import { buildReliancePacket } from './reliance-packet.js';
-import { createEg1Harness, makeGateInvoke, runEg1, EG1_DEFAULT_SELECTOR } from './eg1-conformance.js';
+import { createEg1Harness, makeGateInvoke, runEg1, EG1_DEFAULT_SELECTOR, mintDeviceSignoff, mintQuorumEvidence } from './eg1-conformance.js';
 import { createKeyRegistry, asKeyRegistry } from './key-registry.js';
 import { classifyRetention, buildRetentionExport } from './retention.js';
 
@@ -48,33 +59,82 @@ export { EXECUTION_BINDING_VERSION, canonicalize, hashCanonical, materialFieldsF
 export { RELIANCE_PACKET_VERSION, buildReliancePacket } from './reliance-packet.js';
 export {
   EG1_VERSION, EG1_CHECKS, EG1_DEFAULT_ACTION, EG1_DEFAULT_SELECTOR,
-  createEg1Harness, makeGateInvoke, runEg1,
+  createEg1Harness, makeGateInvoke, runEg1, mintDeviceSignoff, mintQuorumEvidence,
 } from './eg1-conformance.js';
 export const ASSURANCE_TIERS = ['software', 'class_a', 'quorum'];
 const TIER_RANK = { software: 0, class_a: 1, quorum: 2 };
 
 /**
- * The assurance tier a verified EP-RECEIPT-v1 issuer attests. Conservative /
- * fail-closed: if a higher tier's signed structure is not present, the receipt
- * only earns the lower tier, and a guard that needs more will refuse it.
+ * The assurance tier a receipt has CRYPTOGRAPHICALLY EARNED.
  *
- * Trust boundary: this lightweight action gate verifies the pinned issuer's
- * Ed25519 signature over the receipt. It does not re-run a full EP §6.2
- * multi-signature trust-receipt verifier here; the tier is therefore an
- * issuer-attested fact. Use @emilia-protocol/verify verifyTrustReceipt for
- * independent proof of embedded signoff/quorum signatures.
- *   quorum   — a quorum block with >= 2 distinct signers and threshold >= 2.
- *   class_a  — a device signoff (or claim.outcome === 'allow_with_signoff').
- *   software — any otherwise-valid receipt (a software-held key).
+ * SECURITY (DoD audit fix): the credited tier is NOT inferred from
+ * self-asserted payload fields. A receipt earns:
+ *   quorum   — only if it carries an EP-QUORUM-v1 evidence document whose
+ *              per-signer WebAuthn assertions verify (distinct humans + distinct
+ *              keys + threshold + action-binding + window), via verifyQuorum.
+ *   class_a  — only if it carries a device signoff ({context, webauthn}) whose
+ *              WebAuthn assertion verifies against the approver's own key, via
+ *              verifyWebAuthnSignoff.
+ *   software — every other otherwise-valid receipt (a software-held issuer key).
+ *
+ * A payload that merely CLAIMS quorum (e.g. `quorum:{signers:[...],threshold:2}`
+ * with no verifiable signatures) or sets `outcome:'allow_with_signoff'` with no
+ * WebAuthn evidence earns only `software` — it will be refused `assurance_too_low`
+ * by any guard that needs more. This is fail-closed by construction.
+ *
+ * @param {object} doc  the EP-RECEIPT-v1 document
+ * @param {object} [opts]
+ * @param {string} [opts.rpId]  bind device assertions to this WebAuthn RP id
+ * @returns {'software'|'class_a'|'quorum'} the highest tier proven, or a detailed
+ *          result when opts.detail is set.
  */
-export function receiptAssuranceTier(doc) {
+export function receiptAssuranceTier(doc, opts = {}) {
+  const detail = { tier: 'software', quorum: null, signoff: null };
   const p = doc?.payload || {};
+  const verifyOpts = opts.rpId ? { rpId: opts.rpId } : {};
+
+  // --- quorum: require a real, self-contained EP-QUORUM-v1 evidence document. ---
+  // Accept it under payload.quorum or payload.claim.quorum. It only counts if it
+  // is a full quorum document (policy + members with WebAuthn signoffs) AND
+  // verifyQuorum returns valid. A bare {signers,threshold} block has no members
+  // to verify and therefore CANNOT be credited quorum.
   const q = p.quorum || p.claim?.quorum;
-  const signers = q && (q.signers || q.approvers);
-  const threshold = q && (q.m ?? q.threshold ?? (Array.isArray(signers) ? signers.length : 0));
-  if (q && Array.isArray(signers) && signers.length >= 2 && threshold >= 2) return 'quorum';
-  if (p.signoff || p.claim?.outcome === 'allow_with_signoff') return 'class_a';
-  return 'software';
+  if (isQuorumEvidence(q)) {
+    const qr = verifyQuorum(q, verifyOpts);
+    detail.quorum = { valid: qr.valid, checks: qr.checks };
+    if (qr.valid) {
+      detail.tier = 'quorum';
+      return opts.detail ? detail : 'quorum';
+    }
+  }
+
+  // --- class_a: require a verifiable WebAuthn device signoff. ---
+  // The signoff evidence is {context, webauthn}; the approver key travels with
+  // it (signoff.approver_public_key) or alongside it (payload.approver_public_key).
+  const so = p.signoff || p.claim?.signoff;
+  if (isSignoffEvidence(so)) {
+    const key = so.approver_public_key || p.approver_public_key || p.claim?.approver_public_key;
+    if (key) {
+      const sr = verifyWebAuthnSignoff(so, key, verifyOpts);
+      detail.signoff = { valid: sr.valid, checks: sr.checks };
+      if (sr.valid) {
+        detail.tier = 'class_a';
+        return opts.detail ? detail : 'class_a';
+      }
+    }
+  }
+
+  return opts.detail ? detail : 'software';
+}
+
+/** A quorum evidence doc must carry members with per-signer signoffs to be verifiable. */
+function isQuorumEvidence(q) {
+  return !!q && typeof q === 'object' && q.policy && Array.isArray(q.members) && q.members.length > 0
+    && typeof q.action_hash === 'string' && q.action_hash.length > 0;
+}
+/** A device signoff must carry the WebAuthn assertion material to be verifiable. */
+function isSignoffEvidence(s) {
+  return !!s && typeof s === 'object' && s.context && s.webauthn;
 }
 
 /**
@@ -90,7 +150,7 @@ export function receiptAssuranceTier(doc) {
  *   if given it supersedes trustedKeys — a receipt is verified only against keys valid (and not
  *   revoked) at its issuance time.
  */
-export function createGate({ manifest = null, trustedKeys = [], maxAgeSec = 900, store, log, allowInlineKey = false, allowEphemeralStore = false, strictEvidence = true, now = Date.now, keyRegistry = null } = {}) {
+export function createGate({ manifest = null, trustedKeys = [], maxAgeSec = 900, store, log, allowInlineKey = false, allowEphemeralStore = false, strictEvidence = true, now = Date.now, keyRegistry = null, rpId = null } = {}) {
   // Production key custody: a registry (rotation + revocation) supersedes a flat
   // trustedKeys list. A flat list is coerced to an always-valid registry, so
   // existing callers are unchanged.
@@ -186,17 +246,33 @@ export function createGate({ manifest = null, trustedKeys = [], maxAgeSec = 900,
     if (!v.ok) {
       return decide(false, RECEIPT_REQUIRED_STATUS, `receipt_rejected:${v.reason}`, { rejected: v });
     }
-    // Assurance tier.
-    const have = receiptAssuranceTier(receipt);
-    if ((TIER_RANK[have] ?? 0) < (TIER_RANK[requiredTier] ?? 0)) {
-      return decide(false, RECEIPT_REQUIRED_STATUS, 'assurance_too_low', { have_tier: have, need_tier: requiredTier, assurance_tier_source: 'issuer_attestation' });
+    // Assurance tier. CRYPTOGRAPHICALLY VERIFIED (DoD audit fix): the credited
+    // tier comes from re-verifying the receipt's embedded per-signer evidence
+    // (WebAuthn device signoff / EP-QUORUM-v1), not from self-asserted payload
+    // fields. A receipt that only CLAIMS a higher tier earns 'software' and is
+    // refused here.
+    const tierResult = receiptAssuranceTier(receipt, { rpId, detail: true });
+    const have = tierResult.tier;
+    const needRank = TIER_RANK[requiredTier];
+    // Fail CLOSED on an unknown / mis-cased required tier: never silently treat
+    // it as 'software'. If a manifest asks for a tier this gate does not model,
+    // no receipt can satisfy it.
+    if (needRank === undefined) {
+      return decide(false, RECEIPT_REQUIRED_STATUS, 'unknown_required_tier', { have_tier: have, need_tier: requiredTier, assurance_tier_source: 'cryptographic_verification' });
+    }
+    if ((TIER_RANK[have] ?? 0) < needRank) {
+      return decide(false, RECEIPT_REQUIRED_STATUS, 'assurance_too_low', {
+        have_tier: have, need_tier: requiredTier,
+        assurance_tier_source: 'cryptographic_verification',
+        tier_evidence: { quorum: tierResult.quorum, signoff: tierResult.signoff },
+      });
     }
     // The high-risk action packs define material fields that must be observed
     // by the executor from the system of record. A signed, harmless-looking
     // claim cannot authorize a different real mutation.
     const executionBinding = verifyExecutionBinding({ requirement, receipt, observedAction: observed });
     if (!executionBinding.ok) {
-      return decide(false, RECEIPT_REQUIRED_STATUS, 'execution_binding_failed', { execution_binding: executionBinding, have_tier: have, assurance_tier_source: 'issuer_attestation' });
+      return decide(false, RECEIPT_REQUIRED_STATUS, 'execution_binding_failed', { execution_binding: executionBinding, have_tier: have, assurance_tier_source: 'cryptographic_verification' });
     }
     // One-time consumption (replay defense). Require a stable, issuer-generated
     // receipt_id — never fall back to a content hash, whose canonicalization can
@@ -220,7 +296,7 @@ export function createGate({ manifest = null, trustedKeys = [], maxAgeSec = 900,
     if (!fresh) {
       return decide(false, RECEIPT_REQUIRED_STATUS, 'replay_refused', { consumption_key: receiptId });
     }
-    return decide(true, 200, 'allow', { signer: v.signer, outcome: v.outcome, have_tier: have, assurance_tier_source: 'issuer_attestation', execution_binding: executionBinding, consumption_mode: consumptionMode });
+    return decide(true, 200, 'allow', { signer: v.signer, outcome: v.outcome, have_tier: have, assurance_tier_source: 'cryptographic_verification', execution_binding: executionBinding, consumption_mode: consumptionMode });
   }
 
   /** Express/Connect middleware: refuse the route unless a sufficient receipt is present. */


### PR DESCRIPTION
## Summary

DoD audit found the shipped Gate decided a receipt's `class_a`/`quorum` assurance tier by **reading self-asserted receipt payload fields** and never cryptographically verifying that each named signer actually signed. #234 added distinct-signer + threshold checks, but the deeper hole remained: `receiptAssuranceTier` inferred the tier from payload (`quorum:{signers,threshold}` or `outcome:'allow_with_signoff'`) with **no per-signer signature verification**, and the real per-signer verifier (`packages/verify/quorum.js` → `verifyQuorum`) was never called by the Gate.

## Trust model chosen: REAL per-signer cryptographic verification (fail-closed)

Not authorized-issuer-attestation. The Gate now re-verifies the receipt's **embedded evidence** before crediting a tier:

- **`quorum`** — requires a full EP-QUORUM-v1 document (`policy` + `members` each carrying a WebAuthn signoff) that passes `verifyQuorum` (distinct humans + distinct keys + threshold + per-signer assertions + action-binding + window). A bare `{signers, threshold}` block has no members to verify and earns only `software`.
- **`class_a`** — requires a WebAuthn device signoff (`{context, webauthn}`) that passes `verifyWebAuthnSignoff` against the approver's own key. A self-asserted `outcome` string with no assertion earns only `software`.
- **unknown / mis-cased required tier** now fails **CLOSED** (`unknown_required_tier`), never silently downgraded to `software`.

`receiptAssuranceTier()` now does the verification (accepts `{ rpId, detail }`). The evidence log records `assurance_tier_source: 'cryptographic_verification'` (was `'issuer_attestation'`).

The EG-1 conformance harness and demo now mint **genuine** WebAuthn signoff / EP-QUORUM-v1 evidence via new `mintDeviceSignoff` / `mintQuorumEvidence` helpers, so every downstream test/adapter exercises real crypto.

`verifyQuorum` + `verifyWebAuthnSignoff` are **imported** from `@emilia-protocol/verify`; that package is not modified.

## Tests added (all in `packages/gate/gate.test.js`)

- A fabricated `quorum:{signers,threshold}` block with no per-signer signatures is **refused** (`assurance_too_low`, `have_tier: software`).
- A single-issuer software receipt does **not** satisfy `class_a` or `quorum`.
- An `outcome:'allow_with_signoff'` string with **no** WebAuthn evidence does not satisfy `class_a`.
- A quorum whose one member signature is broken is **not** credited `quorum`.
- A genuinely quorum-verified receipt **passes**; a genuine WebAuthn signoff **passes** `class_a`.
- An unknown/mis-cased required tier fails closed.

## Verification

- `npm run build` → succeeds
- `packages/gate` `node --test` → 88 pass, 0 fail (incl. adapters 34)
- `packages/verify` `node --test` → 98 pass (imported verifier unaffected)
- root `vitest run` → 4535 pass / 29 skipped
- `node eg1.mjs` → **EG-1 Enforced (8/8)**; `node demo.mjs` / `custody-demo.mjs` run clean

## Files
- `packages/gate/index.js` — cryptographic `receiptAssuranceTier`; fail-closed unknown-tier; import verify
- `packages/gate/eg1-conformance.js` — real `mintDeviceSignoff` / `mintQuorumEvidence`; genuine evidence in `mint()`
- `packages/gate/gate.test.js` — adversarial + positive tier tests
- `packages/gate/demo.mjs` — demo mints a genuine device signoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>