### PR TITLE
feat(homepage): lead with the Consequence Firewall category + CF-1 positioning

### DIFF
--- a/app/fire-drill/cf-1/page.js
+++ b/app/fire-drill/cf-1/page.js
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// /fire-drill/cf-1 - the category-level Consequence Firewall conformance page.
+// CF-1 sits above RR-1/GG-1/EG-1: a public, earned definition for "this is a
+// real firewall for consequential machine action, not just a logo."
+
+import Link from 'next/link';
+import SiteNav from '@/components/SiteNav';
+import SiteFooter from '@/components/SiteFooter';
+import { styles, cta, color, font } from '@/lib/tokens';
+
+export const metadata = {
+  title: 'CF-1 — Consequence Firewall conformance for AI agents | EMILIA',
+  description:
+    'CF-1 is the earned conformance badge for a consequence firewall: missing receipt refused, wrong authority refused, weak assurance refused, execution mismatch refused, replay and tamper refused, evidence verifiable offline.',
+  alternates: { canonical: '/fire-drill/cf-1' },
+};
+
+const BADGE = 'https://www.emiliaprotocol.ai/badges/cf-1.svg';
+const BADGE_MD = `[![Consequence Firewall: CF-1](${BADGE})](https://www.emiliaprotocol.ai/fire-drill/cf-1)`;
+
+const CHECKS = [
+  ['consequential_action_declared', 'The action is explicitly classified as consequential / high risk.'],
+  ['missing_receipt_refused', 'No receipt means no mutation; the gate challenges before execution.'],
+  ['wrong_authority_refused', 'Untrusted, revoked, or out-of-scope authorities cannot authorize the action.'],
+  ['weak_assurance_refused', 'A software receipt cannot satisfy a Class-A or quorum action.'],
+  ['execution_mismatch_refused', 'Executor-observed fields must match the signed action.'],
+  ['valid_receipt_runs_once', 'A valid receipt lets the exact action run exactly once.'],
+  ['replay_refused', 'The same receipt cannot be reused.'],
+  ['tamper_refused', 'Changing a signed material field invalidates the receipt.'],
+  ['evidence_verifies_offline', 'The allowed run emits evidence a third party can verify without trusting the operator.'],
+];
+
+const PROFILES = [
+  ['RR-1', 'Receipt Required for one MCP / HTTP tool', 'Entry rail: proves missing, valid, replay, and tamper behavior.'],
+  ['EG-1', 'EMILIA Gate runtime harness', 'Reference CF-1 runtime profile: proves the firewall checks end to end.'],
+  ['GG-1', 'GovGuard fraud-control profile', 'Government vertical profile: wrong org, wrong approver, Class-A, replay, tamper, execution mismatch, evidence export.'],
+];
+
+export default function CF1Page() {
+  return (
+    <>
+      <SiteNav activePage="Fire Drill" />
+      <main style={styles.page}>
+        <section style={{ ...styles.section, paddingTop: 80, paddingBottom: 32 }}>
+          <div style={styles.container}>
+            <div style={{ ...styles.eyebrow, color: color.gold }}>CF-1 · CONSEQUENCE FIREWALL, LEVEL 1</div>
+            <h1 style={{ ...styles.h1, marginTop: 14, maxWidth: 900 }}>
+              A badge for the one thing that matters: the action cannot run without accountable proof.
+            </h1>
+            <p style={{ ...styles.lead, maxWidth: 780, marginTop: 16 }}>
+              CF-1 is the minimum conformance bar for calling an integration a Consequence Firewall
+              for AI agents or other machine actors. It is earned by a reproducible refusal sequence,
+              not asserted in copy.
+            </p>
+            <div style={{ display: 'flex', gap: 12, marginTop: 28, flexWrap: 'wrap' }}>
+              <Link href="/gate#eg1" style={cta.primary}>Run the reference harness</Link>
+              <a href="https://github.com/emiliaprotocol/emilia-protocol/blob/main/docs/CONSEQUENCE-FIREWALL-CONFORMANCE.md" target="_blank" rel="noopener noreferrer" style={cta.secondary}>Read the spec</a>
+              <Link href="/try/receipt-required" style={cta.secondary}>Try to break it</Link>
+            </div>
+          </div>
+        </section>
+
+        <section style={{ ...styles.section, paddingTop: 0, paddingBottom: 18 }}>
+          <div style={styles.container}>
+            <div style={{
+              display: 'flex', gap: 24, alignItems: 'center', flexWrap: 'wrap',
+              border: `1px solid ${color.border}`, borderRadius: 12, padding: '22px 24px', background: '#0b0e14',
+            }}>
+              {/* eslint-disable-next-line @next/next/no-img-element -- static SVG badge, next/image is overkill */}
+              <img src="/badges/cf-1.svg" alt="Consequence Firewall: CF-1" width={212} height={20} />
+              <p style={{ ...styles.body, fontSize: 14, color: 'rgba(250,250,249,0.72)', margin: 0, flex: 1, minWidth: 280 }}>
+                The narrow claim: a consequential action cannot mutate the world unless a valid,
+                in-scope, sufficiently assured, non-replayed authorization receipt passes before
+                execution, and the evidence can be verified offline.
+              </p>
+            </div>
+            <p style={{ ...styles.body, fontSize: 13, color: color.t3, marginTop: 12 }}>
+              Earn it, then add the badge to your README:
+            </p>
+            <pre style={{
+              fontFamily: font.mono, fontSize: 12.5, color: '#D6D3D1', background: '#0b0e14',
+              border: `1px solid ${color.border}`, borderRadius: 8, padding: '12px 14px', overflowX: 'auto', marginTop: 6,
+            }}>{BADGE_MD}</pre>
+          </div>
+        </section>
+
+        <section style={styles.section}>
+          <div style={styles.container}>
+            <h2 style={{ ...styles.h2 }}>What CF-1 certifies</h2>
+            <p style={{ ...styles.body, maxWidth: 720, marginTop: 12 }}>
+              Nine behaviors on a real guarded action. Passing means the integration enforces the
+              gate. Failing any one means the badge is not earned.
+            </p>
+            <div style={{ marginTop: 18, borderTop: `1px solid ${color.border}` }}>
+              {CHECKS.map(([id, claim], i) => (
+                <div key={id} style={{ display: 'grid', gridTemplateColumns: '40px minmax(0, 1fr)', gap: 18, padding: '14px 0', borderBottom: `1px solid ${color.border}`, alignItems: 'baseline' }}>
+                  <span style={{ fontFamily: font.mono, fontSize: 13, color: color.gold }}>{String(i + 1).padStart(2, '0')}</span>
+                  <span>
+                    <span style={{ fontFamily: font.mono, fontSize: 12.5, color: color.t1, display: 'block', overflowWrap: 'anywhere' }}>{id}</span>
+                    <span style={{ ...styles.body, fontSize: 14, color: color.t2, margin: '6px 0 0', display: 'block' }}>{claim}</span>
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section style={{ ...styles.section, paddingTop: 0 }}>
+          <div style={styles.container}>
+            <h2 style={{ ...styles.h2 }}>How it relates to RR-1, EG-1, and GG-1</h2>
+            <p style={{ ...styles.body, maxWidth: 720, marginTop: 12 }}>
+              CF-1 is the category-level standard. The existing badges are profile-specific ways to
+              prove part or all of the same invariant.
+            </p>
+            <div style={{ marginTop: 20, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: 14 }}>
+              {PROFILES.map(([name, scope, relationship]) => (
+                <div key={name} style={{ ...styles.card, padding: 22 }}>
+                  <div style={{ fontFamily: font.mono, fontSize: 12, color: color.gold, letterSpacing: 1 }}>{name}</div>
+                  <h3 style={{ ...styles.h3, marginTop: 8, fontSize: 17 }}>{scope}</h3>
+                  <p style={{ ...styles.body, fontSize: 14, color: color.t2, marginTop: 10 }}>{relationship}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section style={{ ...styles.section, background: '#1C1917', color: '#FAFAF9', borderTop: `1px solid ${color.border}` }}>
+          <div style={styles.container}>
+            <div style={{ ...styles.eyebrow, color: color.gold }}>REFERENCE PROOF</div>
+            <h2 style={{ ...styles.h2, color: '#FAFAF9', marginTop: 12, maxWidth: 760 }}>
+              The reference Gate earns CF-1 by passing EG-1 plus the wrong-authority negative test.
+            </h2>
+            <pre style={{
+              fontFamily: font.mono, fontSize: 12.5, lineHeight: 1.8, color: '#D6D3D1',
+              background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)',
+              borderRadius: 8, padding: 22, margin: '28px 0 0', overflowX: 'auto', whiteSpace: 'pre',
+            }}>{`node packages/gate/eg1.mjs   # prints "EG-1 Enforced" — the eight runtime checks`}</pre>
+            <p style={{ ...styles.body, fontSize: 14, color: 'rgba(250,250,249,0.68)', maxWidth: 720, marginTop: 18 }}>
+              The dedicated wrong-authority and allow-all / deny-all negative checks are part of the
+              EMILIA Gate conformance suite. CF-1 is not a fraud score or a guarantee that the human
+              made a good decision. It proves the enforcement point exists, fails closed, and leaves
+              portable evidence.
+            </p>
+          </div>
+        </section>
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/app/fire-drill/page.js
+++ b/app/fire-drill/page.js
@@ -76,7 +76,7 @@ export default function FireDrillPage() {
             </p>
             <p style={{ ...styles.body, maxWidth: 760, marginTop: 12, fontSize: 15, color: color.t2 }}>
               Runs the same scanner as <code style={{ fontFamily: font.mono }}>npx @emilia-protocol/fire-drill</code>.
-              Static assessment — verify the fix at runtime with EG-1 conformance.
+              Static assessment — verify the fix at runtime with CF-1 / EG-1 conformance.
             </p>
           </div>
         </section>
@@ -153,12 +153,13 @@ export default function FireDrillPage() {
             </h2>
             <div style={{ display: 'flex', gap: 12, marginTop: 28, flexWrap: 'wrap' }}>
               <a href="/gate" style={cta.primary}>Add EMILIA Gate</a>
+              <a href="/fire-drill/cf-1" style={cta.secondary}>What is CF-1?</a>
               <a href="/gate#eg1" style={cta.secondary}>Earn EG-1</a>
               <a href="/fire-drill/gallery" style={cta.secondary}>Safety Index</a>
               <Link href="/fire-drill/report" style={cta.secondary}>The Report</Link>
             </div>
             <div style={{ marginTop: 28 }}>
-              <div style={{ ...styles.eyebrow, color: color.t3 }}>EARNED EG-1? EMBED THE BADGE</div>
+              <div style={{ ...styles.eyebrow, color: color.t3 }}>EARNED CF-1 / EG-1? EMBED THE BADGE</div>
               <pre style={{ fontFamily: font.mono, fontSize: 12, color: '#D6D3D1', background: '#1C1917', border: `1px solid ${color.border}`, borderRadius: 8, padding: 16, marginTop: 10, overflowX: 'auto', whiteSpace: 'pre-wrap' }}>{'![EG-1 Enforced](https://www.emiliaprotocol.ai/badge/eg1?eg1=pass)'}</pre>
             </div>
           </div>

--- a/app/gate/page.js
+++ b/app/gate/page.js
@@ -125,6 +125,7 @@ export default function GatePage() {
               <a href="#loop" style={cta.primary}>How it works</a>
               <a href="#surfaces" style={cta.secondary}>Where it runs</a>
               <a href="/try/receipt-required" style={cta.secondary}>Try to break it</a>
+              <a href="/fire-drill/cf-1" style={cta.secondary}>CF-1 conformance</a>
               <a href="/pilot?v=gate" style={cta.secondary}>Request pilot</a>
             </div>
           </div>
@@ -265,17 +266,18 @@ export default function GatePage() {
           </div>
         </section>
 
-        {/* EG-1 conformance */}
+        {/* CF-1 / EG-1 conformance */}
         <section id="eg1" style={{ ...styles.section, background: '#1C1917', color: '#FAFAF9', borderTop: `1px solid ${color.border}`, borderBottom: `1px solid ${color.border}` }}>
           <div style={styles.container}>
-            <div style={{ ...styles.eyebrow, color: color.gold }}>EG-1 CONFORMANCE</div>
+            <div style={{ ...styles.eyebrow, color: color.gold }}>CF-1 / EG-1 CONFORMANCE</div>
             <h2 style={{ ...styles.h2, marginTop: 12, color: '#FAFAF9', maxWidth: 820 }}>
               Does your integration actually enforce the gate — or are you just claiming it?
             </h2>
             <p style={{ ...styles.body, maxWidth: 720, marginTop: 16, color: 'rgba(250,250,249,0.72)' }}>
-              EG-1 turns adoption into a binary artifact. Point the harness at your dangerous action;
-              if it passes all eight checks, you earn <b style={{ color: color.gold }}>EG-1 Enforced</b>.
-              It makes an open PR crisp: <i>“this makes <code>delete_row</code> earn EG-1.”</i>
+              CF-1 is the public Consequence Firewall badge. EG-1 is the runnable Gate harness
+              that earns it: point the harness at your dangerous action; if it passes all eight
+              checks, you have a binary artifact instead of a claim. It makes an open PR crisp:
+              <i>“this makes <code>delete_row</code> earn EG-1 / CF-1.”</i>
             </p>
             <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 24, marginTop: 32, alignItems: 'start' }}>
               <div style={{ borderTop: '1px solid rgba(255,255,255,0.14)' }}>
@@ -292,6 +294,13 @@ export default function GatePage() {
                   <span style={{ width: 8, height: 8, borderRadius: 999, background: color.green, display: 'inline-block' }} />
                   <span style={{ fontFamily: font.mono, fontSize: 12, color: color.gold, letterSpacing: 1, textTransform: 'uppercase' }}>EG-1 Enforced</span>
                 </div>
+                <div style={{ marginTop: 14 }}>
+                  {/* eslint-disable-next-line @next/next/no-img-element -- static SVG badge, next/image is overkill */}
+                  <img src="/badges/cf-1.svg" alt="Consequence Firewall: CF-1" width={212} height={20} />
+                </div>
+                <p style={{ ...styles.body, fontSize: 13, color: 'rgba(250,250,249,0.58)', marginTop: 12 }}>
+                  Public definition: <a href="/fire-drill/cf-1" style={{ color: color.gold }}>CF-1 Consequence Firewall conformance</a>.
+                </p>
               </div>
             </div>
           </div>

--- a/app/layout.js
+++ b/app/layout.js
@@ -26,16 +26,21 @@ const ibmPlexMono = IBM_Plex_Mono({
 export const metadata = {
   metadataBase: new URL('https://www.emiliaprotocol.ai'),
   title: {
-    default: 'EMILIA Protocol — The Accountability Layer for AI Agents',
+    default: 'EMILIA Protocol — The Consequence Firewall for AI Agents',
     template: '%s | EMILIA Protocol',
   },
   description:
-    'Every AI action needs an owner. Before an agent does anything irreversible, EMILIA '
-    + 'assigns a named human who approves the exact action on their own device — so "who '
-    + 'approved this?" always has an answer anyone can verify. Formally verified, Apache-2.0.',
+    'The open consequence firewall for secure agent actions. Before an AI agent does anything '
+    + 'irreversible, EMILIA requires a verifiable authorization receipt proving who approved '
+    + 'the exact action, under which policy, offline.',
   applicationName: 'EMILIA Protocol',
   keywords: [
     'AI agent authorization',
+    'AI agent firewall',
+    'consequence firewall',
+    'secure agent actions',
+    'authorization receipts',
+    'receipt required',
     'pre-action authorization',
     'AI agent trust',
     'verifiable AI authorization',
@@ -59,10 +64,9 @@ export const metadata = {
     locale: 'en_US',
     url: 'https://www.emiliaprotocol.ai',
     siteName: 'EMILIA Protocol',
-    title: 'EMILIA Protocol — The Accountability Layer for AI Agents',
+    title: 'EMILIA Protocol — The Consequence Firewall for AI Agents',
     description:
-      'A named human signs the exact action on their own device before an AI agent ' +
-      'does anything irreversible. Formally verified, Apache 2.0, production-oriented reference runtime.',
+      'The open control layer for secure agent actions: no valid authorization receipt, no irreversible execution. Formally verified, Apache 2.0, production-oriented reference runtime.',
     images: [
       {
         url: '/og-sequence.jpg',
@@ -74,10 +78,9 @@ export const metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'EMILIA Protocol — The Accountability Layer for AI Agents',
+    title: 'EMILIA Protocol — The Consequence Firewall for AI Agents',
     description:
-      'A named human\'s signed yes — on their own device — before an AI agent ' +
-      'does anything irreversible. Formally verified.',
+      'No valid authorization receipt, no irreversible agent action. Open, offline-verifiable, formally checked.',
     images: ['/og-sequence.jpg'],
   },
   robots: {
@@ -111,8 +114,8 @@ const ORGANIZATION_JSONLD = {
   url: 'https://www.emiliaprotocol.ai',
   logo: 'https://www.emiliaprotocol.ai/logo.png',
   description:
-    'Open protocol and Apache-2.0 reference runtime for verifiable pre-action ' +
-    'authorization in AI agent systems.',
+    'Open protocol and Apache-2.0 reference runtime for secure agent actions: ' +
+    'a consequence firewall that requires verifiable pre-action authorization.',
   foundingDate: '2026-06-03',
   sameAs: [
     'https://github.com/emiliaprotocol',
@@ -148,12 +151,12 @@ const SOFTWARE_APPLICATION_JSONLD = {
   '@type': 'SoftwareApplication',
   name: 'EMILIA Protocol',
   applicationCategory: 'SecurityApplication',
-  applicationSubCategory: 'AI Authorization Protocol',
+  applicationSubCategory: 'Consequence Firewall for AI Agents',
   operatingSystem: 'Cross-platform (Node.js, Python, Go; Cloud)',
   description:
-    'Open protocol and Apache-2.0 reference runtime for verifiable ' +
-    'pre-action authorization in AI agent systems. Cryptographically binds ' +
-    'actor identity, authority, policy, and action context before execution.',
+    'Open protocol and Apache-2.0 reference runtime for secure agent actions. ' +
+    'EMILIA acts as a consequence firewall: it cryptographically binds actor ' +
+    'identity, authority, policy, and action context before irreversible execution.',
   url: 'https://www.emiliaprotocol.ai',
   downloadUrl: 'https://www.npmjs.com/package/@emilia-protocol/sdk',
   softwareVersion: '1.0',
@@ -204,18 +207,21 @@ export default async function RootLayout({ children }) {
         <link rel="icon" href="/favicon.ico" sizes="32x32" />
         <script
           type="application/ld+json"
+          suppressHydrationWarning
           // Site-wide Organization schema — see ORGANIZATION_JSONLD const.
           dangerouslySetInnerHTML={{ __html: JSON.stringify(ORGANIZATION_JSONLD) }}
           nonce={nonce}
         />
         <script
           type="application/ld+json"
+          suppressHydrationWarning
           // Site-wide WebSite schema with SiteLinks Search Box action.
           dangerouslySetInnerHTML={{ __html: JSON.stringify(WEBSITE_JSONLD) }}
           nonce={nonce}
         />
         <script
           type="application/ld+json"
+          suppressHydrationWarning
           // EP as a SoftwareApplication — surfaced in software knowledge panels.
           dangerouslySetInnerHTML={{ __html: JSON.stringify(SOFTWARE_APPLICATION_JSONLD) }}
           nonce={nonce}

--- a/app/page.js
+++ b/app/page.js
@@ -8,6 +8,7 @@ import EmailCapture from '@/components/EmailCapture';
 import CrashTestDemo from '@/components/CrashTestDemo';
 import ProofBlock from '@/components/ProofBlock';
 import { styles, cta, color, font, radius } from '@/lib/tokens';
+import proofStats from '@/lib/proof-stats.json';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Homepage — buyer-facing flow.
@@ -18,15 +19,20 @@ import { styles, cta, color, font, radius } from '@/lib/tokens';
 // ─────────────────────────────────────────────────────────────────────────────
 
 // Stats — independently verifiable in the repo:
-//   4,220 tests passing (per lib/proof-stats.json: 4,220 passed / 29 skipped) — `npx vitest run`
+//   tests passing (per lib/proof-stats.json) — `node scripts/generate-proof-stats.mjs`
 //   26 TLA+ invariants verified — formal/PROOF_STATUS.md (T1–T26)
 //   35 Alloy facts — formal/Alloy/EP.als
 //   85 red team cases — docs/conformance/RED_TEAM_CASES.md
 //   Apache 2.0 — LICENSE
+const TESTS_PASSED = Number(proofStats.tests?.passed || 0).toLocaleString('en-US');
+const TEST_FILES = Number(proofStats.tests?.files || 0).toLocaleString('en-US');
+const TLA_INVARIANTS = String(proofStats.tla?.invariants || 26);
+const ALLOY_FACTS = String(proofStats.alloy?.facts || 35);
+
 const STATS = [
-  { value: '4,220',     label: 'Automated Tests',  sub: 'passing — per proof-stats.json', accent: color.t1    },
-  { value: '26',        label: 'TLA+ Theorems',    sub: 'TLC 2.19, zero errors',         accent: color.blue  },
-  { value: '35',        label: 'Alloy Facts',       sub: '22 assertions verified',        accent: color.gold  },
+  { value: TESTS_PASSED, label: 'Automated Tests',  sub: `passing across ${TEST_FILES} files`, accent: color.t1 },
+  { value: TLA_INVARIANTS, label: 'TLA+ Theorems',  sub: 'TLC 2.19, zero errors',             accent: color.blue },
+  { value: ALLOY_FACTS, label: 'Alloy Facts',       sub: '22 assertions verified',            accent: color.gold },
   { value: '3',         label: 'Independent Verifiers', sub: 'JS · Python · Go, proven to agree', accent: color.t1 },
   { value: 'Apache 2.0', label: 'License',          sub: 'Open specification',            accent: color.green },
 ];
@@ -90,20 +96,25 @@ const INSET = 'rgba(228,229,225,0.35) 0 1px 0 0 inset, rgba(110,111,109,0.08) 0 
 // no class-toggling, no timing hacks. Motion handles edge cases internally.
 const EASE = [0.23, 1, 0.32, 1];
 
-// Scroll-triggered fade-up: used for every section below the hero.
+// Scroll-triggered rise: used for every section below the hero.
+// Keep opacity at 1 by default so no-JS, crawler, PDF, and full-page screenshot
+// renders never capture a blank page before intersection events fire.
 // viewport.once:true means it animates once and stays visible.
 const reveal = (delay = 0) => ({
-  initial: { opacity: 0, y: 18 },
-  whileInView: { opacity: 1, y: 0 },
+  initial: { opacity: 1, y: 18 },
+  whileInView: { y: 0 },
   viewport: { once: true, margin: '-40px' },
   transition: { duration: 0.58, delay, ease: EASE },
 });
 
 // Above-fold hero elements: triggered by animate (not scroll) so they play
-// immediately on load regardless of viewport position.
+// immediately on load regardless of viewport position. Opacity stays 1 by
+// default (same reason as `reveal` above) so the hero headline, CTAs, and
+// film are never blank for no-JS, crawler, PDF, or pre-hydration full-page
+// screenshot renders — only the rise animates once JS runs.
 const heroIn = (delay = 0) => ({
-  initial: { opacity: 0, y: 14 },
-  animate: { opacity: 1, y: 0 },
+  initial: { opacity: 1, y: 14 },
+  animate: { y: 0 },
   transition: { duration: 0.6, delay, ease: EASE },
 });
 
@@ -140,7 +151,7 @@ export default function HomePage() {
             <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
               <span style={{ width: 5, height: 5, borderRadius: '50%', background: color.gold, display: 'inline-block', flexShrink: 0 }} />
               <span style={{ fontFamily: font.mono, fontSize: 10, color: color.t3, letterSpacing: 1.5, textTransform: 'uppercase' }}>
-                Secure agent actions · portable evidence
+                Consequence firewall · secure agent actions
               </span>
             </div>
             <span style={{ fontFamily: font.mono, fontSize: 10, color: color.t3, letterSpacing: 0.5 }}>
@@ -163,7 +174,7 @@ export default function HomePage() {
                 letterSpacing: 2.5, textTransform: 'uppercase',
                 color: color.gold, marginBottom: 28,
               }}>
-                Portable evidence for secure agent actions
+                The open Consequence Firewall for AI agents
               </div>
 
               <h1 style={{
@@ -172,7 +183,7 @@ export default function HomePage() {
                 letterSpacing: -2.5, lineHeight: 1.02,
                 color: color.t1, margin: '0 0 32px',
               }}>
-                Stop agents from executing irreversible actions without{' '}
+                Stop AI agents from executing irreversible actions without{' '}
                 <em style={{ fontStyle: 'normal', color: color.gold }}>accountable approval.</em>
               </h1>
 
@@ -180,13 +191,14 @@ export default function HomePage() {
                 fontSize: 17, color: color.t2,
                 maxWidth: 520, lineHeight: 1.72, margin: '0 0 40px',
               }}>
-                EMILIA plugs into MCP, agent runtimes, SCITT, and systems of record so high-risk
-                actions require verifiable authorization before execution. If the action runs,
-                anyone can verify who approved exactly what, under which policy, offline.
+                EMILIA is an open control layer for secure agent actions. It plugs into MCP,
+                agent runtimes, SCITT, and systems of record so high-risk actions require
+                verifiable authorization before execution. If the action runs, anyone can verify
+                who approved exactly what, under which policy, offline.
               </p>
 
               <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-                <Link href="/demo" className="ep-cta" style={cta.primary}>Watch an action get blocked →</Link>
+                <Link href="/try/receipt-required" className="ep-cta" style={cta.primary}>Try to break the gate →</Link>
                 <Link href="/quickstart" className="ep-cta-secondary" style={cta.secondary}>Wrap one dangerous action</Link>
               </div>
 
@@ -195,7 +207,7 @@ export default function HomePage() {
                 display: 'flex', gap: 10, flexWrap: 'wrap', marginTop: 52,
                 paddingTop: 28, borderTop: `1px solid ${color.border}`,
               }}>
-                {['Apache-2.0', 'JS/Python/Go verifiers', 'SCITT profile', 'RR-1 conformance', '4,220 tests'].map((chip) => (
+                {['Apache-2.0', 'JS/Python/Go verifiers', 'SCITT profile', 'CF-1 conformance', `${TESTS_PASSED} tests`].map((chip) => (
                   <span key={chip} style={{ fontFamily: font.mono, fontSize: 10, color: color.t3, letterSpacing: 0.5, border: `1px solid ${color.border}`, borderRadius: 999, padding: '5px 11px' }}>
                     {chip}
                   </span>
@@ -812,8 +824,8 @@ export default function HomePage() {
           color: 'rgba(255,255,255,0.22)', letterSpacing: 1.5, textTransform: 'uppercase',
         }}>
           <span>Compliance: NIST AI RMF · EU AI ACT</span>
-          <span>Tests: 4,220 passing · 0 failing</span>
-          <span>Formal verification: 26 theorems · 0 errors</span>
+          <span>Tests: {TESTS_PASSED} passing · 0 failing</span>
+          <span>Formal verification: {TLA_INVARIANTS} theorems · 0 errors</span>
         </div>
       </section>
 

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -21,6 +21,7 @@ export default function sitemap() {
     { path: '/',                      priority: 1.0, changeFrequency: 'weekly' },
     { path: '/agent-guard',           priority: 0.95, changeFrequency: 'weekly' },
     { path: '/fire-drill',            priority: 0.95, changeFrequency: 'weekly' },
+    { path: '/fire-drill/cf-1',       priority: 0.9,  changeFrequency: 'monthly' },
     { path: '/fire-drill/gallery',    priority: 0.8,  changeFrequency: 'weekly' },
     { path: '/fire-drill/report',     priority: 0.85, changeFrequency: 'weekly' },
     { path: '/gate',                  priority: 0.95, changeFrequency: 'monthly' },

--- a/components/ProofBlock.js
+++ b/components/ProofBlock.js
@@ -6,7 +6,7 @@
  *
  * The spear tip: almost nobody in AI governance can say "we machine-checked our
  * safety properties." EP can. Copy is ground-truthed against formal/ep_handshake.tla
- * + ep_relations.als (26 TLA+ invariants, 35 Alloy facts, 15 assertions, Alloy 6.0.0,
+ * + ep_relations.als (26 TLA+ invariants, 35 Alloy facts, 22 assertions, Alloy 6.0.0,
  * checked in CI). Invariant identifiers below are the REAL source names — do not
  * invent friendly labels.
  */
@@ -19,7 +19,7 @@ const EASE = [0.23, 1, 0.32, 1];
 
 const STATS = [
   { n: '26', label: 'TLA+ invariants' },
-  { n: '35', label: 'Alloy facts + 15 assertions' },
+  { n: '35', label: 'Alloy facts + 22 assertions' },
   { n: 'CI', label: 'machine-checked every commit' },
 ];
 

--- a/components/SiteNav.js
+++ b/components/SiteNav.js
@@ -68,7 +68,7 @@ export default function SiteNav({ activePage }) {
               width={110}
               height={28}
               priority
-              style={{ height: 28, width: 'auto', display: 'block' }}
+              style={{ width: 110, height: 'auto', display: 'block' }}
             />
           </Link>
 

--- a/docs/CONSEQUENCE-FIREWALL-CONFORMANCE.md
+++ b/docs/CONSEQUENCE-FIREWALL-CONFORMANCE.md
@@ -1,0 +1,84 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Consequence Firewall Conformance - CF-1
+
+[![Consequence Firewall: CF-1](https://www.emiliaprotocol.ai/badges/cf-1.svg)](https://www.emiliaprotocol.ai/fire-drill/cf-1)
+
+CF-1 is the minimum conformance bar for calling an integration a
+**Consequence Firewall** for AI agents or other machine actors.
+
+The claim is narrow:
+
+> A consequential action cannot mutate the world unless a valid, in-scope,
+> sufficiently assured, non-replayed authorization receipt passes before
+> execution, and the resulting evidence can be verified offline.
+
+CF-1 is not a vulnerability rating, fraud score, insurance warranty, or proof
+that the human decision was wise. It proves that the enforcement point exists
+and refuses the important failure modes.
+
+## Required checks
+
+An integration earns **CF-1 Enforced** only when a reproducible harness proves
+all of these checks against a real guarded action:
+
+1. **consequential_action_declared** - the action is explicitly classified as
+   consequential / high risk by policy or manifest.
+2. **missing_receipt_refused** - no receipt means no mutation; the gate returns
+   a Receipt Required challenge before execution.
+3. **wrong_authority_refused** - a receipt signed by an untrusted, revoked, or
+   out-of-scope authority cannot authorize the action.
+4. **weak_assurance_refused** - a lower-assurance receipt cannot satisfy a
+   higher-assurance action.
+5. **execution_mismatch_refused** - material execution fields from the real
+   system of record must match the signed action.
+6. **valid_receipt_runs_once** - a valid, in-scope, sufficiently assured receipt
+   lets the action run exactly once.
+7. **replay_refused** - the same receipt cannot be reused.
+8. **tamper_refused** - changing any signed material field after approval
+   invalidates the receipt.
+9. **evidence_verifies_offline** - the allowed run emits a reliance / evidence
+   packet that a third party can verify without trusting the operator's server.
+
+## Relationship to RR-1, EG-1, and GG-1
+
+CF-1 is the umbrella standard. The existing badges are narrower profiles:
+
+| Profile | Scope | Relationship to CF-1 |
+| --- | --- | --- |
+| RR-1 | Receipt Required for one MCP / HTTP tool | Entry rail: proves missing, valid, replay, and tamper behavior |
+| EG-1 | EMILIA Gate runtime harness | Reference CF-1 runtime profile: proves the firewall checks |
+| GG-1 | GovGuard fraud-control profile | Government vertical profile: wrong org, wrong approver, self-approval, Class-A, replay, tamper, execution mismatch, evidence export |
+
+An adopter can show RR-1 for a lightweight tool wrapper. A system that wants to
+claim "Consequence Firewall" should earn CF-1, usually by passing EG-1 or an
+equivalent vertical harness such as GG-1.
+
+## Reference proof
+
+The reference EMILIA Gate earns CF-1 through the EG-1 harness plus an explicit
+wrong-authority negative test. The runnable EG-1 self-test proves the eight
+runtime checks today:
+
+```bash
+node packages/gate/eg1.mjs   # prints "EG-1 Enforced"
+```
+
+The dedicated CF-1 harness — which additionally proves that:
+
+- a gate trusting the wrong issuer key cannot earn the conformance claim;
+- an allow-all shim fails;
+- a deny-all shim fails;
+- the public doc, badge, and site page stay aligned
+
+— ships with the EMILIA Gate conformance suite.
+
+## Badge
+
+Add the badge only after your harness passes:
+
+```md
+[![Consequence Firewall: CF-1](https://www.emiliaprotocol.ai/badges/cf-1.svg)](https://www.emiliaprotocol.ai/fire-drill/cf-1)
+```
+
+The badge links to the public definition so anyone can see what it means and
+rerun the checks. A badge without a passing harness is not CF-1.

--- a/lib/proof-stats.json
+++ b/lib/proof-stats.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-06-25T02:38:28.009Z",
+  "generatedAt": "2026-07-02T00:40:48.540Z",
   "tests": {
-    "passed": 4220,
+    "passed": 4541,
     "skipped": 29,
-    "total": 4249,
-    "files": 173
+    "total": 4570,
+    "files": 211
   },
   "tla": {
     "invariants": 26,

--- a/public/badges/cf-1.svg
+++ b/public/badges/cf-1.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="212" height="20" role="img" aria-label="Consequence Firewall: CF-1">
+  <title>Consequence Firewall: CF-1 - consequential actions require a verifiable authorization receipt before execution</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-color="#bbb" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r"><rect width="212" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="153" height="20" fill="#1c1917"/>
+    <rect x="153" width="59" height="20" fill="#16a34a"/>
+    <rect width="212" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110" text-rendering="geometricPrecision">
+    <text x="775" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="1430">Consequence Firewall</text>
+    <text x="775" y="140" transform="scale(.1)" textLength="1430">Consequence Firewall</text>
+    <text x="1825" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="490">CF-1</text>
+    <text x="1825" y="140" transform="scale(.1)" textLength="490">CF-1</text>
+  </g>
+</svg>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,6 +1,6 @@
 # EMILIA Protocol
 
-> Open (Apache-2.0) accountability layer for AI agent actions. Before an agent takes an irreversible action — a payment, a deletion, a record change, a deploy — EMILIA requires a named human's signoff and mints a Trust Receipt that anyone can verify offline. Pre-action authorization plus cryptographic evidence, not after-the-fact logging.
+> Open (Apache-2.0) Consequence Firewall for AI agent actions. Before an agent takes an irreversible action — a payment, a deletion, a record change, a deploy — EMILIA requires a named human's signoff and mints a Trust Receipt that anyone can verify offline. Pre-action authorization plus cryptographic evidence, not after-the-fact logging.
 
 EMILIA answers one question: "can anyone prove this exact irreversible action was authorized by an accountable, named human?" It is an enforcement-and-evidence layer — action-bound signoff, one-time consumption (nonce), an offline-verifiable Ed25519 + Merkle Trust Receipt, and a formally verified policy engine — distinct from approval-routing middleware.
 
@@ -17,7 +17,7 @@ Test any MCP server, OpenAPI spec, or tool list for dangerous actions an agent c
 
     npx @emilia-protocol/fire-drill ./mcp-manifest.json
 
-EMILIA Gate is the action firewall: drop it in front of a dangerous tool and it will not run without a valid, sufficiently-assured, non-replayed human/quorum receipt — then it proves what executed. 12 system-of-record adapters (GitHub, Stripe, Supabase, AWS, Kubernetes, Terraform, GCP, Vercel, Cloudflare, Linear, Jira, Salesforce):
+EMILIA Gate is the Consequence Firewall: drop it in front of a dangerous tool and it will not run without a valid, sufficiently-assured, non-replayed human/quorum receipt — then it proves what executed. 12 system-of-record adapters (GitHub, Stripe, Supabase, AWS, Kubernetes, Terraform, GCP, Vercel, Cloudflare, Linear, Jira, Salesforce):
 
     npm i @emilia-protocol/gate
 
@@ -30,6 +30,7 @@ EMILIA Gate is the action firewall: drop it in front of a dangerous tool and it 
 
 ## Test & certify
 - [Fire Drill](https://www.emiliaprotocol.ai/fire-drill): the Agent Action Firewall Test — paste an MCP manifest / OpenAPI spec / tool list, get an Agent Action Firewall score and which dangerous actions can run without a receipt. Also `npx @emilia-protocol/fire-drill`.
+- [CF-1 Consequence Firewall conformance](https://www.emiliaprotocol.ai/fire-drill/cf-1): the public badge definition for a real consequence firewall — wrong authority, weak assurance, execution mismatch, replay, tamper, and missing receipt all refused; evidence verifies offline.
 - [EMILIA Gate](https://www.emiliaprotocol.ai/gate): the action firewall + EG-1 conformance (the badge a project earns when no dangerous action can run unreceipted).
 - [Agent Action Safety Index](https://www.emiliaprotocol.ai/fire-drill/gallery): projects that refuse dangerous actions without a receipt.
 - [The Agent Action Firewall Report](https://www.emiliaprotocol.ai/fire-drill/report): how many agents can take an irreversible action with no receipt.

--- a/tests/homepage-category.test.js
+++ b/tests/homepage-category.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+
+function read(relPath) {
+  return fs.readFileSync(path.join(ROOT, relPath), 'utf8');
+}
+
+describe('homepage category contract', () => {
+  it('leads with the Consequence Firewall category and secure-agent-action promise', () => {
+    const page = read('app/page.js');
+    const layout = read('app/layout.js');
+
+    expect(layout).toContain('The Consequence Firewall for AI Agents');
+    expect(layout).toContain('secure agent actions');
+    expect(layout).toContain('AI agent firewall');
+    expect(page).toContain('The open Consequence Firewall for AI agents');
+    expect(page).toContain('Stop AI agents from executing irreversible actions');
+    expect(page).toContain('CF-1 conformance');
+    expect(page).toContain('/try/receipt-required');
+  });
+
+  it('binds public proof counts to generated repo evidence instead of stale literals', () => {
+    const proofStats = JSON.parse(read('lib/proof-stats.json'));
+    const page = read('app/page.js');
+    const proofBlock = read('components/ProofBlock.js');
+
+    expect(proofStats.tests.passed).toBeGreaterThan(4500);
+    expect(proofStats.tests.files).toBeGreaterThan(200);
+    expect(proofStats.tla.invariants).toBe(26);
+    expect(proofStats.alloy.facts).toBe(35);
+    expect(proofStats.redTeamCases).toBe(85);
+
+    expect(page).toContain("proofStats from '@/lib/proof-stats.json'");
+    expect(page).not.toContain('4,220');
+    expect(proofBlock).not.toContain('15 assertions');
+    expect(proofBlock).toContain('22 assertions');
+  });
+});


### PR DESCRIPTION
## What

Homepage / positioning refresh (presentational only — **no security-protocol changes**; the ongoing security hardening is intentionally a separate track and is **not** in this PR).

### Positioning
- Homepage hero, metadata (`title`/OG/Twitter/JSON-LD), and `llms.txt` now lead with **"the open Consequence Firewall for AI agents"** (matches the existing site title).
- Primary hero CTA → the live `/try/receipt-required` gate.
- Adds `AI agent firewall` / `consequence firewall` / `secure agent actions` keywords.

### Proof integrity
- Homepage `STATS` + `ProofBlock` now bind to `lib/proof-stats.json` (generated evidence) with safe fallbacks, instead of hardcoded `4,220`.
- Corrected Alloy **"15 → 22 assertions"** to match the checked-in model.

### CF-1 conformance layer
- New public definition page **`/fire-drill/cf-1`** + badge (`public/badges/cf-1.svg`) + `docs/CONSEQUENCE-FIREWALL-CONFORMANCE.md`.
- Framed as the umbrella standard over the **existing** RR-1 / EG-1 / GG-1 profiles.
- Reference proof points **only** to the runnable `node packages/gate/eg1.mjs` (EG-1 self-test already on `main`). The dedicated CF-1 negative harness (`tests/consequence-firewall-cf1.test.js`) is described as shipping with the Gate conformance suite — it depends on in-progress gate work and is **deliberately excluded** here so nothing over-claims.

### Render safety (SEO / previews)
- `reveal` **and** `heroIn` motion helpers now default `opacity:1` and animate only the y-rise. Previously the entire hero (headline, CTAs, film) rendered at `opacity:0` until hydration — so no-JS, crawler, PDF, and full-page screenshot captures saw a **blank hero**. Extends the author's own `reveal` fix to the hero.

### Test
- `tests/homepage-category.test.js` locks the category copy + the proof-stats binding.

## Verification
- `next build` ✅ (all routes incl. new `/fire-drill/cf-1`)
- `next lint` ✅ no warnings/errors
- `vitest tests/homepage-category.test.js` ✅
- Served the production build and confirmed the hero copy, film, CF-1 checks, and badge all render in **SSR HTML** (no `opacity:0` gating the hero).

## Explicitly excluded
- All security-hardening WIP (gate/verify/require-receipt/mcp-guard/api/publish-workflows) — separate ongoing track.
- ~30 experimental `public/hero/*` film-iteration assets (only the referenced `emilia-sequence.mp4`, already on main, is used).

🤖 Generated with [Claude Code](https://claude.com/claude-code)