### PR TITLE
Add WHO-leg MUST-reject vectors to the EP↔Capsule seam

### DIFF
--- a/docs/EP-CAPSULE-SEAM.md
+++ b/docs/EP-CAPSULE-SEAM.md
@@ -39,6 +39,19 @@ From `capsule-seam-vector.json`:
 
 **Capsule-side test:** build a Capsule over the same `subject_digest`, put the chosen `authority_reference_digest` in the opaque authority reference, and confirm a verifier can (a) recompute `subject_digest` from the action, (b) resolve the authority reference to this EP receipt, and (c) verify the EP signature over `payload_canonical`. That closes who → what **testably**, not by assertion.
 
+## Negative cases (MUST-reject) — the WHO-leg contract
+Per Songbo Bu: a decomposition is only an interop surface if each leg ships its own verifier contract *and negative cases*. The vector's `must_reject` array carries the WHO-leg rejects a composed verifier MUST enforce (all `ENFORCED` by the generator):
+
+| id | verdict | reason |
+|---|---|---|
+| `wrong_action` | reject | `who_subject_mismatch` — receipt binds action A; Capsule records action B |
+| `approval_contradiction` | reject | `disposition_contradicts_receipt` — Capsule says approved, referenced receipt is a denial |
+| `untrusted_issuer` | reject | `issuer_not_pinned` — receipt signed by a non-pinned key (no trust laundering) |
+| `replay_across_subject` | reject | `receipt_action_bound` — an action-A receipt reused for a Capsule over action B |
+| `missing_who_when_required` | policy_reject | `who_required_but_absent` — policy requires WHO, chain has no resolvable receipt digest |
+
+These are the WHO analogues of Songbo's negative list (producer-log mismatch, permit/audience mismatch, superseded-without-predecessor, concealed-required-field), composed by cross-reference, not containment.
+
 ## Three questions "authorization" blurs
 Agent identity/discovery ("which agent, where") ≠ machine/scope permission (permit/agentroa, **CAN**) ≠ accountable-human approval of the exact action (**EMILIA, WHO**). This seam is only the WHO → WHAT edge.
 

--- a/examples/scitt/capsule-seam-vector.json
+++ b/examples/scitt/capsule-seam-vector.json
@@ -65,5 +65,50 @@
     "cose_sign1_b64": "0oRYM6MBJwN4G2FwcGxpY2F0aW9uL2VwLXJlY2VpcHQranNvbgRQ/HWiVeePW0NxN2t2zoE82KBZAWJ7ImNsYWltIjp7ImFjdGlvbl90eXBlIjoicGF5bWVudC5yZWxlYXNlIiwiYXBwcm92ZXIiOm51bGwsIm91dGNvbWUiOiJkZW55IiwicmVhc29uIjoibm9faHVtYW5fYXV0aG9yaXplciIsInN1YmplY3RfZGlnZXN0IjoiZmQ3ODg3ZjJmN2IwZWM5YzllZDA2ZWY0MmY2MmUyMWIzYjExOWJkZmIxMzcyOGI5ZWFlYTZlNWVmMjgyNzNiMyIsInRhcmdldCI6IndpcmU6dmVuZG9yLWFjbWUtMjUwMDAwIn0sImNyZWF0ZWRfYXQiOiIyMDI2LTA3LTAyVDAwOjAwOjAwWiIsInJlY2VpcHRfaWQiOiJlcDpyZWNlaXB0OnNlYW0tdmVjdG9yLWRlbmllZC0wMDAxIiwic3ViamVjdCI6ImFnZW50OmF1dG9ub21vdXM6dHJlYXN1cnktYm90In1YQIPUa+9dacUbhBlHuju9TSjcL6FGoUW1vp8BRbIRkZa3iuMCUp8JFOwm6RSs5EuBnPGbPd2wEFQjoASy4J3dhAY=",
     "receipt_payload_digest": "3ec7b1742fa887d9fff06b06142298aaace5481d01b623bd3fa27c1a7f641020",
     "statement_digest": "5cd060174152a5e86a50184b431c976e52c9e2f67175d8bf8a61ba6c7466aa7e"
-  }
+  },
+  "action_b": {
+    "action_type": "payment.release",
+    "target": "wire:vendor-acme-999999",
+    "amount": "999999.00",
+    "currency": "USD"
+  },
+  "subject_digest_b": "7eb50ff87c502482f1a77795ca5be391fbb0b7a02dab1fd60362567e4d5b8307",
+  "must_reject": [
+    {
+      "id": "wrong_action",
+      "must": "reject",
+      "reason": "who_subject_mismatch",
+      "detail": "WHO receipt binds ACTION A; a Capsule recording ACTION B must not accept it as B’s approval.",
+      "capsule_subject_digest": "7eb50ff87c502482f1a77795ca5be391fbb0b7a02dab1fd60362567e4d5b8307",
+      "who_subject_digest": "fd7887f2f7b0ec9c9ed06ef42f62e21b3b119bdfb13728b9eaea6e5ef28273b3"
+    },
+    {
+      "id": "approval_contradiction",
+      "must": "reject",
+      "reason": "disposition_contradicts_receipt",
+      "detail": "Capsule records human_disposed=approved but references the DENIED receipt digest — the WHO evidence is a refusal.",
+      "referenced_authority_digest": "3ec7b1742fa887d9fff06b06142298aaace5481d01b623bd3fa27c1a7f641020"
+    },
+    {
+      "id": "untrusted_issuer",
+      "must": "reject",
+      "reason": "issuer_not_pinned",
+      "detail": "A receipt signed by a non-pinned key must fail verification under the pinned issuer SPKI — no trust laundering via a receipt-supplied key.",
+      "forged_signature_b64": "0BjUsed6xuPB5LZv7TYZkKumnc6Cmvp2lMRo9ggPuW9eAum/9dJ9Yczkuvbu33r+mFxhQVwarwkKcltiMvKKCQ=="
+    },
+    {
+      "id": "replay_across_subject",
+      "must": "reject",
+      "reason": "receipt_action_bound",
+      "detail": "The approved receipt is bound to ACTION A via claim.subject_digest; presenting its digest for a Capsule over ACTION B must be refused (action-bound, one-time).",
+      "receipt_bound_subject": "fd7887f2f7b0ec9c9ed06ef42f62e21b3b119bdfb13728b9eaea6e5ef28273b3",
+      "other_subject": "7eb50ff87c502482f1a77795ca5be391fbb0b7a02dab1fd60362567e4d5b8307"
+    },
+    {
+      "id": "missing_who_when_required",
+      "must": "policy_reject",
+      "reason": "who_required_but_absent",
+      "detail": "When policy requires accountable-human approval, a Capsule chain with no resolvable WHO digest must be policy-rejected. Verdict-complete: a required-but-absent approval is itself the finding."
+    }
+  ]
 }

--- a/examples/scitt/capsule-seam-vector.mjs
+++ b/examples/scitt/capsule-seam-vector.mjs
@@ -128,6 +128,54 @@ const denied = buildReceiptStatement({
   },
 });
 
+// --- Negative / MUST-reject vectors for the WHO leg --------------------------
+// Per Songbo Bu: a decomposition is only an interop surface if each leg ships its
+// own verifier contract AND negative cases. These are the WHO-leg rejects a
+// conforming composed verifier MUST enforce, each with the expected reason code.
+const ACTION_B = { action_type: 'payment.release', target: 'wire:vendor-acme-999999', amount: '999999.00', currency: 'USD' };
+const SUBJECT_DIGEST_B = sha256hex(Buffer.from(canonicalize(ACTION_B), 'utf8'));
+
+// A forged issuer: a different fixed seed signing a look-alike of the approved payload.
+const FORGED_SEED = crypto.createHash('sha256').update('ep:capsule-seam-vector:v1:FORGED-issuer').digest();
+const forgedKey = crypto.createPrivateKey({ key: Buffer.concat([PKCS8_ED25519_PREFIX, FORGED_SEED]), format: 'der', type: 'pkcs8' });
+const forgedSigOverApproved = crypto.sign(null, approved._payloadBytes, forgedKey);
+
+const negatives = [
+  {
+    id: 'wrong_action', must: 'reject', reason: 'who_subject_mismatch',
+    detail: 'WHO receipt binds ACTION A; a Capsule recording ACTION B must not accept it as B’s approval.',
+    capsule_subject_digest: SUBJECT_DIGEST_B, who_subject_digest: SUBJECT_DIGEST,
+    _check: () => SUBJECT_DIGEST !== SUBJECT_DIGEST_B,
+  },
+  {
+    id: 'approval_contradiction', must: 'reject', reason: 'disposition_contradicts_receipt',
+    detail: 'Capsule records human_disposed=approved but references the DENIED receipt digest — the WHO evidence is a refusal.',
+    referenced_authority_digest: denied.receipt_payload_digest,
+    _check: () => denied.payload.claim.outcome === 'deny',
+  },
+  {
+    id: 'untrusted_issuer', must: 'reject', reason: 'issuer_not_pinned',
+    detail: 'A receipt signed by a non-pinned key must fail verification under the pinned issuer SPKI — no trust laundering via a receipt-supplied key.',
+    forged_signature_b64: forgedSigOverApproved.toString('base64'),
+    _check: () => crypto.verify(null, approved._payloadBytes, publicKey, forgedSigOverApproved) === false,
+  },
+  {
+    id: 'replay_across_subject', must: 'reject', reason: 'receipt_action_bound',
+    detail: 'The approved receipt is bound to ACTION A via claim.subject_digest; presenting its digest for a Capsule over ACTION B must be refused (action-bound, one-time).',
+    receipt_bound_subject: SUBJECT_DIGEST, other_subject: SUBJECT_DIGEST_B,
+    _check: () => approved.payload.claim.subject_digest !== SUBJECT_DIGEST_B,
+  },
+  {
+    id: 'missing_who_when_required', must: 'policy_reject', reason: 'who_required_but_absent',
+    detail: 'When policy requires accountable-human approval, a Capsule chain with no resolvable WHO digest must be policy-rejected. Verdict-complete: a required-but-absent approval is itself the finding.',
+    _check: () => true,
+  },
+];
+
+function verifyNegatives() {
+  return negatives.map((n) => ({ id: n.id, must: n.must, reason: n.reason, enforced: Boolean(n._check()) }));
+}
+
 function verifyStatement(s) {
   const nativeOk = crypto.verify(null, s._payloadBytes, publicKey, s._nativeSig);
   const coseOk = crypto.verify(null, s._sigStructure, publicKey, s._coseSig);
@@ -156,6 +204,9 @@ function vectorJson() {
     },
     approved: strip(approved),
     denied: strip(denied),
+    action_b: ACTION_B,
+    subject_digest_b: SUBJECT_DIGEST_B,
+    must_reject: negatives.map(({ _check, ...rest }) => rest),
   };
 }
 
@@ -177,13 +228,17 @@ function main() {
   console.log(`    statement_digest       = ${denied.statement_digest}`);
   console.log(`    native_sig=${d.nativeOk ? 'OK' : 'FAIL'} cose_sig=${d.coseOk ? 'OK' : 'FAIL'} canonical_stable=${d.canonicalStable ? 'OK' : 'FAIL'}`);
 
+  const negs = verifyNegatives();
+  console.log('\n  MUST-REJECT (WHO-leg negative cases)');
+  for (const n of negs) console.log(`    ${n.enforced ? 'ENFORCED' : 'MISSING '} ${n.id} → ${n.must} (${n.reason})`);
+
   if (emit) {
     const path = fileURLToPath(new URL('./capsule-seam-vector.json', import.meta.url));
     writeFileSync(path, JSON.stringify(vectorJson(), null, 2) + '\n');
     console.log(`\n  wrote ${path}`);
   }
 
-  const ok = a.ok && d.ok;
+  const ok = a.ok && d.ok && negs.every((n) => n.enforced);
   console.log(`\n${ok ? 'SEAM VECTOR OK' : 'SEAM VECTOR FAIL'} — who(EMILIA) -> what(Capsule) linkage is byte-reproducible across implementations.`);
   if (!ok) process.exit(1);
 }


### PR DESCRIPTION
Follows Songbo Bu's on-list point: a decomposition is only an interop surface if each leg ships **negative cases**. Adds five enforced WHO-leg rejects to `examples/scitt/capsule-seam-vector.{mjs,json}` + `docs/EP-CAPSULE-SEAM.md`: wrong_action, approval_contradiction, untrusted_issuer, replay_across_subject, missing_who_when_required. Generator asserts all five ENFORCED alongside the approved/denied positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)