### PR TITLE
fix(security): code-actionable hardening cluster (reconciled onto current main)

### DIFF
--- a/app/api/demo/require-receipt/route.js
+++ b/app/api/demo/require-receipt/route.js
@@ -114,9 +114,27 @@ function gateFor(demo) {
       manifestUrl: MANIFEST_URL,
       maxAgeSec: 900,
       statusCode: RR,
+      verifyAssurance: (doc) => demoAssurance(demo, doc),
     }));
   }
   return gates.get(demo.id);
+}
+
+function demoAssurance(demo, doc) {
+  const claim = doc?.payload?.claim || {};
+  if (claim.policy_id !== demo.policy_id || claim.outcome !== 'allow_with_signoff') {
+    return { ok: false, tier: 'software', reason: 'assurance_proof_required' };
+  }
+  if (demo.quorum?.required) {
+    const q = claim.quorum || {};
+    const signers = Array.isArray(q.signers) ? q.signers : [];
+    const threshold = Number(q.threshold ?? q.m ?? 0);
+    if (threshold >= 2 && new Set(signers).size >= threshold) {
+      return { ok: true, tier: 'quorum', reason: 'demo_assurance_verified' };
+    }
+    return { ok: false, tier: 'class_a', reason: 'assurance_too_low' };
+  }
+  return { ok: true, tier: 'class_a', reason: 'demo_assurance_verified' };
 }
 
 function challengeHeaders(demo) {

--- a/app/api/trust/gate/route.js
+++ b/app/api/trust/gate/route.js
@@ -12,7 +12,10 @@ import { getGuardedClient } from '@/lib/write-guard';
 import { protocolWrite, COMMAND_TYPES } from '@/lib/protocol-write';
 import { canonicalize } from '@/lib/canonical-json';
 import { sha256 } from '@/lib/handshake/invariants';
+import { readLimitedJson } from '@/lib/http/body-limit';
 import { logger } from '../../../../lib/logger.js';
+
+const MAX_TRUST_GATE_BYTES = 256 * 1024;
 
 const GATE_POLICIES = {
   strict:     { min_ee: 40,  max_dispute_rate: 0.02, require_established: true },
@@ -22,7 +25,11 @@ const GATE_POLICIES = {
 
 export async function POST(request) {
   try {
-    const body = await request.json().catch(() => ({}));
+    const parsed = await readLimitedJson(request, MAX_TRUST_GATE_BYTES, { invalidValue: {} });
+    if (!parsed.ok) {
+      return NextResponse.json({ error: parsed.detail || 'Request body too large', code: parsed.code }, { status: parsed.status });
+    }
+    const body = parsed.value;
 
     const auth = await authenticateRequest(request);
     if (auth.error) return EP_ERRORS.UNAUTHORIZED();

--- a/app/api/v1/guarded/route.js
+++ b/app/api/v1/guarded/route.js
@@ -69,6 +69,14 @@ export async function POST(request) {
     return NextResponse.json({ ...receiptChallenge(action, 'Receipt rejected: missing_created_at.'), rejected }, { status: 402 });
   }
 
+  // A verified receipt with no receipt_id cannot be bound to a one-time
+  // consumption record, so it could be replayed indefinitely (every no-id
+  // receipt would collapse to the same empty consume key). Refuse it outright.
+  if (!v.receipt_id) {
+    const rejected = { ok: false, reason: 'missing_receipt_id', detail: 'receipt has no receipt_id; cannot enforce one-time consumption' };
+    return NextResponse.json({ ...receiptChallenge(action, 'Receipt rejected: missing_receipt_id.'), rejected }, { status: 402 });
+  }
+
   // One-time consumption (replay defense): a verified receipt authorizes ONE
   // action, once. Reserve the receipt id (action-scoped) atomically; a replay of
   // the same receipt loses the race and is refused. Commit after we decide to

--- a/conformance/ep-conformance-test.js
+++ b/conformance/ep-conformance-test.js
@@ -8,8 +8,7 @@
  * any other conformant operator via self-verifying receipts.
  *
  * Usage:
- *   npx ep-conformance-test https://ep.example.com
- *   node ep-conformance-test.js https://ep.example.com
+ *   node conformance/ep-conformance-test.js https://ep.example.com
  *
  * Checks:
  *   [REQUIRED] /.well-known/ep-trust.json discovery
@@ -33,8 +32,8 @@ import crypto from 'crypto';
 
 const baseUrl = process.argv[2];
 if (!baseUrl) {
-  console.error('Usage: ep-conformance-test <base-url>');
-  console.error('Example: ep-conformance-test https://ep.example.com');
+  console.error('Usage: node conformance/ep-conformance-test.js <base-url>');
+  console.error('Example: node conformance/ep-conformance-test.js https://ep.example.com');
   process.exit(2);
 }
 

--- a/conformance/vectors/provenance.exec.v1.json
+++ b/conformance/vectors/provenance.exec.v1.json
@@ -13,7 +13,7 @@
         "@version": "EP-PROVENANCE-CHAIN-v1",
         "root_signoff": {
           "receipt": {
-            "receipt_id": "ep:receipt:0QkxAVjr2JM",
+            "receipt_id": "ep:receipt:ycatT-nMPtw",
             "action": {
               "action_type": "payment.release",
               "policy_id": "pol:test",
@@ -34,51 +34,54 @@
                 "approver": "ep:approver:dir",
                 "approver_index": 1,
                 "required_approvals": 1,
-                "nonce": "6uKjweOp24KJPgwOUhTUtA",
+                "nonce": "ytWC8Y5Bhs-56re2bKzkoQ",
                 "issued_at": "2026-06-13T11:00:00.000Z",
                 "expires_at": "2026-06-13T18:00:00.000Z"
               }
             ],
             "signoffs": [
               {
-                "context_hash": "sha256:59349d68b237534f885900307d36ad8945debc23f2cfdddd33630a6b9e0637fa",
+                "context_hash": "sha256:0c2d364fa57511c6b4b5d558c1af71aba3d9a2ac6f5753e3e71ed2c2cb534df1",
                 "key_class": "A",
                 "approver_key_id": "ep:key:dir#1",
                 "signed_at": "2026-06-13T11:00:00.000Z",
                 "webauthn": {
                   "authenticator_data": "eW6Ax-W_ikjLYD8inu7FeOxyRD2_43cQzIDeZyKMZxMFAAAAAQ",
-                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiV1RTZGFMSTNVMC1JV1FBd2ZUYXRpVVhldkNQeXo5M2RNMk1LYTU0R05fbyIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
-                  "signature": "MEUCIQDkYAC8sXMHaKsH-dXava20VTe6Fo7ty3130yk7c7k_ngIgaD5kMj_d5RJS0U-lCkiPqZCWgmT_AjuhGktbWV60yiQ"
+                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiREMwMlQ2VjFFY2EwdGRWWXdhOXhxNlBab3F4dlYxUGo1eDdTd3N0VFRmRSIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+                  "signature": "MEQCIAXKjbRkEPIq-OlBglTbw61PRxjT3VfnTe8US45wXoh3AiBZgDV3Jp8RHTHIarwY_lo8HYcI5dQ5rvV14hOtntT2fw"
                 },
-                "signature": "MEUCIQDkYAC8sXMHaKsH-dXava20VTe6Fo7ty3130yk7c7k_ngIgaD5kMj_d5RJS0U-lCkiPqZCWgmT_AjuhGktbWV60yiQ"
+                "signature": "MEQCIAXKjbRkEPIq-OlBglTbw61PRxjT3VfnTe8US45wXoh3AiBZgDV3Jp8RHTHIarwY_lo8HYcI5dQ5rvV14hOtntT2fw"
               }
             ],
             "consumption": {
-              "nonce": "lbV4CLKFfnklckopm8D_jg",
+              "nonce": "nY-4vcpagqcS9_etjn5qIA",
               "state": "COMMITTED",
               "committed_at": "2026-06-13T11:30:00.000Z"
             },
             "log_proof": {
+              "alg": "EP-MERKLE-v2",
+              "leaf_hash": "sha256:fed190c221f918cbb0a32b7c8f5b9798c0fd83fdf7a8b9d89720e2dacdb94bb9",
               "leaf_index": 0,
               "inclusion_path": [],
               "checkpoint": {
                 "tree_size": 1,
-                "root_hash": "sha256:a6683aa48a54e71cbd6849042d2f5ec47e50bef7db1e031c0f3c84cc8e1c62cf",
+                "root_hash": "sha256:fed190c221f918cbb0a32b7c8f5b9798c0fd83fdf7a8b9d89720e2dacdb94bb9",
                 "log_key_id": "ep:log:test#1",
-                "log_signature": "Irt_aAKPIoj_aIbPz_tjFWXolc3iusSecm3DmOQXqUR4x_sNOWow7ChgJOoBCm_iahjhjVVf7lo3Sb3RbwwTDg"
+                "merkle_alg": "EP-MERKLE-v2",
+                "log_signature": "kAQkRAJ4cSI0Rkigqld8MpXAtRYbd3KWAW3TzdDpjHFP41kU8Ll4Fq76fX3rjJ-PMbOf48L7njKHwe3i0h14CA"
               }
             }
           },
           "verification": {
             "approver_keys": {
               "ep:key:dir#1": {
-                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEv422pG7WjGnelQVcrMbzv3brcQ_pJN4m8HEVTVVx5lqcZYA04WBSAwqjv2KSw3VEnbuUdaTPl6JNOLiZFwP9DQ",
+                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVm8SGhyzPEpi7OSadeGu7ybDV3DSxNJnY8sPDJz7vFf9RoWseYN21AWX_vJHGxfR8EX_Xi26oaJGJboRHP_mmQ",
                 "key_class": "A",
                 "valid_from": "2026-01-01T00:00:00Z",
                 "valid_to": "2036-01-01T00:00:00Z"
               }
             },
-            "log_public_key": "MCowBQYDK2VwAyEAItyvtSAwEGP1jLhH44Ckz4Nf-ekFVZIoinClvMcqZ_U"
+            "log_public_key": "MCowBQYDK2VwAyEATtJ0FA9c6RxWfz8O2CIElQVdICThIqBMdHo-WTXeZL0"
           },
           "human_key_classes": [
             "A"
@@ -100,8 +103,8 @@
             "proof": {
               "algorithm": "Ed25519",
               "signed_payload_b64u": "eyJjb25zdHJhaW50cyI6e30sImRlbGVnYXRlZSI6ImVwOmFnZW50OjEiLCJkZWxlZ2F0aW9uX2lkIjoiZGxnOjEiLCJkZWxlZ2F0b3IiOiJlcDphcHByb3ZlcjpkaXIiLCJleHBpcmVzX2F0IjoiMjAyNi0wNi0xM1QxODowMDowMC4wMDBaIiwibWF4X3ZhbHVlX3VzZCI6MTAwMCwic2NvcGUiOlsicGF5bWVudC5yZWxlYXNlIl19",
-              "signature_b64u": "lUq4Txr9IrpxcuybmqasIJz6j3kedWcj-8z2dPBvy3zhUnLwe6YwZ3aurO6BrAYI3UG07hpRqQWfS7KlskqyBA",
-              "public_key": "MCowBQYDK2VwAyEALXdskngtwmv5_1ln4D1-D4pAGMEt11AXSvWhvTv9HWs"
+              "signature_b64u": "q0v8spc1ZxfEflZIYQNsqInxfhmTwy_P96lAI1PzLbkw_ulvSUZ6qg9I9-ibV0N-v7NIHxOVNgJu42FJEZHWBQ",
+              "public_key": "MCowBQYDK2VwAyEANOfc3s0aQg8yLMbML1x72IjaRYi61_b3gH_GOjWbi0w"
             }
           }
         ],
@@ -112,7 +115,7 @@
         },
         "action_approval": {
           "receipt": {
-            "receipt_id": "ep:receipt:9T44NpFCGis",
+            "receipt_id": "ep:receipt:6M2VJWoOtqY",
             "action": {
               "action_type": "payment.release",
               "policy_id": "pol:test",
@@ -133,62 +136,65 @@
                 "approver": "ep:approver:dir",
                 "approver_index": 1,
                 "required_approvals": 1,
-                "nonce": "1Ft8sLe7B_XHJwcFb1-S2g",
+                "nonce": "bTboOjdmSncjXxMHCV6mxw",
                 "issued_at": "2026-06-13T11:00:00.000Z",
                 "expires_at": "2026-06-13T18:00:00.000Z"
               }
             ],
             "signoffs": [
               {
-                "context_hash": "sha256:0eca47b7004a12adbfef4d94e54875621a2b9752c93f3885a635321953cf3627",
+                "context_hash": "sha256:3149470ef094a8f9400d13cec9b9dfd590eecdc1ce43291060ce75c4421ae85e",
                 "key_class": "A",
                 "approver_key_id": "ep:key:dir#1",
                 "signed_at": "2026-06-13T11:00:00.000Z",
                 "webauthn": {
                   "authenticator_data": "eW6Ax-W_ikjLYD8inu7FeOxyRD2_43cQzIDeZyKMZxMFAAAAAQ",
-                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiRHNwSHR3QktFcTJfNzAyVTVVaDFZaG9ybDFMSlB6aUZwalV5R1ZQUE5pYyIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
-                  "signature": "MEYCIQDPZB74i-lTxy-FvTywzYm_QaQuTzMCH3oZYUfpvIqV3wIhAKowMipOeqJHAZz2vkTrlaFw5DY-XmnhxrEMTkwoGdr-"
+                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiTVVsSER2Q1VxUGxBRFJQT3libmYxWkR1emNIT1F5a1FZTTUxeEVJYTZGNCIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+                  "signature": "MEYCIQDuXRiJuVcUrRUFMNwNIVyg2xH0P-bisIAwtR4OAByHygIhANJYzfU-TYnZpjtZ551YaxK3_DIkirfg7M591lEfosJb"
                 },
-                "signature": "MEYCIQDPZB74i-lTxy-FvTywzYm_QaQuTzMCH3oZYUfpvIqV3wIhAKowMipOeqJHAZz2vkTrlaFw5DY-XmnhxrEMTkwoGdr-"
+                "signature": "MEYCIQDuXRiJuVcUrRUFMNwNIVyg2xH0P-bisIAwtR4OAByHygIhANJYzfU-TYnZpjtZ551YaxK3_DIkirfg7M591lEfosJb"
               }
             ],
             "consumption": {
-              "nonce": "rsv-1B-93qlN_p5DDFQaaw",
+              "nonce": "kfwPXucJQd0Nqjyw467nIg",
               "state": "COMMITTED",
               "committed_at": "2026-06-13T11:30:00.000Z"
             },
             "log_proof": {
+              "alg": "EP-MERKLE-v2",
+              "leaf_hash": "sha256:f750f655a918599661b8ddcbcde9d8b93e408b814166016b971105ffcb1e0d4f",
               "leaf_index": 0,
               "inclusion_path": [],
               "checkpoint": {
                 "tree_size": 1,
-                "root_hash": "sha256:ab561f52b015efa348fda735bf9f79cd10e094ef7aaba5b694c73787c2c83f21",
+                "root_hash": "sha256:f750f655a918599661b8ddcbcde9d8b93e408b814166016b971105ffcb1e0d4f",
                 "log_key_id": "ep:log:test#1",
-                "log_signature": "YoadvTAYw5hLfRQTrQFsIoomG0yBDrHehzfCA914BLknWp5FpEelg6VzkKsqOXQCa5p1LY5mNrbAYllnDB-qAg"
+                "merkle_alg": "EP-MERKLE-v2",
+                "log_signature": "UDqWz0M4Q7VBURT91PLn3N8ttbJNeZCPcugN8AH06sNfDmj9xvaf8BB7KSm2F0WX9T__Gf-1u1i4-Df3O2U-Aw"
               }
             }
           },
           "verification": {
             "approver_keys": {
               "ep:key:dir#1": {
-                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEi4VI82_zbduS538j3SfiNw9WqMQPGlwCP3UST8G0qH8-R_bgMT8jmbgEdoQpBv9zvzdvFE3pnijRw3lhDbAy7A",
+                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmbjTGG5XIyrsmtHI4ZgDtfentPc9OCS2S5vhPotybkoEGGqovnAeb-DipFlKk_L_QzManpLDCvmVTB2hS6msvA",
                 "key_class": "A",
                 "valid_from": "2026-01-01T00:00:00Z",
                 "valid_to": "2036-01-01T00:00:00Z"
               }
             },
-            "log_public_key": "MCowBQYDK2VwAyEAgp0rzpx5t2pSpyi3TBJOPiEeG6xWNJM18CPgOdlikRk"
+            "log_public_key": "MCowBQYDK2VwAyEANdD5aO3PdruQXFLCOjUdYlQPUs2M4EpccjuM__5pYmo"
           }
         },
         "provenance_metadata": {
           "chain_depth": 1,
-          "assembled_at": "2026-06-22T06:14:31.023Z",
+          "assembled_at": "2026-07-02T01:43:38.573Z",
           "note": "Composition of existing EP-RECEIPT-v1 receipts + DRP delegation references. No new trust."
         }
       },
       "delegation_keys": {
         "ep:approver:dir": {
-          "public_key": "MCowBQYDK2VwAyEALXdskngtwmv5_1ln4D1-D4pAGMEt11AXSvWhvTv9HWs"
+          "public_key": "MCowBQYDK2VwAyEANOfc3s0aQg8yLMbML1x72IjaRYi61_b3gH_GOjWbi0w"
         }
       },
       "now_ms": 1781352000000
@@ -202,7 +208,7 @@
         "@version": "EP-PROVENANCE-CHAIN-v1",
         "root_signoff": {
           "receipt": {
-            "receipt_id": "ep:receipt:_Zj0oipIV4g",
+            "receipt_id": "ep:receipt:BQcc6jk5ars",
             "action": {
               "action_type": "payment.release",
               "policy_id": "pol:test",
@@ -223,51 +229,54 @@
                 "approver": "ep:approver:dir",
                 "approver_index": 1,
                 "required_approvals": 1,
-                "nonce": "YqztPiUw44sdbXJHzI77iQ",
+                "nonce": "eYqhOm-0Tu9F9WSD82QTfQ",
                 "issued_at": "2026-06-13T11:00:00.000Z",
                 "expires_at": "2026-06-13T18:00:00.000Z"
               }
             ],
             "signoffs": [
               {
-                "context_hash": "sha256:661e3871f3353d87885c8bb9c4a652f433c3e02b7aca1d42fd480891cb3097ec",
+                "context_hash": "sha256:f098c63c4b09bf93221a6bf7e5085b2bab179cc001d2dd56b880f514e4c30d66",
                 "key_class": "A",
                 "approver_key_id": "ep:key:dir#1",
                 "signed_at": "2026-06-13T11:00:00.000Z",
                 "webauthn": {
                   "authenticator_data": "eW6Ax-W_ikjLYD8inu7FeOxyRD2_43cQzIDeZyKMZxMFAAAAAQ",
-                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiWmg0NGNmTTFQWWVJWEl1NXhLWlM5RFBENEN0NnloMUNfVWdJa2Nzd2wtdyIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
-                  "signature": "MEQCIFt-8fcZZwwNSrxETqJ1cckuWsGs9XqaPSEkXoqULyRDAiA24ZehOQFel6mgJHAbVT6EN6JUixC_EGaF_pZ8qtOgLw"
+                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiOEpqR1BFc0p2NU1pR212MzVRaGJLNnNYbk1BQjB0MVd1SUQxRk9URERXWSIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+                  "signature": "MEYCIQD2ZopDeavPpe86NCWJmahwqyYcH93-5rMIVsaa5-UVmwIhAMqqxzHk0coAsaf56w0rpm99qCsM1FBDz22Jwl-klsxA"
                 },
-                "signature": "MEQCIFt-8fcZZwwNSrxETqJ1cckuWsGs9XqaPSEkXoqULyRDAiA24ZehOQFel6mgJHAbVT6EN6JUixC_EGaF_pZ8qtOgLw"
+                "signature": "MEYCIQD2ZopDeavPpe86NCWJmahwqyYcH93-5rMIVsaa5-UVmwIhAMqqxzHk0coAsaf56w0rpm99qCsM1FBDz22Jwl-klsxA"
               }
             ],
             "consumption": {
-              "nonce": "JB2e4lv2Wx_6ShEaCz9DeQ",
+              "nonce": "ADYWNWVMNrWPDUnnqp3lVw",
               "state": "COMMITTED",
               "committed_at": "2026-06-13T11:30:00.000Z"
             },
             "log_proof": {
+              "alg": "EP-MERKLE-v2",
+              "leaf_hash": "sha256:2b5adde89ee262ee2d537461a9fb2b0c534145d60b568a4a31c67bcc16fce0a0",
               "leaf_index": 0,
               "inclusion_path": [],
               "checkpoint": {
                 "tree_size": 1,
-                "root_hash": "sha256:f5b0a84c7e92852f43758aeb3c16ef423b2877d37342a205c36970c934e05291",
+                "root_hash": "sha256:2b5adde89ee262ee2d537461a9fb2b0c534145d60b568a4a31c67bcc16fce0a0",
                 "log_key_id": "ep:log:test#1",
-                "log_signature": "oRguL7ig3oTCZFs2W7UxAYO597ReTQ-7X0Fz3DorBxj2Uf35UtZuuqhn5G8Q-57Qz1Sypul6DnZoycDZRW_XCg"
+                "merkle_alg": "EP-MERKLE-v2",
+                "log_signature": "bRAEZg5zLyTxjOLzQOKuIjpFw_6hQhotHjiWBB0PJ2mkRZ6a3eu-sJ61bjeUmIEWJ78w3awX_fh9_YYh7lCwDA"
               }
             }
           },
           "verification": {
             "approver_keys": {
               "ep:key:dir#1": {
-                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEV-2J1WKCJWshaS4nEbAtAKOBeMfwwILkQ54nVoSVkeR3ZIbhbFBRTl4fY-pILUoDmczp7K_Amk076HeetTwk1Q",
+                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeGIXngVPbv0BPmEFrdCUnBehEG4wBYptFnvyUdyVEdsRwrbQTYQYjGXVmh-dpl86Yvk0w1Zf_VMuna4jvks8Bw",
                 "key_class": "A",
                 "valid_from": "2026-01-01T00:00:00Z",
                 "valid_to": "2036-01-01T00:00:00Z"
               }
             },
-            "log_public_key": "MCowBQYDK2VwAyEAmsaVUAO5YZu8nTQ54QfgMPB4K1uBjUoV4UV8gVuZbQM"
+            "log_public_key": "MCowBQYDK2VwAyEAgmpkQtEZx0-i7KTkKDUw8cBQeHYmKk0mUpVyYunMcaM"
           },
           "human_key_classes": [
             "A"
@@ -289,8 +298,8 @@
             "proof": {
               "algorithm": "Ed25519",
               "signed_payload_b64u": "eyJjb25zdHJhaW50cyI6e30sImRlbGVnYXRlZSI6ImVwOmFnZW50OjEiLCJkZWxlZ2F0aW9uX2lkIjoiZGxnOjEiLCJkZWxlZ2F0b3IiOiJlcDphcHByb3ZlcjpkaXIiLCJleHBpcmVzX2F0IjoiMjAyNi0wNi0xM1QxODowMDowMC4wMDBaIiwibWF4X3ZhbHVlX3VzZCI6MTAwMCwic2NvcGUiOlsicGF5bWVudC5yZWxlYXNlIl19",
-              "signature_b64u": "fkBRkFhYVl-ZtjFBUZk0F-f6KW75824Vr6xNJ39-d1-eY7zt8O1k-Oltuu1IhILWGf0zqbRfzVzKotd8BY6tBQ",
-              "public_key": "MCowBQYDK2VwAyEAenIWQNQwEoG_qOXtFfntA8_5c4e1t0S8Ty7JHJptG4s"
+              "signature_b64u": "StMaq2lN-P3hL2nHZ3IDh8-PKh6OUzht5xFOVAVd80hsOeZMjVlzqbP_up4O2pSULXtpvyeHVhtlJczQNDZNCg",
+              "public_key": "MCowBQYDK2VwAyEAlLTc8OynUBvGvwMYtaHX42eRr7izYj4z1w_KjN9OD8A"
             }
           }
         ],
@@ -301,7 +310,7 @@
         },
         "action_approval": {
           "receipt": {
-            "receipt_id": "ep:receipt:5dbnMyWRJp0",
+            "receipt_id": "ep:receipt:dCoLSmbuMAY",
             "action": {
               "action_type": "payment.release",
               "policy_id": "pol:test",
@@ -322,62 +331,65 @@
                 "approver": "ep:approver:dir",
                 "approver_index": 1,
                 "required_approvals": 1,
-                "nonce": "3seNE898A2ZUCVHJIGOrNQ",
+                "nonce": "2d6YRoDAXwXnITnGN3xDsg",
                 "issued_at": "2026-06-13T11:00:00.000Z",
                 "expires_at": "2026-06-13T18:00:00.000Z"
               }
             ],
             "signoffs": [
               {
-                "context_hash": "sha256:fb50babe9a3d0eab1494bcf5d04312c0c5c9ab0299384ece14602aa7ec3bba62",
+                "context_hash": "sha256:3b4e85162e7eb1c4190eff96fde684544c20383dd9fd1f270844065880bed037",
                 "key_class": "A",
                 "approver_key_id": "ep:key:dir#1",
                 "signed_at": "2026-06-13T11:00:00.000Z",
                 "webauthn": {
                   "authenticator_data": "eW6Ax-W_ikjLYD8inu7FeOxyRD2_43cQzIDeZyKMZxMFAAAAAQ",
-                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiLTFDNnZwbzlEcXNVbEx6MTBFTVN3TVhKcXdLWk9FN09GR0FxcC13N3VtSSIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
-                  "signature": "MEQCIBcQ_sUn-V4lzQwPe0rSgjS6mI1Glnvi8exMrzCHFBHJAiAJRWXpIfFil2RejPn50ZdqkLBy9A4-cS2H2QSXcHAc7w"
+                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiTzA2RkZpNS1zY1FaRHYtV19lYUVWRXdnT0QzWl9SOG5DRVFHV0lDLTBEYyIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+                  "signature": "MEUCIQC-w4qo0hoLi5kR2VjYbym9_jvRorDUsROr8_c5mHHAHwIgGc_-CG8-LR0OCfS6RRqv2fRazR3fMu7rcVHBWJ5Br4M"
                 },
-                "signature": "MEQCIBcQ_sUn-V4lzQwPe0rSgjS6mI1Glnvi8exMrzCHFBHJAiAJRWXpIfFil2RejPn50ZdqkLBy9A4-cS2H2QSXcHAc7w"
+                "signature": "MEUCIQC-w4qo0hoLi5kR2VjYbym9_jvRorDUsROr8_c5mHHAHwIgGc_-CG8-LR0OCfS6RRqv2fRazR3fMu7rcVHBWJ5Br4M"
               }
             ],
             "consumption": {
-              "nonce": "mOqjRVU-JcmV7ZatMcNaKQ",
+              "nonce": "bxWLi1W8JpV7MSrWU4NlrQ",
               "state": "COMMITTED",
               "committed_at": "2026-06-13T11:30:00.000Z"
             },
             "log_proof": {
+              "alg": "EP-MERKLE-v2",
+              "leaf_hash": "sha256:b90aeb78dc9fb641531e32d572d5c801355750b095fd1797f259f41d58414bd2",
               "leaf_index": 0,
               "inclusion_path": [],
               "checkpoint": {
                 "tree_size": 1,
-                "root_hash": "sha256:18d550164b20564b8f0120b99032fb465a8f7b8436161912093a217eaeb592ed",
+                "root_hash": "sha256:b90aeb78dc9fb641531e32d572d5c801355750b095fd1797f259f41d58414bd2",
                 "log_key_id": "ep:log:test#1",
-                "log_signature": "Q_kZ23_Fs3U3LvQvVHlX6jvC3W6IXRQsjlRpaLqkvofqDSENPjZl5v3T7NjdvZwco5fiuczHQyOh5nMaaQpgAA"
+                "merkle_alg": "EP-MERKLE-v2",
+                "log_signature": "ZKT9W_LHB2JNPTc1glqGO7OmUkHP_2t709odiHhiPPH05iVw4oZIR7vDnNv2arCE46huVsj4fTUuLgAX_U7DBQ"
               }
             }
           },
           "verification": {
             "approver_keys": {
               "ep:key:dir#1": {
-                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgPReU_sXirT0zmqmGp42OCt4Cgeq8TfY02CSPicOUpY3D38AWDCfg3iYJCKlbqAt30r5moq0U_RO6jZZWxfUOA",
+                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEM2AHejenBXFaS0NArA0d_AH61dhInSoeVWzI6zPqBUcoka7XeD3Oq2euK0exfI_9kSxlT34hDpe0_Fi0l2drBg",
                 "key_class": "A",
                 "valid_from": "2026-01-01T00:00:00Z",
                 "valid_to": "2036-01-01T00:00:00Z"
               }
             },
-            "log_public_key": "MCowBQYDK2VwAyEA9YKtZLBsXVxmyNx89tzC_-NRcnBwjTZ50ffY8rE_eUE"
+            "log_public_key": "MCowBQYDK2VwAyEAxcdORuQSImGMizdoMxJ2vbcJEAJOpVPwN_9Hualhbd8"
           }
         },
         "provenance_metadata": {
           "chain_depth": 1,
-          "assembled_at": "2026-06-22T06:14:31.024Z",
+          "assembled_at": "2026-07-02T01:43:38.575Z",
           "note": "Composition of existing EP-RECEIPT-v1 receipts + DRP delegation references. No new trust."
         }
       },
       "delegation_keys": {
         "ep:approver:dir": {
-          "public_key": "MCowBQYDK2VwAyEAenIWQNQwEoG_qOXtFfntA8_5c4e1t0S8Ty7JHJptG4s"
+          "public_key": "MCowBQYDK2VwAyEAlLTc8OynUBvGvwMYtaHX42eRr7izYj4z1w_KjN9OD8A"
         }
       },
       "now_ms": 1781352000000
@@ -391,7 +403,7 @@
         "@version": "EP-PROVENANCE-CHAIN-v1",
         "root_signoff": {
           "receipt": {
-            "receipt_id": "ep:receipt:puDLIBy2WFM",
+            "receipt_id": "ep:receipt:0Xo7lW-YcDc",
             "action": {
               "action_type": "payment.release",
               "policy_id": "pol:test",
@@ -412,51 +424,54 @@
                 "approver": "ep:approver:dir",
                 "approver_index": 1,
                 "required_approvals": 1,
-                "nonce": "D3UBsLAl8Bp47AfwZBFgkQ",
+                "nonce": "g8T6_bNvRRZ6mMRYn3x9SA",
                 "issued_at": "2026-06-13T11:00:00.000Z",
                 "expires_at": "2026-06-13T18:00:00.000Z"
               }
             ],
             "signoffs": [
               {
-                "context_hash": "sha256:10ea91d3c46323277de00d30a9a7c74183100f204e0b8026ed0a6c00caec17a7",
+                "context_hash": "sha256:49dc09c98b1c578df3bbc96822e19a18476d2788bc434787d2da4d131ad9ee9e",
                 "key_class": "A",
                 "approver_key_id": "ep:key:dir#1",
                 "signed_at": "2026-06-13T11:00:00.000Z",
                 "webauthn": {
                   "authenticator_data": "eW6Ax-W_ikjLYD8inu7FeOxyRD2_43cQzIDeZyKMZxMFAAAAAQ",
-                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiRU9xUjA4UmpJeWQ5NEEwd3FhZkhRWU1RRHlCT0M0QW03UXBzQU1yc0Y2YyIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
-                  "signature": "MEUCIBi3nOoV6xtKjpIGdidUCYC-NVKDXmiJI7E43DyKVVuuAiEAu9IQCh9V1Dbc-HzdLdNaFiI0XQDkKrZt4pVbum9zRRI"
+                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiU2R3SnlZc2NWNDN6dThsb0l1R2FHRWR0SjRpOFEwZUgwdHBORXhyWjdwNCIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+                  "signature": "MEYCIQDlZW0f08DO9MDgnWhipLplxqzYSicVas7g1PBx1YNUVgIhAOAKcBUDmYnhhtQ-9L97D3-lcmBsFlaNntA63lZu4Ca7"
                 },
-                "signature": "MEUCIBi3nOoV6xtKjpIGdidUCYC-NVKDXmiJI7E43DyKVVuuAiEAu9IQCh9V1Dbc-HzdLdNaFiI0XQDkKrZt4pVbum9zRRI"
+                "signature": "MEYCIQDlZW0f08DO9MDgnWhipLplxqzYSicVas7g1PBx1YNUVgIhAOAKcBUDmYnhhtQ-9L97D3-lcmBsFlaNntA63lZu4Ca7"
               }
             ],
             "consumption": {
-              "nonce": "pzpkRp9zGPus7hzzTE47zQ",
+              "nonce": "7RNxlf2sHLvRFBHjNjvmUw",
               "state": "COMMITTED",
               "committed_at": "2026-06-13T11:30:00.000Z"
             },
             "log_proof": {
+              "alg": "EP-MERKLE-v2",
+              "leaf_hash": "sha256:1f4b610c208eda6e07168a70945e636c7f8fdc50c5903f9f020dbd5b73149510",
               "leaf_index": 0,
               "inclusion_path": [],
               "checkpoint": {
                 "tree_size": 1,
-                "root_hash": "sha256:422389bf06f7e5a057a906feaec3e4eec99eafc66ddacbd61f64f504d615c534",
+                "root_hash": "sha256:1f4b610c208eda6e07168a70945e636c7f8fdc50c5903f9f020dbd5b73149510",
                 "log_key_id": "ep:log:test#1",
-                "log_signature": "a72UedpSsR3H0G6qLHKchskllZRwa_XlYVRLQc3CNR5t2JF-MsYe1nall8_DNM4PR0AUECDYf6eVq-MNku5ZAg"
+                "merkle_alg": "EP-MERKLE-v2",
+                "log_signature": "nJ5ddncHb2G-WSo1kHYp4VzBJd6MA-4g7di8Vn5LrhX50HwMU4ncIEMWkB2pw8KAw4vrHXDbPQRdmdkJy8XuCw"
               }
             }
           },
           "verification": {
             "approver_keys": {
               "ep:key:dir#1": {
-                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEl21wKlG6XUYMLOxc0WqaX1WRThMa3G0Im7v9kUfjG0uqXZk4KTfWUlz0jSvIBO-73H7OWPDkxdTnVUYzNVCiQw",
+                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEh5AzdBDHsbTuPYyEclXd6UbVa2bwpZPrF_915NcQ4t2XfuBQFRovD322kREsGfu8ZlzsKflpU7tUPsA-oC9QRw",
                 "key_class": "A",
                 "valid_from": "2026-01-01T00:00:00Z",
                 "valid_to": "2036-01-01T00:00:00Z"
               }
             },
-            "log_public_key": "MCowBQYDK2VwAyEAru6OPMwLrxgeEwUs7es6rfML6fWxtetXfEd3feGQ3CM"
+            "log_public_key": "MCowBQYDK2VwAyEA7KRs_f0231oHseZlyU7xLlrG4Jepia_eLWMpkhrkfAo"
           },
           "human_key_classes": [
             "A"
@@ -478,8 +493,8 @@
             "proof": {
               "algorithm": "Ed25519",
               "signed_payload_b64u": "eyJjb25zdHJhaW50cyI6e30sImRlbGVnYXRlZSI6ImVwOmFnZW50OjEiLCJkZWxlZ2F0aW9uX2lkIjoiZGxnOjEiLCJkZWxlZ2F0b3IiOiJlcDphcHByb3ZlcjpkaXIiLCJleHBpcmVzX2F0IjoiMjAyNi0wNi0xM1QxODowMDowMC4wMDBaIiwibWF4X3ZhbHVlX3VzZCI6MTAwMCwic2NvcGUiOlsicGF5bWVudC5yZWxlYXNlIl19",
-              "signature_b64u": "3x3vfpkXaQVWm05xTsKTy4hQRolyHDOQ5T7BTlukzDFarVDMjuMfKhF3RLYT_OLvYhj9FQtwXKKqOS8PD2hqDA",
-              "public_key": "MCowBQYDK2VwAyEArukiYhr_L0z13z2SMd3507hLS1jAAWn2PnaXP3i0G3Y"
+              "signature_b64u": "IL2UUqa_dc1dhIXXQZeLJ6PAj5_p1us1CxyX51cW_tqX824bqBvEEQujLEmL0Y7_-2RDpZA4vHQksiqkYWt_Cw",
+              "public_key": "MCowBQYDK2VwAyEAqw_zecY9zc8HLYwh8HTXM2Ax9CxGrHmdBf0cRXmw4cY"
             }
           }
         ],
@@ -490,7 +505,7 @@
         },
         "action_approval": {
           "receipt": {
-            "receipt_id": "ep:receipt:2zxc1yNOKhM",
+            "receipt_id": "ep:receipt:GYTmGoBEFQI",
             "action": {
               "action_type": "payment.release",
               "policy_id": "pol:test",
@@ -511,62 +526,65 @@
                 "approver": "ep:approver:dir",
                 "approver_index": 1,
                 "required_approvals": 1,
-                "nonce": "eU-lFNnQ2ofpUi0L9NHvUg",
+                "nonce": "wJDGP036OdLqp2-bAQBQRg",
                 "issued_at": "2026-06-13T11:00:00.000Z",
                 "expires_at": "2026-06-13T18:00:00.000Z"
               }
             ],
             "signoffs": [
               {
-                "context_hash": "sha256:ce216cee528d83455f5f3e5f5dbf03fd7b1d3b37a2c21cea7ac96b06f9f3c3e1",
+                "context_hash": "sha256:99360d14fb5894d89b992a5b0373d347df6db969687f97ccc6412b07f45f1d46",
                 "key_class": "A",
                 "approver_key_id": "ep:key:dir#1",
                 "signed_at": "2026-06-13T11:00:00.000Z",
                 "webauthn": {
                   "authenticator_data": "eW6Ax-W_ikjLYD8inu7FeOxyRD2_43cQzIDeZyKMZxMFAAAAAQ",
-                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiemlGczdsS05nMFZmWHo1ZlhiOERfWHNkT3plaXdoenFlc2xyQnZuenctRSIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
-                  "signature": "MEUCIDzyUU9rfrkX47Ut-VdncmHyAypslPbI1_k9pEd8UntcAiEAsWkfYyWGkMVxEfl4vax_j7ksDNjo8ROFc9JGcFHRzzA"
+                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoibVRZTkZQdFlsTmlibVNwYkEzUFRSOTl0dVdsb2Y1Zk14a0VyQl9SZkhVWSIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+                  "signature": "MEUCIQDCvv4TSFlaKA0EBoxxiw_0SzQT4ltlZavpcydWrA2w4gIgMP4BwZkbkR2nfUQJpwcUtVY2TrBW8FU1082j4OHd0pA"
                 },
-                "signature": "MEUCIDzyUU9rfrkX47Ut-VdncmHyAypslPbI1_k9pEd8UntcAiEAsWkfYyWGkMVxEfl4vax_j7ksDNjo8ROFc9JGcFHRzzA"
+                "signature": "MEUCIQDCvv4TSFlaKA0EBoxxiw_0SzQT4ltlZavpcydWrA2w4gIgMP4BwZkbkR2nfUQJpwcUtVY2TrBW8FU1082j4OHd0pA"
               }
             ],
             "consumption": {
-              "nonce": "8ToGyc0_sqUlQXYodE9zLg",
+              "nonce": "7M-ZmudBS1uJdnSYRBXTRg",
               "state": "COMMITTED",
               "committed_at": "2026-06-13T11:30:00.000Z"
             },
             "log_proof": {
+              "alg": "EP-MERKLE-v2",
+              "leaf_hash": "sha256:f0a8ce918ca79a27a23f3b727f862cf6c171c6e5ca6973ba57d753e06d2d2c48",
               "leaf_index": 0,
               "inclusion_path": [],
               "checkpoint": {
                 "tree_size": 1,
-                "root_hash": "sha256:491e99d66af717d5c19f16c694b8b2e0f9d669ec9da0706c286ca2a9cb220dc9",
+                "root_hash": "sha256:f0a8ce918ca79a27a23f3b727f862cf6c171c6e5ca6973ba57d753e06d2d2c48",
                 "log_key_id": "ep:log:test#1",
-                "log_signature": "8CXM-RkD19757u8tNpggfKGN9Hi-pM649mqkGW06LYa_67vF1bF_67x7bmAZSVjT9nBQhey14XQaQyTwQhHKAw"
+                "merkle_alg": "EP-MERKLE-v2",
+                "log_signature": "zOyiVBSuSTxlT9ijFNfjC5JsHraFS7zxwhDJG3jthkhkCZphtSm-EBmGyKL64Ue7pu6WkQxrjRt515A8ZhjzAA"
               }
             }
           },
           "verification": {
             "approver_keys": {
               "ep:key:dir#1": {
-                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEq772pOQnibyzkgQOeaKO9fpBgTl1kx_JLY-G6UKQynNSuGqdAed8ZqmFV6ogKIagHVUPJBVACgeyIJ-P3a9UjQ",
+                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEg-ZYtslGJsazkFi8bk_ey7zLg--SLInu7QhRJt2ewgRZyfKQpDJVOXHeNqA-0c6bImaX1NJpbzUs-0I866s54g",
                 "key_class": "A",
                 "valid_from": "2026-01-01T00:00:00Z",
                 "valid_to": "2036-01-01T00:00:00Z"
               }
             },
-            "log_public_key": "MCowBQYDK2VwAyEAclERtdoKpzLadE3vuTpqpDSP7uTh4pMAzwC4RoPI7ww"
+            "log_public_key": "MCowBQYDK2VwAyEA1RB9Ps_YoJlW-ARms-9rYQDNp9HH0kFOMh43knal7DU"
           }
         },
         "provenance_metadata": {
           "chain_depth": 1,
-          "assembled_at": "2026-06-22T06:14:31.024Z",
+          "assembled_at": "2026-07-02T01:43:38.575Z",
           "note": "Composition of existing EP-RECEIPT-v1 receipts + DRP delegation references. No new trust."
         }
       },
       "delegation_keys": {
         "ep:approver:dir": {
-          "public_key": "MCowBQYDK2VwAyEArukiYhr_L0z13z2SMd3507hLS1jAAWn2PnaXP3i0G3Y"
+          "public_key": "MCowBQYDK2VwAyEAqw_zecY9zc8HLYwh8HTXM2Ax9CxGrHmdBf0cRXmw4cY"
         }
       },
       "now_ms": 1781352000000
@@ -580,7 +598,7 @@
         "@version": "EP-PROVENANCE-CHAIN-v1",
         "root_signoff": {
           "receipt": {
-            "receipt_id": "ep:receipt:H9MER2NMZz0",
+            "receipt_id": "ep:receipt:_cN_AEwPRfc",
             "action": {
               "action_type": "payment.release",
               "policy_id": "pol:test",
@@ -601,51 +619,54 @@
                 "approver": "ep:approver:dir",
                 "approver_index": 1,
                 "required_approvals": 1,
-                "nonce": "xXXL2nxqdQMT-TYhdgWPIw",
+                "nonce": "S4huE-Aqf0z0LdeRrXfxjA",
                 "issued_at": "2026-06-13T11:00:00.000Z",
                 "expires_at": "2026-06-13T18:00:00.000Z"
               }
             ],
             "signoffs": [
               {
-                "context_hash": "sha256:c77a37919285431e4170ff590da029d105446dd793f55bdf6567343dffb7c263",
+                "context_hash": "sha256:25bdddcfc0cb6d5ebfed21c78f46a42e1b4175d20b3d88b271274b370bfa35de",
                 "key_class": "A",
                 "approver_key_id": "ep:key:dir#1",
                 "signed_at": "2026-06-13T11:00:00.000Z",
                 "webauthn": {
                   "authenticator_data": "eW6Ax-W_ikjLYD8inu7FeOxyRD2_43cQzIDeZyKMZxMFAAAAAQ",
-                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoieDNvM2taS0ZReDVCY1A5WkRhQXAwUVZFYmRlVDlWdmZaV2MwUGYtM3dtTSIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
-                  "signature": "MEUCIQC_UW-AOwZ5qdIi0qMVSWXlcfUVtHrTGTvptx0fZeH4OwIgdh4sZRlAZqEfygNak34l9GMY22DI5pGOuizyuIFUfg0"
+                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiSmIzZHo4RExiVjZfN1NISGowYWtMaHRCZGRJTFBZaXljU2RMTnd2Nk5kNCIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+                  "signature": "MEUCIDGLN20J-XG9qsoM6hkFlxZayq93xealRRFjMf5oDW6wAiEAz9WXvZw9KhV_0qS09SEkfCldCPCmwHUWqRieiT9-x4c"
                 },
-                "signature": "MEUCIQC_UW-AOwZ5qdIi0qMVSWXlcfUVtHrTGTvptx0fZeH4OwIgdh4sZRlAZqEfygNak34l9GMY22DI5pGOuizyuIFUfg0"
+                "signature": "MEUCIDGLN20J-XG9qsoM6hkFlxZayq93xealRRFjMf5oDW6wAiEAz9WXvZw9KhV_0qS09SEkfCldCPCmwHUWqRieiT9-x4c"
               }
             ],
             "consumption": {
-              "nonce": "nuAY5P09v_AkL18eGt1Yhw",
+              "nonce": "Ro1QFAChc0CETH99h2B8Kg",
               "state": "COMMITTED",
               "committed_at": "2026-06-13T11:30:00.000Z"
             },
             "log_proof": {
+              "alg": "EP-MERKLE-v2",
+              "leaf_hash": "sha256:aa5b628b8472472f7be4e4c08c27845e21ed28c52fd16b714633cc6f6ef898a2",
               "leaf_index": 0,
               "inclusion_path": [],
               "checkpoint": {
                 "tree_size": 1,
-                "root_hash": "sha256:a54c9f860afc7aaa227ce69d87ae1c4d407b5d7a49bedc3531b3d4895e4932fa",
+                "root_hash": "sha256:aa5b628b8472472f7be4e4c08c27845e21ed28c52fd16b714633cc6f6ef898a2",
                 "log_key_id": "ep:log:test#1",
-                "log_signature": "rGHW0rYZW_jHSxdpuQH44Bv_mH5AC0kvcieV5jb2C39lIOv_RTAscfqnngf2ORSRd7RBQ9eMy0-TtACmYbztCg"
+                "merkle_alg": "EP-MERKLE-v2",
+                "log_signature": "HJfzBeUTScaN_C2FAVzShalJJ4D_MSVWaPgcrQe9lve_zwzqMF1-sGv2tOs2MuToS_YIayDrgxX09jlQ58N3Cg"
               }
             }
           },
           "verification": {
             "approver_keys": {
               "ep:key:dir#1": {
-                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEubyypjy2M0C-uag0XL6wLZj5TlXFDklKyj4InI7eIrIM-jZBDzAne9uBkDIodAOVDaZl1Oj6K5VgolWUHtW05g",
+                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERVBSP-LGRJrjNAWNVv4eJN-9Lgg9x_70staMTD6tMIcPeRc0GLeU22h-8Wb1SbtvyttpXZMC_eQSUNeJSG5Dzw",
                 "key_class": "A",
                 "valid_from": "2026-01-01T00:00:00Z",
                 "valid_to": "2036-01-01T00:00:00Z"
               }
             },
-            "log_public_key": "MCowBQYDK2VwAyEAWU-jVPle_JfissGbL-qDhjdMm1bPF8p-WcETPPXHQpE"
+            "log_public_key": "MCowBQYDK2VwAyEA2R9fkjbdFikt-TUlkOlgru76gViuvGegY0iqCxueLgE"
           },
           "human_key_classes": [
             "A"
@@ -667,8 +688,8 @@
             "proof": {
               "algorithm": "Ed25519",
               "signed_payload_b64u": "eyJjb25zdHJhaW50cyI6e30sImRlbGVnYXRlZSI6ImVwOmFnZW50OjEiLCJkZWxlZ2F0aW9uX2lkIjoiZGxnOjEiLCJkZWxlZ2F0b3IiOiJlcDphcHByb3ZlcjpkaXIiLCJleHBpcmVzX2F0IjoiMjAyNi0wNi0xM1QxODowMDowMC4wMDBaIiwibWF4X3ZhbHVlX3VzZCI6MTAwMCwic2NvcGUiOlsicGF5bWVudC5yZWxlYXNlIl19",
-              "signature_b64u": "WXKfLXMxZv-8aA9CTddyrJlPF3IZDiUSQd06awsPVsnnQxtW6mfnty4x9sJMv6yXh_E069bNXsQ1kmrWiJIfAQ",
-              "public_key": "MCowBQYDK2VwAyEAOhRIjqb5ZBFOl4kcGBuvlxHEXtNGh8jbQUjG2K0wGH4"
+              "signature_b64u": "5emrv6cwTPv8paFWPUSw636TFNhlQmaqI4wjxkILqPIHDuimJviwgR2gmwk5he6eExaJ4r37WMvtizoUXlQFBA",
+              "public_key": "MCowBQYDK2VwAyEAchvjQrCIubV6CTR9jJnVKrfJ_loCyz_3o8hvYv3zLyM"
             }
           }
         ],
@@ -679,7 +700,7 @@
         },
         "action_approval": {
           "receipt": {
-            "receipt_id": "ep:receipt:uiOMYt1oiRA",
+            "receipt_id": "ep:receipt:HXkLIPhrBBg",
             "action": {
               "action_type": "payment.release",
               "policy_id": "pol:test",
@@ -700,56 +721,59 @@
                 "approver": "ep:approver:dir",
                 "approver_index": 1,
                 "required_approvals": 1,
-                "nonce": "6-FJDIzBhWGsZBoYfHX7pw",
+                "nonce": "4o_ZPoOdgtypU-zeDgG8EA",
                 "issued_at": "2026-06-13T11:00:00.000Z",
                 "expires_at": "2026-06-13T18:00:00.000Z"
               }
             ],
             "signoffs": [
               {
-                "context_hash": "sha256:b0cf0c15e9f6aeb5c1801cbcf5dcc42a63d8bbb2167bc78df0ce779a2066b768",
+                "context_hash": "sha256:d3b6275f309922e51e16c94ae401964a28111b82059c7b81b8847fa26729bfa9",
                 "key_class": "A",
                 "approver_key_id": "ep:key:dir#1",
                 "signed_at": "2026-06-13T11:00:00.000Z",
                 "webauthn": {
                   "authenticator_data": "eW6Ax-W_ikjLYD8inu7FeOxyRD2_43cQzIDeZyKMZxMFAAAAAQ",
-                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoic004TUZlbjJyclhCZ0J5ODlkekVLbVBZdTdJV2U4ZU44TTUzbWlCbXQyZyIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
-                  "signature": "MEUCIQCycnwIpqWgqW1mqeGeBcRGkirCYVl69SNhByeBZnS3igIgPesMZ2Pd-ubC66zkBVkxBI32A4D4uT6csGtZi5rr6B4"
+                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiMDdZblh6Q1pJdVVlRnNsSzVBR1dTaWdSRzRJRm5IdUJ1SVJfb21jcHY2ayIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+                  "signature": "MEUCIF5SHNOiVjYw-24a301QE2cZhddQeSm1cPAKALCRD_onAiEAkiqnaxJXf0DXNUujohBM0fFwO3Ic0A0sh0-AKLMCZ1g"
                 },
-                "signature": "MEUCIQCycnwIpqWgqW1mqeGeBcRGkirCYVl69SNhByeBZnS3igIgPesMZ2Pd-ubC66zkBVkxBI32A4D4uT6csGtZi5rr6B4"
+                "signature": "MEUCIF5SHNOiVjYw-24a301QE2cZhddQeSm1cPAKALCRD_onAiEAkiqnaxJXf0DXNUujohBM0fFwO3Ic0A0sh0-AKLMCZ1g"
               }
             ],
             "consumption": {
-              "nonce": "DOyNypsTr_QooybjUq-tvA",
+              "nonce": "47pw-hAy50cgOMRjCBNS8Q",
               "state": "COMMITTED",
               "committed_at": "2026-06-13T11:30:00.000Z"
             },
             "log_proof": {
+              "alg": "EP-MERKLE-v2",
+              "leaf_hash": "sha256:3d291a84eb48f60baab1f83b0200a95eaef3338e511413b2714f982a29318976",
               "leaf_index": 0,
               "inclusion_path": [],
               "checkpoint": {
                 "tree_size": 1,
-                "root_hash": "sha256:90140dc8dcab90956e4a6736eef8e3622efa7bdf5c012a7bdeadc6491c1b8d19",
+                "root_hash": "sha256:3d291a84eb48f60baab1f83b0200a95eaef3338e511413b2714f982a29318976",
                 "log_key_id": "ep:log:test#1",
-                "log_signature": "Wsf2ErLmfiRC1YyBtI4_auGfrPHtBBM3AwokLzjjeGd8TB6LChdhNQ-bg1QzgxctXxEukfiJYMmzljtqvesHCg"
+                "merkle_alg": "EP-MERKLE-v2",
+                "log_signature": "GweZbl1b-_hMctUepMZ-y-kClFiTW9LO7afHXmPqsbHkuvkNuR3HyNcB58Mad9skCDawHM-60nQWj-k7ztD_Aw"
               }
             }
           },
           "verification": {
             "approver_keys": {
               "ep:key:dir#1": {
-                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEGfPhfbiwI4N7bGFSKGmL_Wh4MMj5eJ0St234MjgejjjhlnJMcEqaEeZww1-xW6Pwn4GlcRacf3iwxHZSiL8rYQ",
+                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDxBv2RSElspsXyoDojGYBA0HgfW_584LGnOIC39UFK_7YeLSYTwdsibpcFE4HSqNcs_UF8dNdeSU-YCCvQqoaA",
                 "key_class": "A",
                 "valid_from": "2026-01-01T00:00:00Z",
                 "valid_to": "2036-01-01T00:00:00Z"
               }
             },
-            "log_public_key": "MCowBQYDK2VwAyEA67EoBwLtpCwZuD60Vi7_tPxqa8unS26xYJZDxq5lUOA"
+            "log_public_key": "MCowBQYDK2VwAyEAtiIoebSScCvUJyeRu86zrz2c4i3WYULzfXt8lLQctZo"
           }
         },
         "provenance_metadata": {
           "chain_depth": 1,
-          "assembled_at": "2026-06-22T06:14:31.025Z",
+          "assembled_at": "2026-07-02T01:43:38.576Z",
           "note": "Composition of existing EP-RECEIPT-v1 receipts + DRP delegation references. No new trust."
         }
       },
@@ -765,7 +789,7 @@
         "@version": "EP-PROVENANCE-CHAIN-v1",
         "root_signoff": {
           "receipt": {
-            "receipt_id": "ep:receipt:zcjMk_NZ1LA",
+            "receipt_id": "ep:receipt:fWEhV09359M",
             "action": {
               "action_type": "payment.release",
               "policy_id": "pol:test",
@@ -786,51 +810,54 @@
                 "approver": "ep:approver:dir",
                 "approver_index": 1,
                 "required_approvals": 1,
-                "nonce": "u5opCQpeP_VFFLWox1xunA",
+                "nonce": "afKVLf8dhEK_0a3_WMi0LA",
                 "issued_at": "2026-06-13T11:00:00.000Z",
                 "expires_at": "2026-06-13T18:00:00.000Z"
               }
             ],
             "signoffs": [
               {
-                "context_hash": "sha256:7efe88540dc2dbb68da76684eb4c5a4e5fb91d75162134559dbe0576347a7f8b",
+                "context_hash": "sha256:9db03ab5a436c0fdc8c227ea284aadb72af1782ce04da5d89dbc09d752fd2dd4",
                 "key_class": "A",
                 "approver_key_id": "ep:key:dir#1",
                 "signed_at": "2026-06-13T11:00:00.000Z",
                 "webauthn": {
                   "authenticator_data": "eW6Ax-W_ikjLYD8inu7FeOxyRD2_43cQzIDeZyKMZxMFAAAAAQ",
-                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiZnY2SVZBM0MyN2FOcDJhRTYweGFUbC01SFhVV0lUUlZuYjRGZGpSNmY0cyIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
-                  "signature": "MEQCIHf61bQQr9h7Xsw4LrR0dafcBS19PnROcKNif0iUSKxzAiAwCrSdD7Z64Ol1PiHeQ9iiRViI9cu2zSEMRXMaOj7KkQ"
+                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoibmJBNnRhUTJ3UDNJd2lmcUtFcXR0eXJ4ZUN6Z1RhWFluYndKMTFMOUxkUSIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+                  "signature": "MEUCIQCqRvBAvkKIcKz2a6_CV_aS_tGzLoJHZArFBvIo6l7zAAIgbbXzfCdjvYC-P9ZTT5AOABiQkCYQmH5Xl1aoIaji3i4"
                 },
-                "signature": "MEQCIHf61bQQr9h7Xsw4LrR0dafcBS19PnROcKNif0iUSKxzAiAwCrSdD7Z64Ol1PiHeQ9iiRViI9cu2zSEMRXMaOj7KkQ"
+                "signature": "MEUCIQCqRvBAvkKIcKz2a6_CV_aS_tGzLoJHZArFBvIo6l7zAAIgbbXzfCdjvYC-P9ZTT5AOABiQkCYQmH5Xl1aoIaji3i4"
               }
             ],
             "consumption": {
-              "nonce": "MIbGBGBX8wreJiKypE7FoQ",
+              "nonce": "kAtMi4hgeEVZ5rkFvu3Q8w",
               "state": "COMMITTED",
               "committed_at": "2026-06-13T11:30:00.000Z"
             },
             "log_proof": {
+              "alg": "EP-MERKLE-v2",
+              "leaf_hash": "sha256:416eb9aaa24dc3d785130fbcc04ef122b4ccd57be4cd80e915b3af1dd2b829e3",
               "leaf_index": 0,
               "inclusion_path": [],
               "checkpoint": {
                 "tree_size": 1,
-                "root_hash": "sha256:9448d4009e0a6f93d0facc878f8da9d63d580f0c359f2e65a0f0bdd988cee82e",
+                "root_hash": "sha256:416eb9aaa24dc3d785130fbcc04ef122b4ccd57be4cd80e915b3af1dd2b829e3",
                 "log_key_id": "ep:log:test#1",
-                "log_signature": "HZZDrdy5TE2trmdTj2fOXXfIvE5n-UBv06x9zvYw1QfGghJY06dzd0gwK-wRwvlXFF6j4J3X3AfjYGxnRqtCAg"
+                "merkle_alg": "EP-MERKLE-v2",
+                "log_signature": "w2i_6odoU6hAmajKqbI6G7Py-21MIKJTyZH6L0BlGMT5WGMmc1P0qvEXU4k2hOaLmRHTP4Nz4c0OtNkXehJ5Bw"
               }
             }
           },
           "verification": {
             "approver_keys": {
               "ep:key:dir#1": {
-                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzV32hxBXdDvW56RmjL2ZW_BDqZdKqJyvdOywdnw3lAmCM7xbHHW0SpIhDyXNQXqVpFKfLC8EYS41burRCXKmzQ",
+                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3SXSTcbVOmDhvfPl-e6dRuS5zh1x99IMCipsFyNaJzlvpKh-DL9G8Y8pJ7_R3mBBfxRNGo6UDhHpgP0SDOzv0A",
                 "key_class": "A",
                 "valid_from": "2026-01-01T00:00:00Z",
                 "valid_to": "2036-01-01T00:00:00Z"
               }
             },
-            "log_public_key": "MCowBQYDK2VwAyEAMTkh6HVbpTGXKhOzfLc5dkhkCD7l0BQTxGRERti075g"
+            "log_public_key": "MCowBQYDK2VwAyEADxSnexIbikmzEElXqBxF46szKumKCI8cCDfoR60tIt0"
           },
           "human_key_classes": [
             "A"
@@ -854,8 +881,8 @@
             "proof": {
               "algorithm": "Ed25519",
               "signed_payload_b64u": "eyJjb25zdHJhaW50cyI6eyJtYXhfY2FsbHMiOjV9LCJkZWxlZ2F0ZWUiOiJlcDphZ2VudDpBIiwiZGVsZWdhdGlvbl9pZCI6ImRsZzoxIiwiZGVsZWdhdG9yIjoiZXA6YXBwcm92ZXI6ZGlyIiwiZXhwaXJlc19hdCI6IjIwMjYtMDYtMTNUMTg6MDA6MDAuMDAwWiIsIm1heF92YWx1ZV91c2QiOjEwMDAsInNjb3BlIjpbInBheW1lbnQucmVsZWFzZSJdfQ",
-              "signature_b64u": "ZUPnPKDnOuEtdGcyLHN8HuPY386zSp2W3_0zpi10xUg9bR9GLzNmxjHs27P7MRroR09FuBJlZU27j-U83JjvBg",
-              "public_key": "MCowBQYDK2VwAyEAD7kkBQg5QM58LSXy_XQ5nOR-2NFjk5qxd1R2v2IjvfM"
+              "signature_b64u": "gqFS8ECrJDBxSVrhKhxA4wfsWcnn41F8_D2SRQVnoZenzIYug5ptzwkold7FH-0hqM0Rn4xBIle9ZcooK-YcCA",
+              "public_key": "MCowBQYDK2VwAyEAW7p6R6iRLL9vqheKxpHL-6ctLzLR3H-gMtFLHVedVGc"
             }
           },
           {
@@ -875,8 +902,8 @@
             "proof": {
               "algorithm": "Ed25519",
               "signed_payload_b64u": "eyJjb25zdHJhaW50cyI6eyJtYXhfY2FsbHMiOjN9LCJkZWxlZ2F0ZWUiOiJlcDphZ2VudDoxIiwiZGVsZWdhdGlvbl9pZCI6ImRsZzoyIiwiZGVsZWdhdG9yIjoiZXA6YWdlbnQ6QSIsImV4cGlyZXNfYXQiOiIyMDI2LTA2LTEzVDE4OjAwOjAwLjAwMFoiLCJtYXhfdmFsdWVfdXNkIjo1MDAsInNjb3BlIjpbInBheW1lbnQucmVsZWFzZSJdfQ",
-              "signature_b64u": "wmlqGjY6fXYcgn6jrMRf8O877Xzo_VwaQB_EfbevAFT3_bKSpstqo7Ghb1VbMt0jBlHnWDIvwj5LxwgZ5950Cg",
-              "public_key": "MCowBQYDK2VwAyEARHAvUldz9jYjiN_iDPPJBGcUz4q1y46mb4Iq4C6V1C8"
+              "signature_b64u": "2dbPwOKejhFo5ASjOraWGxYlLmsjCrAs7-k5LB4F3xLTbcSDgLOfG6ENaGC0NG6Dx7juwCu3StalQxsz99irDQ",
+              "public_key": "MCowBQYDK2VwAyEA3UCeu3zd7qOufBKUgPiq3VadMSo-eA2DfSh2HiO-5pY"
             }
           }
         ],
@@ -887,7 +914,7 @@
         },
         "action_approval": {
           "receipt": {
-            "receipt_id": "ep:receipt:Y2oVoCYqxgk",
+            "receipt_id": "ep:receipt:X6T2WrxCgcw",
             "action": {
               "action_type": "payment.release",
               "policy_id": "pol:test",
@@ -908,65 +935,68 @@
                 "approver": "ep:approver:dir",
                 "approver_index": 1,
                 "required_approvals": 1,
-                "nonce": "2R0DLK0uSH9VFtHNZurHzg",
+                "nonce": "L6qvuw-YQvEOl9OtPdjsXg",
                 "issued_at": "2026-06-13T11:00:00.000Z",
                 "expires_at": "2026-06-13T18:00:00.000Z"
               }
             ],
             "signoffs": [
               {
-                "context_hash": "sha256:bd203972ac4801955c9c1ef7839c53670fcaecf8f96e0deda8d14d4d21444a51",
+                "context_hash": "sha256:93989df9b6701f1932aadfca0701bc0c662230c6377183be3bd800e39de33019",
                 "key_class": "A",
                 "approver_key_id": "ep:key:dir#1",
                 "signed_at": "2026-06-13T11:00:00.000Z",
                 "webauthn": {
                   "authenticator_data": "eW6Ax-W_ikjLYD8inu7FeOxyRD2_43cQzIDeZyKMZxMFAAAAAQ",
-                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoidlNBNWNxeElBWlZjbkI3M2c1eFRad19LN1BqNWJnM3RxTkZOVFNGRVNsRSIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
-                  "signature": "MEUCIEBEggJUR6w2v-BxCx5NnEtf6taDUYkgFg6IQuoC9c3hAiEA8NH0L2ha9FHdRrL2VcxmIiAS2CDYA5zYp4K78EOMAEc"
+                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiazVpZC1iWndIeGt5cXRfS0J3RzhER1lpTU1ZM2NZTy1POWdBNDUzak1CayIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+                  "signature": "MEUCIHhs141vlig-pT0TUyIxJ2ikz8XYbLxuq7ZC1M8_ENgVAiEAzoZSgvTtciJ77VhlioRfvRO7YI4sqsaeXSeXfaBXV9A"
                 },
-                "signature": "MEUCIEBEggJUR6w2v-BxCx5NnEtf6taDUYkgFg6IQuoC9c3hAiEA8NH0L2ha9FHdRrL2VcxmIiAS2CDYA5zYp4K78EOMAEc"
+                "signature": "MEUCIHhs141vlig-pT0TUyIxJ2ikz8XYbLxuq7ZC1M8_ENgVAiEAzoZSgvTtciJ77VhlioRfvRO7YI4sqsaeXSeXfaBXV9A"
               }
             ],
             "consumption": {
-              "nonce": "cdF8yYpRKDc2w-sNs9AzUg",
+              "nonce": "oWstu4-sdpyqAG2A1P4axw",
               "state": "COMMITTED",
               "committed_at": "2026-06-13T11:30:00.000Z"
             },
             "log_proof": {
+              "alg": "EP-MERKLE-v2",
+              "leaf_hash": "sha256:d69e5106032481714536499492ff0ff66a70d4eac1915541eaedf2d23b1129dd",
               "leaf_index": 0,
               "inclusion_path": [],
               "checkpoint": {
                 "tree_size": 1,
-                "root_hash": "sha256:8a793176f3412add81f486b3d1605ad4940299b5bb17cc5dcc381a23df679da8",
+                "root_hash": "sha256:d69e5106032481714536499492ff0ff66a70d4eac1915541eaedf2d23b1129dd",
                 "log_key_id": "ep:log:test#1",
-                "log_signature": "yRtp4l14IfjWeMASlBG2PdT0-dIX2H1xwGuAjYbwIZyb0vx8o5vSrKb0up_wzych9rqt5kgP75iSJPGOLb9YCg"
+                "merkle_alg": "EP-MERKLE-v2",
+                "log_signature": "gdVfVDX1kWNjqrh5kSSMs0muSTNWoQbggvWNSw63XRRxs7OMYrbZhZ4wsrWqDSg_fYK2SiFgOs2BIGx8_iK1CA"
               }
             }
           },
           "verification": {
             "approver_keys": {
               "ep:key:dir#1": {
-                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpWwkmZ2Msw2n16OVhJpXo6hn0Dk1XVlhJp2zcU5ykryULYAdb2_iDpTlwFXPkz4i_GgkQk_PXkMCsTcWG6atlw",
+                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEONm3Q1Cppg2R4XSrQ50j03wjlONUfkSJbELfEiT2JdKicT0BgQ9eJ3eg1YhttLQ1hojg5bMf9xyPMlhAn0cfxA",
                 "key_class": "A",
                 "valid_from": "2026-01-01T00:00:00Z",
                 "valid_to": "2036-01-01T00:00:00Z"
               }
             },
-            "log_public_key": "MCowBQYDK2VwAyEA_HsZnh2eKesX23bzyEk2BpDfOOXs6qwzN0UV0_QNId0"
+            "log_public_key": "MCowBQYDK2VwAyEAnYkwGE1_phRDzRqhYZJTfmj_jH38ckXWhj_w2TbDVRE"
           }
         },
         "provenance_metadata": {
           "chain_depth": 2,
-          "assembled_at": "2026-06-22T06:14:31.026Z",
+          "assembled_at": "2026-07-02T01:43:38.576Z",
           "note": "Composition of existing EP-RECEIPT-v1 receipts + DRP delegation references. No new trust."
         }
       },
       "delegation_keys": {
         "ep:approver:dir": {
-          "public_key": "MCowBQYDK2VwAyEAD7kkBQg5QM58LSXy_XQ5nOR-2NFjk5qxd1R2v2IjvfM"
+          "public_key": "MCowBQYDK2VwAyEAW7p6R6iRLL9vqheKxpHL-6ctLzLR3H-gMtFLHVedVGc"
         },
         "ep:agent:A": {
-          "public_key": "MCowBQYDK2VwAyEARHAvUldz9jYjiN_iDPPJBGcUz4q1y46mb4Iq4C6V1C8"
+          "public_key": "MCowBQYDK2VwAyEA3UCeu3zd7qOufBKUgPiq3VadMSo-eA2DfSh2HiO-5pY"
         }
       },
       "now_ms": 1781352000000
@@ -980,7 +1010,7 @@
         "@version": "EP-PROVENANCE-CHAIN-v1",
         "root_signoff": {
           "receipt": {
-            "receipt_id": "ep:receipt:2OR2HGnJQxk",
+            "receipt_id": "ep:receipt:yXrFBbqLMkQ",
             "action": {
               "action_type": "payment.release",
               "policy_id": "pol:test",
@@ -1001,51 +1031,54 @@
                 "approver": "ep:approver:dir",
                 "approver_index": 1,
                 "required_approvals": 1,
-                "nonce": "goNANxC691_SK3MA7Gfr9Q",
+                "nonce": "0faqSUpy47OB-PhKadXo9g",
                 "issued_at": "2026-06-13T11:00:00.000Z",
                 "expires_at": "2026-06-13T18:00:00.000Z"
               }
             ],
             "signoffs": [
               {
-                "context_hash": "sha256:18ccc19257406ebc659d0f694804746dad551645ef35a670130906713eda4cad",
+                "context_hash": "sha256:431420af4be26d3193fdf272f5afedfaee9c9e719ae328ecf05ae674ec7c3807",
                 "key_class": "A",
                 "approver_key_id": "ep:key:dir#1",
                 "signed_at": "2026-06-13T11:00:00.000Z",
                 "webauthn": {
                   "authenticator_data": "eW6Ax-W_ikjLYD8inu7FeOxyRD2_43cQzIDeZyKMZxMFAAAAAQ",
-                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiR016QmtsZEFicnhsblE5cFNBUjBiYTFWRmtYdk5hWndFd2tHY1Q3YVRLMCIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
-                  "signature": "MEUCIEm9HQU0yH5OG_Kt0gnPlBU-OlEqEUCRFydLSTsFVF85AiEA3Rv0_msFidAa4mi9lJaw9whNLrPjQWrCewmxOlFYqX0"
+                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiUXhRZ3IwdmliVEdUX2ZKeTlhX3QtdTZjbm5HYTR5anM4RnJtZE94OE9BYyIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+                  "signature": "MEQCIC1Dh0VOExqVNtWvFtEuZbV4EEt8S4MEO3YqzlFm7cjLAiAw3x6Z48MMtHvyssxgdSnOtaQDkdfHqNuTZl5XxNSNhg"
                 },
-                "signature": "MEUCIEm9HQU0yH5OG_Kt0gnPlBU-OlEqEUCRFydLSTsFVF85AiEA3Rv0_msFidAa4mi9lJaw9whNLrPjQWrCewmxOlFYqX0"
+                "signature": "MEQCIC1Dh0VOExqVNtWvFtEuZbV4EEt8S4MEO3YqzlFm7cjLAiAw3x6Z48MMtHvyssxgdSnOtaQDkdfHqNuTZl5XxNSNhg"
               }
             ],
             "consumption": {
-              "nonce": "Tsoh_F6EAXWsTregpusP_w",
+              "nonce": "jICseSYi_lCZ-U3aA0J1Sg",
               "state": "COMMITTED",
               "committed_at": "2026-06-13T11:30:00.000Z"
             },
             "log_proof": {
+              "alg": "EP-MERKLE-v2",
+              "leaf_hash": "sha256:e6388855908a57f5bddec41671f358410fc8cdff1922406c48342e492d6edb36",
               "leaf_index": 0,
               "inclusion_path": [],
               "checkpoint": {
                 "tree_size": 1,
-                "root_hash": "sha256:5c47604b58e51821cfb53d0fff34787141f80f410be606063b45a00e7d4d1c7e",
+                "root_hash": "sha256:e6388855908a57f5bddec41671f358410fc8cdff1922406c48342e492d6edb36",
                 "log_key_id": "ep:log:test#1",
-                "log_signature": "AP_MdFpRM1mpk0fhp8wNncs192KEv0Jj2ky_Hjf6mtbus5SOPBdaVdFale-HltSPlBA1Y7D8Cl5LRa-UeHRoAg"
+                "merkle_alg": "EP-MERKLE-v2",
+                "log_signature": "xWkfIeBuZsdZhRr-djhLpDVAJSKun48vFvOcju4aEgcHVpua1TJwfzBoQgcF8CCUZa50vw0jD5I6AMY1_2xmDQ"
               }
             }
           },
           "verification": {
             "approver_keys": {
               "ep:key:dir#1": {
-                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpZxu32qmnLLpgg55BOFk4-FkPpB3u_7uFWN-IcJ_dIFxV31IYYzNVVEM4_f8b0Qj2gGaGmQ_ie36d0i62Qlj1A",
+                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKO7GKVGlNysgZ2wWT4YJzPgw1DMQn0iYuBV3LU_NHyAwaxhw6q0KdIAI-AnJFDuAAppeLD6NsKTKPdIH6DqBmw",
                 "key_class": "A",
                 "valid_from": "2026-01-01T00:00:00Z",
                 "valid_to": "2036-01-01T00:00:00Z"
               }
             },
-            "log_public_key": "MCowBQYDK2VwAyEA1a8iqqgdDpyKa1bunZJ0ipOie1FfG3vXUl2TaAvyeow"
+            "log_public_key": "MCowBQYDK2VwAyEAjYe63RQOsW39zeJdmY5hcnFE13paoTmNOB2DUYvIPy0"
           },
           "human_key_classes": [
             "A"
@@ -1069,8 +1102,8 @@
             "proof": {
               "algorithm": "Ed25519",
               "signed_payload_b64u": "eyJjb25zdHJhaW50cyI6eyJtYXhfY2FsbHMiOjV9LCJkZWxlZ2F0ZWUiOiJlcDphZ2VudDpBIiwiZGVsZWdhdGlvbl9pZCI6ImRsZzoxIiwiZGVsZWdhdG9yIjoiZXA6YXBwcm92ZXI6ZGlyIiwiZXhwaXJlc19hdCI6IjIwMjYtMDYtMTNUMTg6MDA6MDAuMDAwWiIsIm1heF92YWx1ZV91c2QiOjEwMDAsInNjb3BlIjpbInBheW1lbnQucmVsZWFzZSJdfQ",
-              "signature_b64u": "pJSAU-p8pgVE2EVCN_16kKMH-vA34s62u2mP3k7gVBmqpUjXMwpLSXEDPRxAfwjkfyyBCldrZoW5hJvIYtwkCA",
-              "public_key": "MCowBQYDK2VwAyEALGvkEYUDPaTIDAZXZQOm-1uGMhnjfYY-5twFwmCw84c"
+              "signature_b64u": "hqJvaJqt0c-4HHdSX3osSaUlOKKQ3Po6uSVBJ23A9niJwu45_u-oxMnzWLvQoSnz8P9s-LyNlMFTXu1PixyKDQ",
+              "public_key": "MCowBQYDK2VwAyEAKeVI-vCMTj6YLZlbcMjzmTL2g8qZkQYj5HH2JebkgyM"
             }
           },
           {
@@ -1090,8 +1123,8 @@
             "proof": {
               "algorithm": "Ed25519",
               "signed_payload_b64u": "eyJjb25zdHJhaW50cyI6eyJtYXhfY2FsbHMiOjUwfSwiZGVsZWdhdGVlIjoiZXA6YWdlbnQ6MSIsImRlbGVnYXRpb25faWQiOiJkbGc6MiIsImRlbGVnYXRvciI6ImVwOmFnZW50OkEiLCJleHBpcmVzX2F0IjoiMjAyNi0wNi0xM1QxODowMDowMC4wMDBaIiwibWF4X3ZhbHVlX3VzZCI6NTAwLCJzY29wZSI6WyJwYXltZW50LnJlbGVhc2UiXX0",
-              "signature_b64u": "GJgRMLSOgCkXTto6c3tFJi5FZnur6QonNDHf_dh2x1iE7uNYZ4u92HU3Zqmb6BvzryJKqUtX8XA2O1mqP2x-Dg",
-              "public_key": "MCowBQYDK2VwAyEA78xIAEkZK1nC1XUvjk4EFnJxkaTvHCta_IeYPyFGLto"
+              "signature_b64u": "_oAD62kxwVtoWAXUqjr5FXlWgtpgDHkq86JmgjNPU2lvZcmqOXXrr8zovPy8izvr1GBoz11OOUKjWNS-arGWBw",
+              "public_key": "MCowBQYDK2VwAyEApusbGxbm5QE3iN-LgGNwBnjK0JHi4y_blvJjB2R90gA"
             }
           }
         ],
@@ -1102,7 +1135,7 @@
         },
         "action_approval": {
           "receipt": {
-            "receipt_id": "ep:receipt:APBHXtAmC3o",
+            "receipt_id": "ep:receipt:FvY72giZ_5g",
             "action": {
               "action_type": "payment.release",
               "policy_id": "pol:test",
@@ -1123,65 +1156,68 @@
                 "approver": "ep:approver:dir",
                 "approver_index": 1,
                 "required_approvals": 1,
-                "nonce": "V-gEtr_DTW2BYLOvlw-E3w",
+                "nonce": "bAEezy-eOiOBc6fuSuvkdg",
                 "issued_at": "2026-06-13T11:00:00.000Z",
                 "expires_at": "2026-06-13T18:00:00.000Z"
               }
             ],
             "signoffs": [
               {
-                "context_hash": "sha256:2bbd55ab38b9b32be4992e681f4915ce4912df8d8c315a2f3a25a9dd792001b1",
+                "context_hash": "sha256:d1a15d00bbd396aa3ffbe572c9e79fde20ba7e07962d4482c6c111a3f6c77aec",
                 "key_class": "A",
                 "approver_key_id": "ep:key:dir#1",
                 "signed_at": "2026-06-13T11:00:00.000Z",
                 "webauthn": {
                   "authenticator_data": "eW6Ax-W_ikjLYD8inu7FeOxyRD2_43cQzIDeZyKMZxMFAAAAAQ",
-                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiSzcxVnF6aTVzeXZrbVM1b0gwa1Z6a2tTMzQyTU1Wb3ZPaVdwM1hrZ0FiRSIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
-                  "signature": "MEQCIF1D5OOFXttbS_imLuOaV4OQ46M_8_GNReyh7vVlJMymAiAnhT6kYS0fSVWu5T1OveY3wtuvbDPZBVsBy5yZLJJUUA"
+                  "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiMGFGZEFMdlRscW9fLS1WeXllZWYzaUM2ZmdlV0xVU0N4c0VSb19iSGV1dyIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+                  "signature": "MEQCIAvPjonWbEe3NQfVwz5BnxJ136-qQaWU64nGqywKL24OAiAWqHHZp0mc4QVEN1Odx28WEFMmpl8AkpBXcDe_3x2llA"
                 },
-                "signature": "MEQCIF1D5OOFXttbS_imLuOaV4OQ46M_8_GNReyh7vVlJMymAiAnhT6kYS0fSVWu5T1OveY3wtuvbDPZBVsBy5yZLJJUUA"
+                "signature": "MEQCIAvPjonWbEe3NQfVwz5BnxJ136-qQaWU64nGqywKL24OAiAWqHHZp0mc4QVEN1Odx28WEFMmpl8AkpBXcDe_3x2llA"
               }
             ],
             "consumption": {
-              "nonce": "-yiY1JdPrHs9c_J8_CgC_w",
+              "nonce": "mL_CbmEanVJ03LtrC6Z7yQ",
               "state": "COMMITTED",
               "committed_at": "2026-06-13T11:30:00.000Z"
             },
             "log_proof": {
+              "alg": "EP-MERKLE-v2",
+              "leaf_hash": "sha256:49f3bd574ac23471873cef419a5a69d93ed42c4161ff21e3da1732092457d0cb",
               "leaf_index": 0,
               "inclusion_path": [],
               "checkpoint": {
                 "tree_size": 1,
-                "root_hash": "sha256:8224d13ce039e528178bf2ed73311b55052c41f987e486c6774d3e6836c8470d",
+                "root_hash": "sha256:49f3bd574ac23471873cef419a5a69d93ed42c4161ff21e3da1732092457d0cb",
                 "log_key_id": "ep:log:test#1",
-                "log_signature": "FakXTVevAZONo0KDxNreUT0_t5e6U1V6pUlgdwzrFXHwoeJrJR96nuB55eyFcIOmxMVuO8uLcbpaKJJhrP2_CA"
+                "merkle_alg": "EP-MERKLE-v2",
+                "log_signature": "D0t_ESAK8wnNNYrTHGwUZLDDoltZvI5ozLUvciLiyMcT0aIp8qpdCx-LDGbWiXXTiUaT89M4z5rMfLajzz6bDA"
               }
             }
           },
           "verification": {
             "approver_keys": {
               "ep:key:dir#1": {
-                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1fxUfltav9wQnrCq9Ok33b_fB9fcu9eOcb-gI1jitQTgYtxjg5rB3ut22FBxp0ShhcHteD8fMpkIQLTMUSg9Cw",
+                "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyaTGvwWYVpna_PmL1yIsczaOGe4KuIkmVyrgnqjiWG1rumQ89TaVptbwv2z9iwUgm93Ya0dnsb3iEy_zqHj5wQ",
                 "key_class": "A",
                 "valid_from": "2026-01-01T00:00:00Z",
                 "valid_to": "2036-01-01T00:00:00Z"
               }
             },
-            "log_public_key": "MCowBQYDK2VwAyEAhHQjT8L3C8o_lBxrv8_1KFRf9WCTlMYxLOxKYLMbxro"
+            "log_public_key": "MCowBQYDK2VwAyEA8RoKO4UGAFmdL0OEJd3lyU2KOEsycYHtdKawUOGmtu4"
           }
         },
         "provenance_metadata": {
           "chain_depth": 2,
-          "assembled_at": "2026-06-22T06:14:31.026Z",
+          "assembled_at": "2026-07-02T01:43:38.577Z",
           "note": "Composition of existing EP-RECEIPT-v1 receipts + DRP delegation references. No new trust."
         }
       },
       "delegation_keys": {
         "ep:approver:dir": {
-          "public_key": "MCowBQYDK2VwAyEALGvkEYUDPaTIDAZXZQOm-1uGMhnjfYY-5twFwmCw84c"
+          "public_key": "MCowBQYDK2VwAyEAKeVI-vCMTj6YLZlbcMjzmTL2g8qZkQYj5HH2JebkgyM"
         },
         "ep:agent:A": {
-          "public_key": "MCowBQYDK2VwAyEA78xIAEkZK1nC1XUvjk4EFnJxkaTvHCta_IeYPyFGLto"
+          "public_key": "MCowBQYDK2VwAyEApusbGxbm5QE3iN-LgGNwBnjK0JHi4y_blvJjB2R90gA"
         }
       },
       "now_ms": 1781352000000

--- a/conformance/vectors/trust-receipt.exec.v1.json
+++ b/conformance/vectors/trust-receipt.exec.v1.json
@@ -10,7 +10,7 @@
         "valid": true
       },
       "trust_receipt": {
-        "receipt_id": "ep:receipt:91-vNURHIt8",
+        "receipt_id": "ep:receipt:tfjB1iUOqpA",
         "action": {
           "action_type": "payment.release",
           "policy_id": "pol:test",
@@ -32,51 +32,54 @@
             "approver": "ep:approver:dir",
             "approver_index": 1,
             "required_approvals": 1,
-            "nonce": "jZG9pKBRKcMcvh5PICPpKw",
+            "nonce": "5zwbpAtTNFPsfAelt2Xgrw",
             "issued_at": "2026-06-13T11:00:00.000Z",
             "expires_at": "2026-06-13T18:00:00.000Z"
           }
         ],
         "signoffs": [
           {
-            "context_hash": "sha256:2b7515692a0f7f1a61e8f8af2362490da5a5d7bd33891d8c89b5873a3814835d",
+            "context_hash": "sha256:2f324a439b6e1369b73afa65c22ab06fba34a9ccdeda5d668967cb2358615012",
             "key_class": "A",
             "approver_key_id": "ep:key:dir#1",
             "signed_at": "2026-06-13T11:00:00.000Z",
             "webauthn": {
               "authenticator_data": "eW6Ax-W_ikjLYD8inu7FeOxyRD2_43cQzIDeZyKMZxMFAAAAAQ",
-              "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiSzNVVmFTb1BmeHBoNlBpdkkySkpEYVdsMTcwemlSMk1pYldIT2pnVWcxMCIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
-              "signature": "MEUCIQC5uFDaOzyvYYHPYITYCbDkgd5ygYaLoKj1RCxBOgMeSgIgOrrjzR_PdvRijC4U75Uoxa772rbTcZEAaA-Kru7yxF4"
+              "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiTHpKS1E1dHVFMm0zT3ZwbHdpcXdiN28wcWN6ZTJsMW1pV2ZMSTFoaFVCSSIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+              "signature": "MEYCIQC_xOcyxxC0hvuaKT8WOc0G3cNAvjgnO_wCoPwzHhZtSwIhAJajCPQ1fnJKYURAYXZ1q3Jt35byCtKGa3a9vZtpa9eV"
             },
-            "signature": "MEUCIQC5uFDaOzyvYYHPYITYCbDkgd5ygYaLoKj1RCxBOgMeSgIgOrrjzR_PdvRijC4U75Uoxa772rbTcZEAaA-Kru7yxF4"
+            "signature": "MEYCIQC_xOcyxxC0hvuaKT8WOc0G3cNAvjgnO_wCoPwzHhZtSwIhAJajCPQ1fnJKYURAYXZ1q3Jt35byCtKGa3a9vZtpa9eV"
           }
         ],
         "consumption": {
-          "nonce": "NkV347yqGx4xstyrGEn0Ig",
+          "nonce": "bmVZIFgAwNsm4pmyQgCDuQ",
           "state": "COMMITTED",
           "committed_at": "2026-06-13T11:30:00.000Z"
         },
         "log_proof": {
+          "alg": "EP-MERKLE-v2",
+          "leaf_hash": "sha256:0b22d4d12dd6f01629e6716d7afc20ed3daf8d30d558404c5eebcbe994e42318",
           "leaf_index": 0,
           "inclusion_path": [],
           "checkpoint": {
             "tree_size": 1,
-            "root_hash": "sha256:552b718d573c44e93eaa1b0239577a19c26ca5d0dc477af9d4a0bd3bbe7e5a92",
+            "root_hash": "sha256:0b22d4d12dd6f01629e6716d7afc20ed3daf8d30d558404c5eebcbe994e42318",
             "log_key_id": "ep:log:test#1",
-            "log_signature": "XP5m-gVxc_1m6QaroUCfti8foQXAC3mYzMcFnn4WT_s1rD3I-l9Ho9pebT1TermPyxMmFbI4Oy8iE2CfhzqrBA"
+            "merkle_alg": "EP-MERKLE-v2",
+            "log_signature": "2-Nsqm__VSu15NOX5hwDzB04E5WPXnwekuGWm8acedxzZNRqiUrlzVO1vksFmfm8L3L1vDJc2_uFwvfLukEpAw"
           }
         }
       },
       "verification": {
         "approver_keys": {
           "ep:key:dir#1": {
-            "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9C-6Yxyfy2u3hCmyMCBsVZRr7I2jCXiyGhjnjP_aXkBAQjqTH1zEMts5yaYARDp-S4K-lTwU3kPq963uEdLvYg",
+            "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWQwA3Uqe50UbpXerabANGQivTEvMRhpyIVH6Gk4VaEcK9_yYmQm_DqRPPE7pSJGLY9MdIUS-w369hiCFzgWe7A",
             "key_class": "A",
             "valid_from": "2026-01-01T00:00:00Z",
             "valid_to": "2036-01-01T00:00:00Z"
           }
         },
-        "log_public_key": "MCowBQYDK2VwAyEAfHBd5t-0Hoy-pfApTdcsenwEB3UxNzz7dXq0DSGUXxQ"
+        "log_public_key": "MCowBQYDK2VwAyEAa4euWYeQY65cBRqAkw5WCmSoTKap0SHS-N7LgdHJwNc"
       }
     },
     {
@@ -85,7 +88,7 @@
         "valid": false
       },
       "trust_receipt": {
-        "receipt_id": "ep:receipt:Mh452uFhnb4",
+        "receipt_id": "ep:receipt:a7CV9FHjR7A",
         "action": {
           "action_type": "payment.release",
           "policy_id": "pol:test",
@@ -107,51 +110,54 @@
             "approver": "ep:approver:dir",
             "approver_index": 1,
             "required_approvals": 1,
-            "nonce": "cPrQXK7N4O14NTdJfKz3Og",
+            "nonce": "gDvalNecrDaaGUkCAddt6w",
             "issued_at": "2026-06-13T11:00:00.000Z",
             "expires_at": "2026-06-13T18:00:00.000Z"
           }
         ],
         "signoffs": [
           {
-            "context_hash": "sha256:864f03a8ddd77a29ace3928348d8f31e4c3acc37fbe77b51057bff451686e0c7",
+            "context_hash": "sha256:f28b84bfc8aa51da27d2cda3eefe23b2deece9050da3138853ffb8a0639373ea",
             "key_class": "A",
             "approver_key_id": "ep:key:dir#1",
             "signed_at": "2026-06-13T11:00:00.000Z",
             "webauthn": {
               "authenticator_data": "eW6Ax-W_ikjLYD8inu7FeOxyRD2_43cQzIDeZyKMZxMFAAAAAQ",
-              "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiaGs4RHFOM1hlaW1zNDVLRFNOanpIa3c2ekRmNzUzdFJCWHZfUlJhRzRNYyIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
-              "signature": "MEYCIQDbct7A4XXuUhxxLPRrJnPbGAmKQg9gfgKdmW9grQvIdAIhAJcbz8Q4JA3rSlwg7b4eDW_ZgObGLlWWbNk7WDmPpzYs"
+              "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiOG91RXY4aXFVZG9uMHMyajd2NGpzdDdzNlFVTm94T0lVXy00b0dPVGMtbyIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+              "signature": "MEQCIBjN4gRl3V0kqaBAIwwTOHIDD1Nzr8sREriHiC_gfkEqAiANkrgYPlQ7fxAHre3WB7LXuy3TEaqs_8WvpHgL5J0aYA"
             },
-            "signature": "MEYCIQDbct7A4XXuUhxxLPRrJnPbGAmKQg9gfgKdmW9grQvIdAIhAJcbz8Q4JA3rSlwg7b4eDW_ZgObGLlWWbNk7WDmPpzYs"
+            "signature": "MEQCIBjN4gRl3V0kqaBAIwwTOHIDD1Nzr8sREriHiC_gfkEqAiANkrgYPlQ7fxAHre3WB7LXuy3TEaqs_8WvpHgL5J0aYA"
           }
         ],
         "consumption": {
-          "nonce": "yWUrvfSJoQpoY__E2mh5uA",
+          "nonce": "vAquF-k-tfDrk3IlGKoZsw",
           "state": "COMMITTED",
           "committed_at": "2026-06-13T11:30:00.000Z"
         },
         "log_proof": {
+          "alg": "EP-MERKLE-v2",
+          "leaf_hash": "sha256:e420c411903ec8af4421e95c054b143887c6e2892a6d412444f32c101b62dcbf",
           "leaf_index": 0,
           "inclusion_path": [],
           "checkpoint": {
             "tree_size": 1,
-            "root_hash": "sha256:d329ce1566c001f8e14e52d0c623860ea72ce37e594a1e273d0451ed36f05be3",
+            "root_hash": "sha256:e420c411903ec8af4421e95c054b143887c6e2892a6d412444f32c101b62dcbf",
             "log_key_id": "ep:log:test#1",
-            "log_signature": "du4IPaP_BF8zwl4f3jy-BeDEZCUc74ugKOohMhZZpmS4YQcF5-pWCBViinedeRu5D0SCUCRgkb8ZtYnPJe_-Bw"
+            "merkle_alg": "EP-MERKLE-v2",
+            "log_signature": "djY5UkId4cTI2bw2wR9gzAekAGnYFgBJrxUfejGjR9QlCvbWw4QD1fOFjwk7L66tFShMMGlvd0Bqyh58k1MJBg"
           }
         }
       },
       "verification": {
         "approver_keys": {
           "ep:key:dir#1": {
-            "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2iNHbl-J1wFuLbFNs_Oj9vtVikS8mCD5cbjt_EAv9vjapWOTvlZ4RPMczYa-dUgsHnt5wL6g7gkZm_6Pp1cXbA",
+            "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEb6pZRfgmiiIH0gZ_omxBxJNXoPlwwqCvY14agm8QRVAOjhTvxA_9c_9cYOEkfeVW76JYgq8lqk2s74xrN1Mmgw",
             "key_class": "A",
             "valid_from": "2026-01-01T00:00:00Z",
             "valid_to": "2036-01-01T00:00:00Z"
           }
         },
-        "log_public_key": "MCowBQYDK2VwAyEAVoGVHG9dGBZy_VQAKO8tR7Vc8862QLgEFPiP7RTxs58"
+        "log_public_key": "MCowBQYDK2VwAyEA6QrgLfwsNrmaEqDtBhLACy5KZZ8y8AtN3NXD10ZTOcE"
       }
     },
     {
@@ -160,7 +166,7 @@
         "valid": false
       },
       "trust_receipt": {
-        "receipt_id": "ep:receipt:Sp6sUIRfGQ8",
+        "receipt_id": "ep:receipt:24I1AK8LkvQ",
         "action": {
           "action_type": "payment.release",
           "policy_id": "pol:test",
@@ -182,51 +188,54 @@
             "approver": "ep:approver:dir",
             "approver_index": 1,
             "required_approvals": 1,
-            "nonce": "tyssrsR45K_ZZjN2-GxDNw",
+            "nonce": "0ZMAtlmP9o2QIOQf2t5ywQ",
             "issued_at": "2026-06-13T11:00:00.000Z",
             "expires_at": "2026-06-13T18:00:00.000Z"
           }
         ],
         "signoffs": [
           {
-            "context_hash": "sha256:42e2f8db11f44fc05a6fe17331d32233efd91fe840ed42a3fe38caf619f1b79b",
+            "context_hash": "sha256:461314a0408f5d93a6695456abc85ad5345b96c7803724486e513c8cfe771b6a",
             "key_class": "A",
             "approver_key_id": "ep:key:dir#1",
             "signed_at": "2026-06-13T11:00:00.000Z",
             "webauthn": {
               "authenticator_data": "eW6Ax-W_ikjLYD8inu7FeOxyRD2_43cQzIDeZyKMZxMFAAAAAQ",
-              "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiUXVMNDJ4SDBUOEJhYi1Gek1kTWlNLV9aSC1oQTdVS2pfampLOWhueHQ1cyIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
-              "signature": "MEYCIQDdeooFerytuXiZiHt8NNiK0CemGoR7Ne-v8xtBxsvZJgIhANDlqZua0wGrKyEb_h4U3D-TBxqc-jBQk_F9t49WvSiN"
+              "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiUmhNVW9FQ1BYWk9tYVZSV3E4aGExVFJibHNlQU55UklibEU4alA1M0cybyIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+              "signature": "MEUCIQDYIj-T-adSeDMh0J6lGP-THvfSOXp1ZOB4LwQD3BhX7QIgfDbK8W0dCmSA7U4XT7ylH9Bcl1eu3shZxc8QbZs4CS8"
             },
-            "signature": "MEYCIQDdeooFerytuXiZiHt8NNiK0CemGoR7Ne-v8xtBxsvZJgIhANDlqZua0wGrKyEb_h4U3D-TBxqc-jBQk_F9t49WvSiN"
+            "signature": "MEUCIQDYIj-T-adSeDMh0J6lGP-THvfSOXp1ZOB4LwQD3BhX7QIgfDbK8W0dCmSA7U4XT7ylH9Bcl1eu3shZxc8QbZs4CS8"
           }
         ],
         "consumption": {
-          "nonce": "MGHGun1dUnNCsgUYFn6jhw",
+          "nonce": "119xIeO2IFDqreo92RpjKg",
           "state": "COMMITTED",
           "committed_at": "2026-06-13T11:30:00.000Z"
         },
         "log_proof": {
+          "alg": "EP-MERKLE-v2",
+          "leaf_hash": "sha256:d4dbc17eb53605831e6e5b7efbb4cab26d87b60ab8c01b6b7bdd6ac95451750e",
           "leaf_index": 0,
           "inclusion_path": [],
           "checkpoint": {
             "tree_size": 1,
-            "root_hash": "sha256:8c897e703b399605426fc6a6597dbcba7369ba52fba4165220e4473aeb28cda8",
+            "root_hash": "sha256:d4dbc17eb53605831e6e5b7efbb4cab26d87b60ab8c01b6b7bdd6ac95451750e",
             "log_key_id": "ep:log:test#1",
-            "log_signature": "T89yhqQRkeVtgnI0bXy7UKArglqp5vOs_DW6uy2fwHa5nW4wuj8oKNCEuq3UBZElqkebA3nsKijA-cOkqVO9Cg"
+            "merkle_alg": "EP-MERKLE-v2",
+            "log_signature": "nSiZbxwBakaJ7St73W6FGg1V-1wsuGI1PcTAfhxSCam7KCV5KF5NOOkWZvWp5K5owkO49r7fGhGnDfQPmT2iAA"
           }
         }
       },
       "verification": {
         "approver_keys": {
           "ep:key:dir#1": {
-            "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmxDOdDUovxCZCjl0N2j6xEPVVabbALz22_ewj01BTLLnO2n9daD9rtelML3R1kVxPWzTpceKkfqhT5G00le7pg",
+            "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEz97F62DRXArTqstbIb0FtcYHOgwa54bDKcd7ZiibnIoBb0JTJd1Ya3m0p2OXcv2sQI2r0R_lP2uLBbeOhshlAA",
             "key_class": "A",
             "valid_from": "2026-01-01T00:00:00Z",
             "valid_to": "2036-01-01T00:00:00Z"
           }
         },
-        "log_public_key": "MCowBQYDK2VwAyEAhylaPFg7-i931xmYF11PLgxrF66ZXpCKydwGup-sadU"
+        "log_public_key": "MCowBQYDK2VwAyEA1_Y--9uO6R-He3n7nI6WnJ8Jf6hD-Uu5POWZuJggkEc"
       }
     },
     {
@@ -235,7 +244,7 @@
         "valid": false
       },
       "trust_receipt": {
-        "receipt_id": "ep:receipt:B2MU4i916Yk",
+        "receipt_id": "ep:receipt:kZ55MZNbbsU",
         "action": {
           "action_type": "payment.release",
           "policy_id": "pol:test",
@@ -257,31 +266,33 @@
             "approver": "ep:approver:dir",
             "approver_index": 1,
             "required_approvals": 1,
-            "nonce": "2K7mwFz2Vo2FtqtQlfmKGg",
+            "nonce": "10PTztgc9ZH2i_QvGejaig",
             "issued_at": "2026-06-13T11:00:00.000Z",
             "expires_at": "2026-06-13T18:00:00.000Z"
           }
         ],
         "signoffs": [
           {
-            "context_hash": "sha256:c14a8777fbf0aba3ad8b8a3c21d50d3f68881f9b6c93d267b49162688ad63ac1",
+            "context_hash": "sha256:9f4cc0286c6281b998326f5591c3a956b03a8ae763aa3f1495a010c4d9106997",
             "key_class": "A",
             "approver_key_id": "ep:key:dir#1",
             "signed_at": "2026-06-13T11:00:00.000Z",
             "webauthn": {
               "authenticator_data": "eW6Ax-W_ikjLYD8inu7FeOxyRD2_43cQzIDeZyKMZxMFAAAAAQ",
-              "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoid1VxSGRfdndxNk90aTRvOElkVU5QMmlJSDV0c2s5Sm50SkZpYUlyV09zRSIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
-              "signature": "MEUCIQCU4q7gRnUryKRNnugQYzWM4tLE_0PcxRisOvstL-vl1AIgKL8y00cNeeN38bWXI3Pai4wgfhFklTWfH-v7GWe6Ikg"
+              "client_data_json": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoibjB6QUtHeGlnYm1ZTW05VmtjT3BWckE2aXVkanFqOFVsYUFReE5rUWFaYyIsIm9yaWdpbiI6Imh0dHBzOi8vdGVzdC5lbWlsaWEiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+              "signature": "MEQCIHbw1rCmVgldNC3Pjg2cLX3XqYdG8uAOatKiC83SiIARAiBqF03-t-gVPaj5ViWp15sx3tbyZit_C0ZL4PehQ0F0aA"
             },
-            "signature": "MEUCIQCU4q7gRnUryKRNnugQYzWM4tLE_0PcxRisOvstL-vl1AIgKL8y00cNeeN38bWXI3Pai4wgfhFklTWfH-v7GWe6Ikg"
+            "signature": "MEQCIHbw1rCmVgldNC3Pjg2cLX3XqYdG8uAOatKiC83SiIARAiBqF03-t-gVPaj5ViWp15sx3tbyZit_C0ZL4PehQ0F0aA"
           }
         ],
         "consumption": {
-          "nonce": "qZRMxxhgJwHntdFIiFZnmg",
+          "nonce": "h1Ti-KwqywdcDid_a0DN2A",
           "state": "COMMITTED",
           "committed_at": "2026-06-13T11:30:00.000Z"
         },
         "log_proof": {
+          "alg": "EP-MERKLE-v2",
+          "leaf_hash": "sha256:3b4d22e95e5233b0338c9f545a8e5a0a95dbfe03d8bc57c1e222ce3bcd2e89fe",
           "leaf_index": 0,
           "inclusion_path": [
             {
@@ -291,22 +302,23 @@
           ],
           "checkpoint": {
             "tree_size": 1,
-            "root_hash": "sha256:047b93f7663ca201d590345c9057cd57319d216388bd422a10fffa186b4f07df",
+            "root_hash": "sha256:3b4d22e95e5233b0338c9f545a8e5a0a95dbfe03d8bc57c1e222ce3bcd2e89fe",
             "log_key_id": "ep:log:test#1",
-            "log_signature": "KyajpVAFgSbjwU9C-EUv6it6xf7MkqtOEZz_lvTcS3tyxM98YzbOFWV5OioqSweXpZi3qkcxKndeqbEZrgD2CQ"
+            "merkle_alg": "EP-MERKLE-v2",
+            "log_signature": "EvbDfwCj7KQ4Q_UJy4XElB4NOjjKsnhqAzTb-U3xsuuzGE_2wlaaJDhSq6aZ52-BScyUWg0qYHiJgj20BTYsCg"
           }
         }
       },
       "verification": {
         "approver_keys": {
           "ep:key:dir#1": {
-            "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzSa1V-gFfvRD3GUXxD_a25PwB0R9r6AJvLDyThOsKH4S0spqfIScwdMFNnrpJu3jl-fS3yFvX0bp1LXLr_r06g",
+            "public_key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1RY0STDmbUDTzmVcQOvIvzdgnHvcwY1TBPIjJcaFuNIe2reCmdjDlDOV2LPEh5buyZzHtjftP5ILqmvFKvvYKA",
             "key_class": "A",
             "valid_from": "2026-01-01T00:00:00Z",
             "valid_to": "2036-01-01T00:00:00Z"
           }
         },
-        "log_public_key": "MCowBQYDK2VwAyEAkuwg6UetdLfRrPoEGoPh9moSLiD2kpExoqdzq9fHVLk"
+        "log_public_key": "MCowBQYDK2VwAyEAgT8W2jh_asEGhsrNmkjMJL5620C2O1Y2JczykmI_0l8"
       }
     }
   ]

--- a/create-ep-app/index.js
+++ b/create-ep-app/index.js
@@ -3,14 +3,7 @@
 /**
  * create-ep-app — Zero to verified trust system in 5 minutes
  *
- * Usage (works today, from a repo checkout):
- *   node create-ep-app/index.js my-trust-system
- *
- * Once published under the EP-controlled scope:
- *   npx @emilia-protocol/create-app my-trust-system
- *
- * NOTE: the unscoped npm name "create-ep-app" is owned by an unrelated
- * third party — never instruct `npx create-ep-app`.
+ * Usage: npx @emilia-protocol/create-ep-app my-trust-system
  *
  * Creates a minimal but complete EP-powered application with:
  *   - Entity registration
@@ -34,11 +27,9 @@ const rawProjectName = process.argv[2];
 
 if (!rawProjectName) {
   console.error(`
-  Usage: node create-ep-app/index.js <project-name>
+  Usage: npx @emilia-protocol/create-ep-app <project-name>
 
-  Example: node create-ep-app/index.js my-trust-system
-
-  (Once the scoped creator is published: npx @emilia-protocol/create-app <project-name>)
+  Example: npx @emilia-protocol/create-ep-app my-trust-system
   `);
   process.exit(1);
 }

--- a/create-ep-app/package.json
+++ b/create-ep-app/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@emilia-protocol/create-ep-app",
+  "version": "0.1.0",
+  "description": "Create a minimal EMILIA Protocol trust system in five minutes.",
+  "type": "module",
+  "bin": {
+    "create-ep-app": "./index.js"
+  },
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/docs/FEDERATION-REGISTRY.md
+++ b/docs/FEDERATION-REGISTRY.md
@@ -74,9 +74,11 @@ Every EP-RECEIPT-v1 MUST carry, in its `signature` block:
 }
 ```
 
-`signer` + `key_discovery` are what make a receipt **self-locating**: a relying
-party who has never heard of Operator A can still find A's keys from the receipt
-alone.
+`signer` identifies the issuing operator. `key_discovery` is a portability hint
+for demos and offline exchange, not a relying-party trust root. A production
+verifier MUST pin or allowlist the discovery origin it is willing to dereference;
+otherwise a malicious receipt can choose where the verifier sends network
+traffic.
 
 ---
 
@@ -88,8 +90,11 @@ This is implemented, tested, and published as
 later** (`npm install @emilia-protocol/verify`); earlier releases do not carry
 the federation exports. The algorithm:
 
-1. Read `signature.signer` and `signature.key_discovery` from the receipt.
-2. Fetch (or use a cached, un-expired copy of) the operator's `ep-keys.json`.
+1. Read `signature.signer` from the receipt and select the pinned discovery URL
+   for that operator. Treat `signature.key_discovery` as a hint unless an
+   explicit unsafe/demo opt-in is enabled.
+2. Fetch (or use a cached, un-expired copy of) the operator's `ep-keys.json`
+   from that pinned HTTPS URL.
 3. Resolve candidate keys for `signer`: **current first, then historical**.
 4. Verify the Ed25519 signature over the canonical payload against each
    candidate; the first that validates wins. A tampered payload or an
@@ -103,7 +108,9 @@ the federation exports. The algorithm:
 // requires @emilia-protocol/verify >= 1.3.0
 import { verifyFederatedReceipt } from '@emilia-protocol/verify';
 
-const verdict = await verifyFederatedReceipt(receipt);
+const verdict = await verifyFederatedReceipt(receipt, {
+  keyDiscoveryUrl: 'https://op-a.example/.well-known/ep-keys.json',
+});
 // { accepted, verified, revoked, signer, keyMatched: 'current'|'historical', checks }
 ```
 
@@ -121,8 +128,9 @@ There is no central registrar. An operator joins the federation by:
 2. Passing the cross-operator conformance harness against the primary:
    `node conformance/federation.mjs https://<your-operator-origin>`.
 3. (Optional, recommended) opening a PR to the operator list below so relying
-   parties can pin a known origin. Pinning is a *convenience*, never a
-   *requirement* — a receipt's `key_discovery` URL is always authoritative.
+   parties can pin a known origin. Pinning is required for production online
+   verification; a receipt's `key_discovery` URL is never authoritative by
+   itself.
 
 ### Known operators
 

--- a/docs/FEDERATION-SPEC.md
+++ b/docs/FEDERATION-SPEC.md
@@ -103,10 +103,10 @@ When Operator B receives an EP-RECEIPT-v1 document issued by Operator A:
 
 ```
 1. Extract signer entity_id from doc.signature.signer
-2. Discover Operator A's keys URL:
-   a. If doc.signature.key_discovery is a full URL, fetch it
-   b. Otherwise, look up the entity's operator via federation registry
-3. Fetch Operator A's /.well-known/ep-keys.json
+2. Select Operator A's pinned discovery URL from local policy or a federation
+   registry. Treat doc.signature.key_discovery as a hint only; do not fetch a
+   receipt-supplied URL as a trust anchor.
+3. Fetch Operator A's /.well-known/ep-keys.json over HTTPS from that pinned URL
 4. Find the signer's public key
 5. Verify Ed25519 signature over canonical payload
 6. If anchor present:

--- a/docs/WHAT-THE-WINNER-HAS.md
+++ b/docs/WHAT-THE-WINNER-HAS.md
@@ -21,10 +21,9 @@ EP today has 137 documentation files, 50 database tables, and a setup process th
 **What the winner has:**
 
 ```bash
-git clone https://github.com/emilia-protocol/emilia-protocol.git
-node emilia-protocol/create-ep-app/index.js my-trust-system
+npx @emilia-protocol/create-ep-app my-trust-system
 cd my-trust-system
-npm install && npm run dev
+npm run dev
 # Open localhost:3000 → working trust system with:
 #   - Entity registration
 #   - Receipt submission
@@ -36,14 +35,14 @@ npm install && npm run dev
 
 Not "read the docs and figure out which of 45 API endpoints to call." A working app. In 5 minutes. With a guided walkthrough that shows you what trust enforcement looks like.
 
-**Status: BUILT.** `create-ep-app/index.js` ships this exact experience. Run `node create-ep-app/index.js my-app && cd my-app && npm install && npm run dev` → working trust system with in-browser demo dashboard in under 5 minutes. (Publishes as `npx @emilia-protocol/create-app` once the scoped creator is released — the unscoped `create-ep-app` name on npm belongs to an unrelated third party and must not be used.)
+**Status: BUILT.** `create-ep-app/index.js` ships this exact experience through the scoped package `@emilia-protocol/create-ep-app`. Run `npx @emilia-protocol/create-ep-app my-app && cd my-app && npm run dev` → working trust system with in-browser demo dashboard in under 5 minutes.
 
 ### 2. The Acid Test (Conformance Test Suite)
 
 **What the winner has:**
 
 ```bash
-npx ep-conformance-test https://my-ep-server.com
+node conformance/ep-conformance-test.js https://my-ep-server.com
 # ✓ Trust Receipt format (EP-RECEIPT-v1)
 # ✓ Ed25519 signature verification
 # ✓ Merkle anchor proof verification
@@ -58,7 +57,7 @@ npx ep-conformance-test https://my-ep-server.com
 
 Like the W3C Acid tests for browsers. If you pass, you're EP-conformant. If you're EP-conformant, every other EP operator can verify your receipts. This is what turns a single implementation into a network.
 
-**Status: BUILT.** `conformance/ep-conformance-test.js` implements this exact test. Primary operator passes 7/7 required checks (`CONFORMANT: EP Core v1.0`). Any external operator can run `npx ep-conformance-test https://their-server.com` to validate.
+**Status: BUILT.** `conformance/ep-conformance-test.js` implements this exact test. Primary operator passes 7/7 required checks (`CONFORMANT: EP Core v1.0`). Any external operator can clone the repo and run `node conformance/ep-conformance-test.js https://their-server.com` to validate.
 
 ### 3. The Trust Explorer (Etherscan for Trust)
 
@@ -138,7 +137,7 @@ The structural work is done:
 - LLM schema ✓
 
 All six adoption primitives are now **BUILT AND DEPLOYED:**
-- `create-ep-app` ✅ → `create-ep-app/index.js` (zero-to-trust in 5 minutes)
+- `@emilia-protocol/create-ep-app` ✅ → `create-ep-app/index.js` (zero-to-trust in 5 minutes)
 - Conformance test suite ✅ → `conformance/ep-conformance-test.js` (7/7 PASS)
 - Trust Explorer ✅ → `/explorer` (live verification UI)
 - Embed widget ✅ → `public/embed.js` (`<ep-trust-badge>` web component)

--- a/docs/conformance/FEDERATION-PROOF.md
+++ b/docs/conformance/FEDERATION-PROOF.md
@@ -15,7 +15,7 @@ Federation is what makes EP an open standard rather than a single-vendor service
 **EP Federation Operator 2** is a second EP operator standing on its own infrastructure: a Supabase Edge Function (`conformance/operator2/index.ts`) on a different project and region, with its own Ed25519 key. It publishes exactly the three PIP-006 surfaces a relying party needs:
 
 - `GET …/.well-known/ep-keys.json` — Operator 2's published verification keys plus a `verify_url_template` (the discovery doc; `version: "1.1"`, `protocol_version: "EP-CORE-v1.0"`).
-- `GET …/receipt` — a real `EP-RECEIPT-v1` document Operator 2 signed (`conformance/operator2/operator2-receipt.json`): a `fin/payment-release` of $42,000, signed with Operator 2's key, carrying a `signature.key_discovery` URL that points back at Operator 2's own `ep-keys.json`.
+- `GET …/receipt` — a real `EP-RECEIPT-v1` document Operator 2 signed (`conformance/operator2/operator2-receipt.json`): a `fin/payment-release` of $42,000, signed with Operator 2's key, carrying a `signature.key_discovery` hint that points back at Operator 2's own `ep-keys.json`.
 - `GET …/api/verify/{receipt_id}` — Operator 2's verifier-of-record / revocation surface.
 
 The identity and the signed receipt are generated together by `gen-operator2.mjs` (the served public key and the served receipt's signature are produced in the same run, so they always match), and the canonicalization is byte-identical to `packages/verify/index.js`. There is no private key at runtime — the receipt is pre-signed and the edge function only static-serves.
@@ -25,7 +25,7 @@ The identity and the signed receipt are generated together by `gen-operator2.mjs
 `node conformance/operator2/verify-live.mjs` runs the relying-party path against Operator 2's live origin and asserts six things:
 
 1. It **fetched a receipt Operator 2 issued** from Operator 2's own `/receipt` endpoint.
-2. The **receipt verifies against Operator 2's published keys** — resolved live from the receipt's `key_discovery` URL on Operator 2's origin (`verifyFederatedReceipt`, `packages/verify/federation.js`).
+2. The **receipt verifies against Operator 2's published keys** — resolved live from Operator 2's pinned discovery origin (`verifyFederatedReceipt`, `packages/verify/federation.js`).
 3. The **signer is Operator 2** (`signature.signer` matches the verified signer).
 4. **Operator 2's revocation surface was consulted** — the discovery doc's `verify_url_template` is followed to Operator 2's `/api/verify/{receipt_id}`.
 5. The **verdict is `accepted`** — verified *and* not revoked.
@@ -35,7 +35,7 @@ This upgrades PIP-006 acceptance gate #1 from a self-hosted synthetic harness to
 
 ## What this demonstrates about PIP-006 mechanics
 
-- **Key discovery works against a foreign origin.** The relying party never had Operator 2's key in advance; it learned it from `ep-keys.json` at the `key_discovery` URL carried in the receipt.
+- **Key discovery works against a foreign origin.** The relying party pins Operator 2's discovery origin, fetches `ep-keys.json`, and treats the receipt's `key_discovery` field as a non-authoritative hint.
 - **`verify_url_template` works.** Revocation status is resolved by following the template from the discovery doc to the issuer's verifier-of-record.
 - **Offline and online both hold.** `verifyFederatedReceiptOffline` verifies with a supplied `ep-keys.json` and revocation set (air-gapped); `verifyFederatedReceipt` does the same over the network with an injectable `fetch`. Both reject tamper, wrong-operator, rotation, and revocation cases (`packages/verify/federation.test.js`, 14 cases). The path is also modeled and machine-checked in `formal/ep_federation.als` (seven safety assertions, no counterexample).
 

--- a/docs/deployment/AWS-DEPLOYMENT-GUIDE.md
+++ b/docs/deployment/AWS-DEPLOYMENT-GUIDE.md
@@ -146,7 +146,7 @@ Keys are auto-populated as entities register.
 ## Step 5: Run Conformance Test
 
 ```bash
-npx ep-conformance-test https://ep.your-org.com
+node conformance/ep-conformance-test.js https://ep.your-org.com
 
 # Expected output:
 # ✓ Discovery (/.well-known/ep-trust.json)

--- a/docs/guides/FIVE_MINUTE_QUICKSTART.md
+++ b/docs/guides/FIVE_MINUTE_QUICKSTART.md
@@ -7,17 +7,11 @@
 ## Step 1: Create your trust system (30 seconds)
 
 ```bash
-# Clone the protocol repo and run the scaffolder directly
-git clone https://github.com/emilia-protocol/emilia-protocol.git
-node emilia-protocol/create-ep-app/index.js my-trust-system
+npx @emilia-protocol/create-ep-app my-trust-system
 cd my-trust-system
 npm install
 npm run dev
 ```
-
-> Once the scoped creator is published, this becomes a one-liner:
-> `npx @emilia-protocol/create-app my-trust-system`
-> (The scaffolder in `create-ep-app/index.js` is identical either way.)
 
 Open http://localhost:3000. Click **Run Trust Demo**. Watch the full EP lifecycle execute in 60 seconds.
 
@@ -135,7 +129,7 @@ The handshake is consumed exactly once. Replay attacks are structurally impossib
 | Integrate via SDK | `npm install @emilia-protocol/sdk` (TypeScript) or `pip install emilia-protocol` (Python) |
 | Read the specification | [PROTOCOL-STANDARD.md](https://github.com/emilia-protocol/docs/PROTOCOL-STANDARD.md) |
 | Check compliance mappings | [NIST AI RMF](../compliance/NIST-AI-RMF-MAPPING.md) · [EU AI Act](../compliance/EU-AI-ACT-MAPPING.md) |
-| Run conformance tests | `npx ep-conformance-test https://your-ep-server.com` |
+| Run conformance tests | `node conformance/ep-conformance-test.js https://your-ep-server.com` |
 | Request a pilot | [emiliaprotocol.ai/partners](https://emiliaprotocol.ai/partners) |
 
 ---

--- a/docs/operations/NPM-PUBLISH-CHECKLIST.md
+++ b/docs/operations/NPM-PUBLISH-CHECKLIST.md
@@ -32,7 +32,7 @@ npm whoami
 # → emiliaprotocol
 
 # 3. Publish
-npm publish --access public
+npm publish --access public --provenance
 # → 2FA prompt: enter OTP from authenticator app
 # → "+ @emilia-protocol/verify@1.0.1"
 

--- a/examples/eve-receipt-required/lib/emilia-gate.mjs
+++ b/examples/eve-receipt-required/lib/emilia-gate.mjs
@@ -27,7 +27,7 @@
 //
 //   GENERATED — do not edit by hand. Regenerate with:
 //     npx @emilia-protocol/require-receipt   (or: node build-drop-in.mjs)
-//   source: @emilia-protocol/require-receipt@0.4.1  ·  content-sha256:ed1ce5337419db87
+//   source: @emilia-protocol/require-receipt@0.4.1  ·  content-sha256:dc952e178f03b850
 //   docs: https://www.emiliaprotocol.ai/gate   spec: draft-schrock-ep-authorization-receipts
 
 /**
@@ -56,6 +56,11 @@ export const RECEIPT_REQUIRED_HEADER = 'Receipt-Required';
 export const RECEIPT_PROOF_HEADER = 'X-EMILIA-Receipt';
 export const ACTION_RISK_MANIFEST_VERSION = 'EP-ACTION-RISK-MANIFEST-v0.1';
 export const DEFAULT_ACTION_RISK_MANIFEST = '/.well-known/agent-actions.json';
+export const ASSURANCE_TIERS = ['software', 'class_a', 'quorum'];
+export const ASSURANCE_PROOF_VERSION = 'EP-ASSURANCE-PROOF-v1';
+const ASSURANCE_RANK = { software: 0, class_a: 1, quorum: 2 };
+const FLAG_UP = 0x01;
+const FLAG_UV = 0x04;
 
 function canonicalize(v) {
   if (v === null || v === undefined) return JSON.stringify(v);
@@ -118,28 +123,137 @@ function isObject(v) {
   return v && typeof v === 'object' && !Array.isArray(v);
 }
 
-const MIDDLEWARE_ASSURANCE_RANK = { software: 0, class_a: 1, quorum: 2 };
-
-function receiptAssuranceTierForMiddleware(doc) {
-  const payload = doc?.payload || {};
-  const q = payload.quorum || payload.claim?.quorum;
-  const signers = q && (q.signers || q.approvers);
-  const threshold = Number(q && (q.m ?? q.threshold ?? (Array.isArray(signers) ? signers.length : 0)));
-  if (q && Array.isArray(signers) && Number.isFinite(threshold) && threshold >= 2) {
-    const distinct = new Set(signers.map((s) => String(s))).size;
-    if (distinct >= 2) return 'quorum';
-  }
-  if (payload.signoff || payload.claim?.outcome === 'allow_with_signoff') return 'class_a';
-  return 'software';
+function normalizeAssuranceClass(value) {
+  return ASSURANCE_TIERS.includes(value) ? value : 'software';
 }
 
-function middlewareAssuranceMeets(doc, required) {
-  const need = MIDDLEWARE_ASSURANCE_RANK[required] === undefined ? 'software' : required;
-  const have = receiptAssuranceTierForMiddleware(doc);
+function b64urlDecode(value) {
+  return Buffer.from(String(value || ''), 'base64url');
+}
+
+function sha256Bytes(value) {
+  return crypto.createHash('sha256').update(value).digest();
+}
+
+function sha256Hex(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function proofContext(doc) {
   return {
-    ok: (MIDDLEWARE_ASSURANCE_RANK[have] ?? 0) >= (MIDDLEWARE_ASSURANCE_RANK[need] ?? 0),
+    '@version': 'EP-ASSURANCE-CONTEXT-v1',
+    receipt_id: doc?.payload?.receipt_id || null,
+    claim_hash: `sha256:${sha256Hex(canonicalize(doc?.payload?.claim || {}))}`,
+  };
+}
+
+function verifyEd25519Digest(signature, digest, publicKeyB64u) {
+  try {
+    const pub = crypto.createPublicKey({ key: b64urlDecode(publicKeyB64u), format: 'der', type: 'spki' });
+    return crypto.verify(null, digest, pub, b64urlDecode(signature));
+  } catch {
+    return false;
+  }
+}
+
+function verifyWebAuthnDigest(webauthn, digest, publicKeyB64u) {
+  try {
+    if (!webauthn || typeof webauthn !== 'object') return false;
+    const authData = b64urlDecode(webauthn.authenticator_data);
+    const clientDataBytes = b64urlDecode(webauthn.client_data_json);
+    if (authData.length < 37) return false;
+    const flags = authData[32];
+    if ((flags & FLAG_UP) !== FLAG_UP || (flags & FLAG_UV) !== FLAG_UV) return false;
+    const clientData = JSON.parse(clientDataBytes.toString('utf8'));
+    if (clientData.type !== 'webauthn.get') return false;
+    if (clientData.challenge !== Buffer.from(digest).toString('base64url')) return false;
+    const signedData = Buffer.concat([authData, sha256Bytes(clientDataBytes)]);
+    const pub = crypto.createPublicKey({ key: b64urlDecode(publicKeyB64u), format: 'der', type: 'spki' });
+    return crypto.verify('sha256', signedData, pub, b64urlDecode(webauthn.signature));
+  } catch {
+    return false;
+  }
+}
+
+function normalizeApproverKeys(input) {
+  if (!input || typeof input !== 'object') return {};
+  return input;
+}
+
+function verifyPinnedAssuranceProof(doc, opts = {}) {
+  const proof = doc?.payload?.assurance_proof || doc?.assurance_proof;
+  if (!proof || typeof proof !== 'object') return { ok: false, tier: 'software', reason: 'assurance_proof_required' };
+  if (proof['@version'] !== ASSURANCE_PROOF_VERSION) {
+    return { ok: false, tier: 'software', reason: 'assurance_proof_bad_version' };
+  }
+  const approverKeys = normalizeApproverKeys(opts.approverKeys || opts.approver_keys);
+  const signoffs = Array.isArray(proof.signoffs) ? proof.signoffs : [];
+  if (!signoffs.length) return { ok: false, tier: 'software', reason: 'assurance_proof_missing_signoffs' };
+
+  const context = proofContext(doc);
+  const contextHash = `sha256:${sha256Hex(canonicalize(context))}`;
+  if (proof.context_hash && proof.context_hash !== contextHash) {
+    return { ok: false, tier: 'software', reason: 'assurance_context_mismatch' };
+  }
+  const digest = Buffer.from(contextHash.replace(/^sha256:/, ''), 'hex');
+  const valid = [];
+  for (const s of signoffs) {
+    const keyId = s?.approver_key_id;
+    const entry = keyId ? approverKeys[keyId] : null;
+    if (!entry?.public_key) continue;
+    const keyClass = s.key_class || entry.key_class || 'B';
+    const ok = keyClass === 'A'
+      ? verifyWebAuthnDigest(s.webauthn, digest, entry.public_key)
+      : verifyEd25519Digest(s.signature, digest, entry.public_key);
+    if (!ok) continue;
+    valid.push({ approver: String(s.approver || keyId), keyClass });
+  }
+  if (!valid.length) return { ok: false, tier: 'software', reason: 'assurance_proof_invalid' };
+  const distinctApprovers = new Set(valid.map((s) => s.approver));
+  const threshold = Number(proof.threshold ?? proof.m ?? 1);
+  if (Number.isFinite(threshold) && threshold >= 2 && distinctApprovers.size >= threshold && valid.length >= threshold) {
+    return { ok: true, tier: 'quorum', reason: 'assurance_proof_verified' };
+  }
+  if (valid.some((s) => s.keyClass === 'A')) {
+    return { ok: true, tier: 'class_a', reason: 'assurance_proof_verified' };
+  }
+  return { ok: true, tier: 'software', reason: 'assurance_proof_verified' };
+}
+
+function normalizeVerifierResult(result) {
+  if (typeof result === 'string') return { ok: true, tier: normalizeAssuranceClass(result), reason: 'custom_assurance_verifier' };
+  if (result && typeof result === 'object') {
+    return {
+      ok: result.ok !== false,
+      tier: normalizeAssuranceClass(result.tier || result.have || result.assuranceClass),
+      reason: result.reason || 'custom_assurance_verifier',
+    };
+  }
+  return { ok: false, tier: 'software', reason: 'custom_assurance_verifier_failed' };
+}
+
+export function receiptAssuranceTier(doc, opts = {}) {
+  const custom = typeof opts.verifyAssurance === 'function'
+    ? normalizeVerifierResult(opts.verifyAssurance(doc, { requiredTier: 'quorum' }))
+    : null;
+  if (custom?.ok) return custom.tier;
+  return verifyPinnedAssuranceProof(doc, opts).tier;
+}
+
+export function evaluateReceiptAssurance(doc, required, opts = {}) {
+  const need = normalizeAssuranceClass(required);
+  if (need === 'software') return { ok: true, have: 'software', need, reason: 'software_receipt' };
+  const custom = typeof opts.verifyAssurance === 'function'
+    ? normalizeVerifierResult(opts.verifyAssurance(doc, { requiredTier: need }))
+    : null;
+  const proof = custom || verifyPinnedAssuranceProof(doc, opts);
+  const have = normalizeAssuranceClass(proof.tier);
+  const rankOk = (ASSURANCE_RANK[have] ?? 0) >= (ASSURANCE_RANK[need] ?? 0);
+  return {
+    ok: proof.ok === true && rankOk,
     have,
     need,
+    reason: proof.ok === true && !rankOk ? 'assurance_too_low' : (proof.reason || (proof.ok ? 'assurance_ok' : 'assurance_proof_required')),
   };
 }
 
@@ -342,15 +456,15 @@ export function requireEmiliaReceipt(opts = {}) {
       return res.status(status).json({ ...receiptChallenge(action, `Receipt rejected: ${v.reason}.`, challengeOpts), rejected: v });
     }
     if (opts.assuranceClass || opts.assurance_class) {
-      const tier = middlewareAssuranceMeets(doc, opts.assuranceClass || opts.assurance_class);
+      const tier = evaluateReceiptAssurance(doc, opts.assuranceClass || opts.assurance_class, opts);
       if (!tier.ok) {
         res.setHeader(RECEIPT_REQUIRED_HEADER, receiptRequiredHeader(challengeOpts));
         if (status === LEGACY_RECEIPT_REQUIRED_STATUS) {
           res.setHeader('WWW-Authenticate', `EMILIA realm="agent-actions"${action ? `, action="${action}"` : ''}`);
         }
         return res.status(status).json({
-          ...receiptChallenge(action, 'Receipt rejected: assurance_too_low.', challengeOpts),
-          rejected: { ok: false, reason: 'assurance_too_low', have_tier: tier.have, need_tier: tier.need },
+          ...receiptChallenge(action, `Receipt rejected: ${tier.reason}.`, challengeOpts),
+          rejected: { ok: false, reason: tier.reason, have_tier: tier.have, need_tier: tier.need },
         });
       }
     }
@@ -465,31 +579,12 @@ function normalizeTarget(target) {
   return String(target);
 }
 
-export const ASSURANCE_TIERS = ['software', 'class_a', 'quorum'];
 const TIER_RANK = { software: 0, class_a: 1, quorum: 2 };
 
-function normalizeAssuranceClass(value) {
-  return ASSURANCE_TIERS.includes(value) ? value : 'software';
+function normalizeGateAssuranceClass(value) {
+  return Object.prototype.hasOwnProperty.call(TIER_RANK, value) ? value : 'software';
 }
 
-/**
- * Conservative tier earned by the receipt itself.
- * - software: a valid software-held receipt.
- * - class_a: a human signoff receipt (`allow_with_signoff` or explicit signoff).
- * - quorum: explicit quorum evidence with threshold >= 2 and >= 2 distinct humans.
- */
-export function receiptAssuranceTier(doc) {
-  const p = doc?.payload || {};
-  const q = p.quorum || p.claim?.quorum;
-  const signers = q && (q.signers || q.approvers);
-  const threshold = Number(q && (q.m ?? q.threshold ?? (Array.isArray(signers) ? signers.length : 0)));
-  if (q && Array.isArray(signers) && Number.isFinite(threshold) && threshold >= 2) {
-    const distinct = new Set(signers.map((s) => String(s))).size;
-    if (distinct >= 2) return 'quorum';
-  }
-  if (p.signoff || p.claim?.outcome === 'allow_with_signoff') return 'class_a';
-  return 'software';
-}
 
 /**
  * Build a hardened Receipt-Required gate for one action type.
@@ -522,6 +617,9 @@ export function makeReceiptGate(opts = {}) {
     manifestUrl,
     assuranceClass,
     quorum,
+    approverKeys,
+    approver_keys,
+    verifyAssurance,
     store = inMemoryStore(),
   } = opts;
 
@@ -536,7 +634,7 @@ export function makeReceiptGate(opts = {}) {
     return t === null ? base : `${base}:${t}`;
   };
 
-  const requiredTier = normalizeAssuranceClass(assuranceClass);
+  const requiredTier = normalizeGateAssuranceClass(assuranceClass);
   const challengeOpts = () => ({ statusCode, manifestUrl, assuranceClass: requiredTier, quorum, maxAgeSec });
 
   function refuse(boundAction, reason) {
@@ -567,9 +665,9 @@ export function makeReceiptGate(opts = {}) {
     const v = verifyEmiliaReceipt(receipt, { trustedKeys, allowInlineKey, action: boundAction, maxAgeSec, allowedOutcomes });
     if (!v.ok) return refuse(boundAction, v.reason); // sanitized: reason code only
 
-    const haveTier = receiptAssuranceTier(receipt);
-    if ((TIER_RANK[haveTier] ?? 0) < (TIER_RANK[requiredTier] ?? 0)) {
-      return refuse(boundAction, 'assurance_too_low');
+    const assurance = evaluateReceiptAssurance(receipt, requiredTier, { approverKeys, approver_keys, verifyAssurance });
+    if (!assurance.ok || (TIER_RANK[assurance.have] ?? 0) < (TIER_RANK[requiredTier] ?? 0)) {
+      return refuse(boundAction, assurance.reason || 'assurance_too_low');
     }
 
     if (store.has(v.receipt_id) || inflight.has(v.receipt_id)) return refuse(boundAction, 'replay_refused');

--- a/examples/mcp/_kit.mjs
+++ b/examples/mcp/_kit.mjs
@@ -67,6 +67,20 @@ export function signAction(action, { approver, outcome = 'allow_with_signoff', q
   return doc;
 }
 
+function demoMcpAssurance(doc) {
+  const claim = doc?.payload?.claim || {};
+  const q = claim.quorum || {};
+  const signers = Array.isArray(q.signers) ? q.signers : [];
+  const threshold = Number(q.threshold ?? q.m ?? 0);
+  if (threshold >= 2 && new Set(signers).size >= threshold) {
+    return { ok: true, tier: 'quorum', reason: 'demo_mcp_assurance_verified' };
+  }
+  if (claim.outcome === 'allow_with_signoff') {
+    return { ok: true, tier: 'class_a', reason: 'demo_mcp_assurance_verified' };
+  }
+  return { ok: true, tier: 'software', reason: 'demo_mcp_assurance_verified' };
+}
+
 // Per-tool identifying argument — the resource a dangerous tool actually acts on.
 // The receipt is bound to action_type PLUS this target id, so a receipt approving
 // (e.g.) "delete repo acme/billing-core" can't be replayed to delete a different
@@ -105,6 +119,7 @@ export function makeGuardedServer({ tool }) {
         manifestUrl: MANIFEST_URL,
         assuranceClass: req.assurance_class,
         quorum: req.quorum,
+        verifyAssurance: demoMcpAssurance,
       });
       gates.set(req.action_type, gate);
     }

--- a/infrastructure/aws/template.yaml
+++ b/infrastructure/aws/template.yaml
@@ -351,4 +351,4 @@ Outputs:
 
   ConformanceTestCommand:
     Description: Run this to verify conformance
-    Value: !Sub 'npx ep-conformance-test ${ApiGateway.ApiEndpoint}'
+    Value: !Sub 'node conformance/ep-conformance-test.js ${ApiGateway.ApiEndpoint}'

--- a/packages/gate/adapters/aws.test.js
+++ b/packages/gate/adapters/aws.test.js
@@ -18,7 +18,7 @@ function fakeAws() {
 }
 function setup(action) {
   const harness = createEg1Harness({ action });
-  return { harness, gate: createGate({ manifest: createAwsManifest(), trustedKeys: [harness.publicKey] }), aws: fakeAws() };
+  return { harness, gate: createGate({ manifest: createAwsManifest(), trustedKeys: [harness.publicKey], approverKeys: harness.approverKeys }), aws: fakeAws() };
 }
 
 test('exposes the high-blast-radius AWS ops', () => {

--- a/packages/gate/adapters/cloud.test.js
+++ b/packages/gate/adapters/cloud.test.js
@@ -10,7 +10,7 @@ import { createGcpManifest, guardGcpMutation, GCP_OPS } from './gcp.js';
 
 function gateFor(manifest, action) {
   const harness = createEg1Harness({ action });
-  return { harness, gate: createGate({ manifest, trustedKeys: [harness.publicKey] }) };
+  return { harness, gate: createGate({ manifest, trustedKeys: [harness.publicKey], approverKeys: harness.approverKeys }) };
 }
 const A = 'allow_with_signoff';
 const Q = { quorum: { signers: ['ep:a', 'ep:b'], threshold: 2 } };

--- a/packages/gate/adapters/github.test.js
+++ b/packages/gate/adapters/github.test.js
@@ -18,7 +18,7 @@ function fakeOctokit() {
 
 function setup(action) {
   const harness = createEg1Harness({ action });
-  const gate = createGate({ manifest: createGithubManifest(), trustedKeys: [harness.publicKey] });
+  const gate = createGate({ manifest: createGithubManifest(), trustedKeys: [harness.publicKey], approverKeys: harness.approverKeys });
   return { harness, gate, octokit: fakeOctokit() };
 }
 

--- a/packages/gate/adapters/saas.test.js
+++ b/packages/gate/adapters/saas.test.js
@@ -14,7 +14,7 @@ const A = 'allow_with_signoff';
 const Q = { quorum: { signers: ['ep:a', 'ep:b'], threshold: 2 } };
 function setup(manifest, action) {
   const harness = createEg1Harness({ action });
-  return { harness, gate: createGate({ manifest, trustedKeys: [harness.publicKey] }) };
+  return { harness, gate: createGate({ manifest, trustedKeys: [harness.publicKey], approverKeys: harness.approverKeys }) };
 }
 
 test('op inventories', () => {
@@ -66,7 +66,7 @@ test('linear: bulk delete binds the query hash', async () => {
   const action = { action_type: 'linear.issue.bulk_delete', team: 'ENG', query_hash: undefined };
   // mint with the same query the call uses so the hash matches.
   const harness = createEg1Harness({ action: { action_type: 'linear.issue.bulk_delete', team: 'ENG' } });
-  const gate = createGate({ manifest: createLinearManifest(), trustedKeys: [harness.publicKey] });
+  const gate = createGate({ manifest: createLinearManifest(), trustedKeys: [harness.publicKey], approverKeys: harness.approverKeys });
   const client = { bulkDeleteIssues: async () => ({ deleted: 9 }) };
   // The receipt must carry the query_hash; mint with extra fields matching observed.
   const { hashCanonical } = await import('./_kit.js');

--- a/packages/gate/adapters/stripe.test.js
+++ b/packages/gate/adapters/stripe.test.js
@@ -15,7 +15,7 @@ function fakeStripe() {
 }
 function setup(action) {
   const harness = createEg1Harness({ action });
-  return { harness, gate: createGate({ manifest: createStripeManifest(), trustedKeys: [harness.publicKey] }), stripe: fakeStripe() };
+  return { harness, gate: createGate({ manifest: createStripeManifest(), trustedKeys: [harness.publicKey], approverKeys: harness.approverKeys }), stripe: fakeStripe() };
 }
 const PAYOUT = { action_type: 'stripe.payout.create', amount: 40000, currency: 'usd', destination: 'acct_x' };
 

--- a/packages/gate/adapters/supabase.test.js
+++ b/packages/gate/adapters/supabase.test.js
@@ -17,7 +17,7 @@ function fakeDb() {
 }
 function setup(action) {
   const harness = createEg1Harness({ action });
-  return { harness, gate: createGate({ manifest: createSupabaseManifest(), trustedKeys: [harness.publicKey] }), db: fakeDb() };
+  return { harness, gate: createGate({ manifest: createSupabaseManifest(), trustedKeys: [harness.publicKey], approverKeys: harness.approverKeys }), db: fakeDb() };
 }
 
 const SQL = 'DELETE FROM payments WHERE id = 1';

--- a/packages/gate/custody.test.js
+++ b/packages/gate/custody.test.js
@@ -17,7 +17,7 @@ test('key registry: a revoked issuer key is refused (fail closed)', async () => 
   const h = createEg1Harness();
   const { DEFAULT_GATE_MANIFEST } = await import('./action-packs.js');
   const registry = createKeyRegistry([{ kid: 'issuer-1', key: h.publicKey }]);
-  const gate = createGate({ manifest: DEFAULT_GATE_MANIFEST, keyRegistry: registry });
+  const gate = createGate({ manifest: DEFAULT_GATE_MANIFEST, keyRegistry: registry, approverKeys: h.approverKeys });
 
   const ok = await gate.run({ selector: SEL, receipt: h.mint({ outcome: 'allow_with_signoff' }), observedAction: h.action }, async () => ({ ran: true }));
   assert.equal(ok.ok, true, 'valid key works before revocation');
@@ -34,7 +34,7 @@ test('key registry: a receipt signed by a not-yet-valid / expired key is refused
   // Key only valid in the far future.
   const future = Date.now() + 10 * 24 * 60 * 60 * 1000;
   const registry = createKeyRegistry([{ kid: 'k', key: h.publicKey, not_before: new Date(future).toISOString() }]);
-  const gate = createGate({ manifest: DEFAULT_GATE_MANIFEST, keyRegistry: registry });
+  const gate = createGate({ manifest: DEFAULT_GATE_MANIFEST, keyRegistry: registry, approverKeys: h.approverKeys });
   const out = await gate.run({ selector: SEL, receipt: h.mint({ outcome: 'allow_with_signoff' }), observedAction: h.action }, async () => ({ ran: true }));
   assert.equal(out.ok, false, 'a receipt issued before the key window is refused');
 });
@@ -49,8 +49,8 @@ test('key registry: rotation overlap — both keys valid in the window', async (
   ]);
   // Two gate instances share the same registry (two pods, same trust config,
   // independent consumption stores) — both issuer keys verify during overlap.
-  const gateA = createGate({ manifest: DEFAULT_GATE_MANIFEST, keyRegistry: registry });
-  const gateB = createGate({ manifest: DEFAULT_GATE_MANIFEST, keyRegistry: registry });
+  const gateA = createGate({ manifest: DEFAULT_GATE_MANIFEST, keyRegistry: registry, approverKeys: h.approverKeys });
+  const gateB = createGate({ manifest: DEFAULT_GATE_MANIFEST, keyRegistry: registry, approverKeys: other.approverKeys });
   const a = await gateA.run({ selector: SEL, receipt: h.mint({ outcome: 'allow_with_signoff' }), observedAction: h.action }, async () => 1);
   const b = await gateB.run({ selector: SEL, receipt: other.mint({ outcome: 'allow_with_signoff' }), observedAction: other.action }, async () => 2);
   assert.equal(a.ok, true);
@@ -64,7 +64,7 @@ test('key registry: rotation overlap — both keys valid in the window', async (
 test('flat trustedKeys still works (back-compat)', async () => {
   const h = createEg1Harness();
   const { DEFAULT_GATE_MANIFEST } = await import('./action-packs.js');
-  const gate = createGate({ manifest: DEFAULT_GATE_MANIFEST, trustedKeys: [h.publicKey] });
+  const gate = createGate({ manifest: DEFAULT_GATE_MANIFEST, trustedKeys: [h.publicKey], approverKeys: h.approverKeys });
   const out = await gate.run({ selector: SEL, receipt: h.mint({ outcome: 'allow_with_signoff' }), observedAction: h.action }, async () => ({ ran: true }));
   assert.equal(out.ok, true);
 });
@@ -75,8 +75,8 @@ test('durable store: a receipt consumed on one gate cannot be replayed on anothe
   const h = createEg1Harness();
   const { DEFAULT_GATE_MANIFEST } = await import('./action-packs.js');
   const backend = createMemoryBackend(); // a single SHARED backend == two pods sharing Redis
-  const gateA = createGate({ manifest: DEFAULT_GATE_MANIFEST, trustedKeys: [h.publicKey], store: createDurableConsumptionStore(backend) });
-  const gateB = createGate({ manifest: DEFAULT_GATE_MANIFEST, trustedKeys: [h.publicKey], store: createDurableConsumptionStore(backend) });
+  const gateA = createGate({ manifest: DEFAULT_GATE_MANIFEST, trustedKeys: [h.publicKey], approverKeys: h.approverKeys, store: createDurableConsumptionStore(backend) });
+  const gateB = createGate({ manifest: DEFAULT_GATE_MANIFEST, trustedKeys: [h.publicKey], approverKeys: h.approverKeys, store: createDurableConsumptionStore(backend) });
   const receipt = h.mint({ outcome: 'allow_with_signoff' });
 
   const a = await gateA.run({ selector: SEL, receipt, observedAction: h.action }, async () => ({ ran: true }));
@@ -134,7 +134,7 @@ test('retention: export manifest carries the evidence head + counts', () => {
 test('gate.retention() classifies the live evidence log', async () => {
   const h = createEg1Harness();
   const { DEFAULT_GATE_MANIFEST } = await import('./action-packs.js');
-  const gate = createGate({ manifest: DEFAULT_GATE_MANIFEST, trustedKeys: [h.publicKey] });
+  const gate = createGate({ manifest: DEFAULT_GATE_MANIFEST, trustedKeys: [h.publicKey], approverKeys: h.approverKeys });
   await gate.run({ selector: SEL, receipt: h.mint({ outcome: 'allow_with_signoff' }), observedAction: h.action }, async () => ({ ran: true }));
   const r = gate.retention();
   assert.ok(r.summary.total >= 1);

--- a/packages/gate/eg1-conformance.js
+++ b/packages/gate/eg1-conformance.js
@@ -40,6 +40,8 @@ const canon = (v) => (v == null ? JSON.stringify(v)
   : Array.isArray(v) ? `[${v.map(canon).join(',')}]`
     : typeof v === 'object' ? `{${Object.keys(v).sort().map((k) => JSON.stringify(k) + ':' + canon(v[k])).join(',')}}`
       : JSON.stringify(v));
+const sha256Hex = (v) => crypto.createHash('sha256').update(v, 'utf8').digest('hex');
+const sha256Bytes = (v) => crypto.createHash('sha256').update(v).digest();
 
 // The default high-risk action EG-1 exercises: a Class-A money movement, which
 // the default gate manifest guards (selector { protocol:'mcp', tool:'release_payment' }).
@@ -70,8 +72,70 @@ export const EG1_CHECKS = Object.freeze([
 export function createEg1Harness({ now = Date.now, action = EG1_DEFAULT_ACTION, idPrefix = 'eg1' } = {}) {
   const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
   const pub = publicKey.export({ type: 'spki', format: 'der' }).toString('base64url');
+  const approverA = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+  const approverB = crypto.generateKeyPairSync('ed25519');
+  const approverKeys = {
+    'ep:key:eg1:class-a': {
+      public_key: approverA.publicKey.export({ type: 'spki', format: 'der' }).toString('base64url'),
+      key_class: 'A',
+    },
+    'ep:key:eg1:controller': {
+      public_key: approverB.publicKey.export({ type: 'spki', format: 'der' }).toString('base64url'),
+      key_class: 'B',
+    },
+  };
   let counter = 0;
   const nowMs = () => (typeof now === 'function' ? now() : now);
+
+  function assuranceContext(payload) {
+    return {
+      '@version': 'EP-ASSURANCE-CONTEXT-v1',
+      receipt_id: payload.receipt_id,
+      claim_hash: `sha256:${sha256Hex(canon(payload.claim))}`,
+    };
+  }
+
+  function classASignoff(digest) {
+    const challenge = Buffer.from(digest).toString('base64url');
+    const clientDataJSON = Buffer.from(JSON.stringify({ type: 'webauthn.get', challenge, origin: 'https://www.emiliaprotocol.ai' }), 'utf8');
+    const rpIdHash = crypto.createHash('sha256').update('www.emiliaprotocol.ai').digest();
+    const authData = Buffer.concat([rpIdHash, Buffer.from([0x05]), Buffer.from([0, 0, 0, 0])]); // UP + UV
+    const signedData = Buffer.concat([authData, sha256Bytes(clientDataJSON)]);
+    return {
+      approver: 'ep:approver:eg1:cfo',
+      approver_key_id: 'ep:key:eg1:class-a',
+      key_class: 'A',
+      webauthn: {
+        authenticator_data: authData.toString('base64url'),
+        client_data_json: clientDataJSON.toString('base64url'),
+        signature: crypto.sign('sha256', signedData, approverA.privateKey).toString('base64url'),
+      },
+    };
+  }
+
+  function softwareSignoff(digest) {
+    return {
+      approver: 'ep:approver:eg1:controller',
+      approver_key_id: 'ep:key:eg1:controller',
+      key_class: 'B',
+      signature: crypto.sign(null, digest, approverB.privateKey).toString('base64url'),
+    };
+  }
+
+  function assuranceProof(payload, quorum) {
+    const context = assuranceContext(payload);
+    const contextHash = `sha256:${sha256Hex(canon(context))}`;
+    const digest = Buffer.from(contextHash.replace(/^sha256:/, ''), 'hex');
+    const threshold = Number(quorum?.threshold ?? quorum?.m ?? 1);
+    const signoffs = [classASignoff(digest)];
+    if (threshold >= 2) signoffs.push(softwareSignoff(digest));
+    return {
+      '@version': 'EP-ASSURANCE-PROOF-v1',
+      context_hash: contextHash,
+      threshold: threshold >= 2 ? threshold : 1,
+      signoffs,
+    };
+  }
 
   /**
    * Mint a scenario receipt.
@@ -94,13 +158,16 @@ export function createEg1Harness({ now = Date.now, action = EG1_DEFAULT_ACTION, 
         ...extra,
       },
     };
+    if (outcome === 'allow_with_signoff' || quorum) {
+      payload.assurance_proof = assuranceProof(payload, quorum);
+    }
     const value = crypto.sign(null, Buffer.from(canon(payload), 'utf8'), privateKey).toString('base64url');
     const receipt = { '@version': 'EP-RECEIPT-v1', payload, signature: { algorithm: 'Ed25519', value } };
     if (tamper) Object.assign(receipt.payload.claim, tamper); // tamper AFTER signing -> signature no longer binds
     return receipt;
   }
 
-  return { publicKey: pub, mint, action, now: nowMs };
+  return { publicKey: pub, approverKeys, mint, action, now: nowMs };
 }
 
 /**

--- a/packages/gate/gate.test.js
+++ b/packages/gate/gate.test.js
@@ -28,6 +28,22 @@ function receipt(privateKey, { action = 'payment.release', outcome = 'allow', ex
     created_at: new Date().toISOString(), claim: { action_type: action, outcome, ...extra },
   });
 }
+function fixtureAssurance(doc) {
+  const claim = doc?.payload?.claim || {};
+  const q = claim.quorum || doc?.payload?.quorum;
+  const signers = Array.isArray(q?.signers) ? q.signers : [];
+  const threshold = Number(q?.threshold ?? q?.m ?? 0);
+  if (threshold >= 2 && new Set(signers).size >= threshold) {
+    return { ok: true, tier: 'quorum', reason: 'fixture_assurance_verified' };
+  }
+  if (claim.outcome === 'allow_with_signoff' || doc?.payload?.signoff) {
+    return { ok: true, tier: 'class_a', reason: 'fixture_assurance_verified' };
+  }
+  return { ok: true, tier: 'software', reason: 'fixture_assurance_verified' };
+}
+function gateOpts(opts = {}) {
+  return { verifyAssurance: fixtureAssurance, ...opts };
+}
 
 const MANIFEST = {
   '@version': 'EP-ACTION-RISK-MANIFEST-v0.1',
@@ -40,7 +56,7 @@ const PAY = { protocol: 'mcp', tool: 'release_payment' };
 
 test('passes through non-guarded actions', async () => {
   const { pub } = makeKey();
-  const g = createGate({ manifest: MANIFEST, trustedKeys: [pub] });
+  const g = createGate(gateOpts({ manifest: MANIFEST, trustedKeys: [pub] }));
   const out = await g.check({ selector: { protocol: 'mcp', tool: 'read_balance' } });
   assert.equal(out.allow, true);
   assert.equal(out.reason, 'not_guarded');
@@ -48,7 +64,7 @@ test('passes through non-guarded actions', async () => {
 
 test('missing receipt -> 428 challenge', async () => {
   const { pub } = makeKey();
-  const g = createGate({ manifest: MANIFEST, trustedKeys: [pub] });
+  const g = createGate(gateOpts({ manifest: MANIFEST, trustedKeys: [pub] }));
   const out = await g.check({ selector: PAY });
   assert.equal(out.allow, false);
   assert.equal(out.status, 428);
@@ -58,7 +74,7 @@ test('missing receipt -> 428 challenge', async () => {
 
 test('valid class_a receipt -> allow; same receipt again -> replay refused', async () => {
   const { pub, privateKey } = makeKey();
-  const g = createGate({ manifest: MANIFEST, trustedKeys: [pub] });
+  const g = createGate(gateOpts({ manifest: MANIFEST, trustedKeys: [pub] }));
   const r = receipt(privateKey, { action: 'payment.release', outcome: 'allow_with_signoff' });
   const a = await g.check({ selector: PAY, receipt: r });
   assert.equal(a.allow, true, a.reason);
@@ -69,7 +85,7 @@ test('valid class_a receipt -> allow; same receipt again -> replay refused', asy
 
 test('tampered receipt -> rejected', async () => {
   const { pub, privateKey } = makeKey();
-  const g = createGate({ manifest: MANIFEST, trustedKeys: [pub] });
+  const g = createGate(gateOpts({ manifest: MANIFEST, trustedKeys: [pub] }));
   const r = receipt(privateKey, { action: 'payment.release', outcome: 'allow_with_signoff' });
   r.payload.claim.amount_usd = 999; // mutate a signed field
   const out = await g.check({ selector: PAY, receipt: r });
@@ -79,7 +95,7 @@ test('tampered receipt -> rejected', async () => {
 
 test('assurance too low (software receipt where class_a required) -> refused', async () => {
   const { pub, privateKey } = makeKey();
-  const g = createGate({ manifest: MANIFEST, trustedKeys: [pub] });
+  const g = createGate(gateOpts({ manifest: MANIFEST, trustedKeys: [pub] }));
   const r = receipt(privateKey, { action: 'payment.release', outcome: 'allow' }); // software tier
   const out = await g.check({ selector: PAY, receipt: r });
   assert.equal(out.allow, false);
@@ -89,7 +105,7 @@ test('assurance too low (software receipt where class_a required) -> refused', a
 test('untrusted issuer key -> refused', async () => {
   const { pub } = makeKey();
   const attacker = makeKey();
-  const g = createGate({ manifest: MANIFEST, trustedKeys: [pub] });
+  const g = createGate(gateOpts({ manifest: MANIFEST, trustedKeys: [pub] }));
   const r = receipt(attacker.privateKey, { action: 'payment.release', outcome: 'allow_with_signoff' });
   const out = await g.check({ selector: PAY, receipt: r });
   assert.equal(out.allow, false);
@@ -97,7 +113,7 @@ test('untrusted issuer key -> refused', async () => {
 
 test('wrong action_type -> refused', async () => {
   const { pub, privateKey } = makeKey();
-  const g = createGate({ manifest: MANIFEST, trustedKeys: [pub] });
+  const g = createGate(gateOpts({ manifest: MANIFEST, trustedKeys: [pub] }));
   const r = receipt(privateKey, { action: 'payment.refund', outcome: 'allow_with_signoff' });
   const out = await g.check({ selector: PAY, receipt: r });
   assert.equal(out.allow, false);
@@ -105,7 +121,7 @@ test('wrong action_type -> refused', async () => {
 
 test('guard() wrapper throws when refused, runs when allowed', async () => {
   const { pub, privateKey } = makeKey();
-  const g = createGate({ manifest: MANIFEST, trustedKeys: [pub] });
+  const g = createGate(gateOpts({ manifest: MANIFEST, trustedKeys: [pub] }));
   const release = g.guard(async (amt) => `sent ${amt}`, { selector: () => PAY, receipt: (amt, r) => r });
   await assert.rejects(() => release(100, null), /EMILIA Gate refused/);
   const r = receipt(privateKey, { action: 'payment.release', outcome: 'allow_with_signoff' });
@@ -114,7 +130,7 @@ test('guard() wrapper throws when refused, runs when allowed', async () => {
 
 test('evidence log is hash-chained and tamper-evident', async () => {
   const { pub, privateKey } = makeKey();
-  const g = createGate({ manifest: MANIFEST, trustedKeys: [pub] });
+  const g = createGate(gateOpts({ manifest: MANIFEST, trustedKeys: [pub] }));
   await g.check({ selector: PAY }); // a denial
   await g.check({ selector: PAY, receipt: receipt(privateKey, { action: 'payment.release', outcome: 'allow_with_signoff' }) }); // an allow
   assert.equal(g.evidence.verify().ok, true);
@@ -128,7 +144,7 @@ test('evidence log is hash-chained and tamper-evident', async () => {
 
 test('execution receipt binds to the authorization decision (full loop)', async () => {
   const { pub, privateKey } = makeKey();
-  const g = createGate({ manifest: MANIFEST, trustedKeys: [pub] });
+  const g = createGate(gateOpts({ manifest: MANIFEST, trustedKeys: [pub] }));
   const out = await g.check({ selector: PAY, receipt: receipt(privateKey, { action: 'payment.release', outcome: 'allow_with_signoff' }) });
   assert.equal(out.allow, true, out.reason);
   const exec = await g.recordExecution({ authorization: out, outcome: 'executed' });
@@ -140,7 +156,7 @@ test('execution receipt binds to the authorization decision (full loop)', async 
 
 test('guard() emits an execution receipt after a guarded run', async () => {
   const { pub, privateKey } = makeKey();
-  const g = createGate({ manifest: MANIFEST, trustedKeys: [pub] });
+  const g = createGate(gateOpts({ manifest: MANIFEST, trustedKeys: [pub] }));
   const release = g.guard(async (amt) => `sent ${amt}`, { selector: () => PAY, receipt: (amt, r) => r });
   const r = receipt(privateKey, { action: 'payment.release', outcome: 'allow_with_signoff' });
   assert.equal(await release(100, r), 'sent 100');
@@ -153,7 +169,7 @@ test('guard() emits an execution receipt after a guarded run', async () => {
 
 test('run() releases a reserved receipt when the side effect fails before mutation', async () => {
   const { pub, privateKey } = makeKey();
-  const g = createGate({ manifest: MANIFEST, trustedKeys: [pub] });
+  const g = createGate(gateOpts({ manifest: MANIFEST, trustedKeys: [pub] }));
   const r = receipt(privateKey, { action: 'payment.release', outcome: 'allow_with_signoff' });
   await assert.rejects(
     () => g.run({ selector: PAY, receipt: r }, async () => {
@@ -168,9 +184,10 @@ test('run() releases a reserved receipt when the side effect fails before mutati
 });
 
 test('receiptAssuranceTier classification', () => {
-  assert.equal(receiptAssuranceTier({ payload: { quorum: { m: 2, signers: ['a', 'b'] } } }), 'quorum');
-  assert.equal(receiptAssuranceTier({ payload: { claim: { outcome: 'allow_with_signoff' } } }), 'class_a');
+  assert.equal(receiptAssuranceTier({ payload: { quorum: { m: 2, signers: ['a', 'b'] } } }), 'software');
+  assert.equal(receiptAssuranceTier({ payload: { claim: { outcome: 'allow_with_signoff' } } }), 'software');
   assert.equal(receiptAssuranceTier({ payload: { claim: { outcome: 'allow' } } }), 'software');
+  assert.equal(receiptAssuranceTier({ payload: { claim: { outcome: 'allow_with_signoff' } } }, { verifyAssurance: fixtureAssurance }), 'class_a');
 });
 
 test('default product pack guards the seven high-risk action families', () => {
@@ -206,7 +223,7 @@ test('createTrustedActionFirewall uses default high-risk packs', async () => {
 
 test('execution binding refuses a mismatched system-of-record mutation without consuming the receipt', async () => {
   const { pub, privateKey } = makeKey();
-  const g = createTrustedActionFirewall({ trustedKeys: [pub] });
+  const g = createTrustedActionFirewall(gateOpts({ trustedKeys: [pub] }));
   const selector = { protocol: 'mcp', tool: 'release_payment' };
   const signedFields = {
     action_type: 'payment.release',
@@ -233,7 +250,7 @@ test('execution binding refuses a mismatched system-of-record mutation without c
 
 test('reliance packet ties allow decision, execution attestation, field binding, and evidence head', async () => {
   const { pub, privateKey } = makeKey();
-  const g = createTrustedActionFirewall({ trustedKeys: [pub] });
+  const g = createTrustedActionFirewall(gateOpts({ trustedKeys: [pub] }));
   const selector = { protocol: 'mcp', tool: 'release_payment' };
   const observedAction = {
     action_type: 'payment.release',

--- a/packages/gate/index.js
+++ b/packages/gate/index.js
@@ -27,6 +27,8 @@ const {
   receiptRequiredHeader,
   validateActionRiskManifest,
   findActionRequirement,
+  evaluateReceiptAssurance,
+  receiptAssuranceTier: receiptAssuranceTierFromProof,
   RECEIPT_REQUIRED_STATUS,
   RECEIPT_REQUIRED_HEADER,
 } = await import('@emilia-protocol/require-receipt').catch(() => import('../require-receipt/index.js'));
@@ -54,27 +56,11 @@ export const ASSURANCE_TIERS = ['software', 'class_a', 'quorum'];
 const TIER_RANK = { software: 0, class_a: 1, quorum: 2 };
 
 /**
- * The assurance tier a verified EP-RECEIPT-v1 issuer attests. Conservative /
- * fail-closed: if a higher tier's signed structure is not present, the receipt
- * only earns the lower tier, and a guard that needs more will refuse it.
- *
- * Trust boundary: this lightweight action gate verifies the pinned issuer's
- * Ed25519 signature over the receipt. It does not re-run a full EP §6.2
- * multi-signature trust-receipt verifier here; the tier is therefore an
- * issuer-attested fact. Use @emilia-protocol/verify verifyTrustReceipt for
- * independent proof of embedded signoff/quorum signatures.
- *   quorum   — a quorum block with >= 2 distinct signers and threshold >= 2.
- *   class_a  — a device signoff (or claim.outcome === 'allow_with_signoff').
- *   software — any otherwise-valid receipt (a software-held key).
+ * Return the proof-backed assurance tier. Without pinned approver keys or a
+ * caller-supplied verifier, higher tiers are not inferred from receipt fields.
  */
-export function receiptAssuranceTier(doc) {
-  const p = doc?.payload || {};
-  const q = p.quorum || p.claim?.quorum;
-  const signers = q && (q.signers || q.approvers);
-  const threshold = q && (q.m ?? q.threshold ?? (Array.isArray(signers) ? signers.length : 0));
-  if (q && Array.isArray(signers) && signers.length >= 2 && threshold >= 2) return 'quorum';
-  if (p.signoff || p.claim?.outcome === 'allow_with_signoff') return 'class_a';
-  return 'software';
+export function receiptAssuranceTier(doc, opts = {}) {
+  return receiptAssuranceTierFromProof(doc, opts);
 }
 
 /**
@@ -90,7 +76,7 @@ export function receiptAssuranceTier(doc) {
  *   if given it supersedes trustedKeys — a receipt is verified only against keys valid (and not
  *   revoked) at its issuance time.
  */
-export function createGate({ manifest = null, trustedKeys = [], maxAgeSec = 900, store, log, allowInlineKey = false, allowEphemeralStore = false, strictEvidence = true, now = Date.now, keyRegistry = null } = {}) {
+export function createGate({ manifest = null, trustedKeys = [], maxAgeSec = 900, store, log, allowInlineKey = false, allowEphemeralStore = false, strictEvidence = true, now = Date.now, keyRegistry = null, approverKeys = {}, approver_keys = null, verifyAssurance = null } = {}) {
   // Production key custody: a registry (rotation + revocation) supersedes a flat
   // trustedKeys list. A flat list is coerced to an always-valid registry, so
   // existing callers are unchanged.
@@ -186,17 +172,28 @@ export function createGate({ manifest = null, trustedKeys = [], maxAgeSec = 900,
     if (!v.ok) {
       return decide(false, RECEIPT_REQUIRED_STATUS, `receipt_rejected:${v.reason}`, { rejected: v });
     }
-    // Assurance tier.
-    const have = receiptAssuranceTier(receipt);
-    if ((TIER_RANK[have] ?? 0) < (TIER_RANK[requiredTier] ?? 0)) {
-      return decide(false, RECEIPT_REQUIRED_STATUS, 'assurance_too_low', { have_tier: have, need_tier: requiredTier, assurance_tier_source: 'issuer_attestation' });
+    // Assurance tier: proof-backed only. A receipt's issuer may describe a human
+    // signoff, but high-tier enforcement requires pinned approver proof or an
+    // explicit verifier hook. Self-asserted `allow_with_signoff` / `quorum`
+    // fields are software-tier until proven.
+    const assurance = evaluateReceiptAssurance(receipt, requiredTier, {
+      approverKeys: approver_keys || approverKeys,
+      verifyAssurance,
+    });
+    const have = assurance.have;
+    if (!assurance.ok || (TIER_RANK[have] ?? 0) < (TIER_RANK[requiredTier] ?? 0)) {
+      return decide(false, RECEIPT_REQUIRED_STATUS, assurance.reason || 'assurance_too_low', {
+        have_tier: have,
+        need_tier: requiredTier,
+        assurance_tier_source: 'proof',
+      });
     }
     // The high-risk action packs define material fields that must be observed
     // by the executor from the system of record. A signed, harmless-looking
     // claim cannot authorize a different real mutation.
     const executionBinding = verifyExecutionBinding({ requirement, receipt, observedAction: observed });
     if (!executionBinding.ok) {
-      return decide(false, RECEIPT_REQUIRED_STATUS, 'execution_binding_failed', { execution_binding: executionBinding, have_tier: have, assurance_tier_source: 'issuer_attestation' });
+      return decide(false, RECEIPT_REQUIRED_STATUS, 'execution_binding_failed', { execution_binding: executionBinding, have_tier: have, assurance_tier_source: 'proof' });
     }
     // One-time consumption (replay defense). Require a stable, issuer-generated
     // receipt_id — never fall back to a content hash, whose canonicalization can
@@ -220,7 +217,7 @@ export function createGate({ manifest = null, trustedKeys = [], maxAgeSec = 900,
     if (!fresh) {
       return decide(false, RECEIPT_REQUIRED_STATUS, 'replay_refused', { consumption_key: receiptId });
     }
-    return decide(true, 200, 'allow', { signer: v.signer, outcome: v.outcome, have_tier: have, assurance_tier_source: 'issuer_attestation', execution_binding: executionBinding, consumption_mode: consumptionMode });
+    return decide(true, 200, 'allow', { signer: v.signer, outcome: v.outcome, have_tier: have, assurance_tier_source: 'proof', execution_binding: executionBinding, consumption_mode: consumptionMode });
   }
 
   /** Express/Connect middleware: refuse the route unless a sufficient receipt is present. */
@@ -384,7 +381,7 @@ export async function gateConformance({ gate, harness, action, selector = EG1_DE
  */
 export async function gateConformanceSelfTest({ now } = {}) {
   const harness = createEg1Harness({ now });
-  const gate = createTrustedActionFirewall({ trustedKeys: [harness.publicKey], now });
+  const gate = createTrustedActionFirewall({ trustedKeys: [harness.publicKey], approverKeys: harness.approverKeys, now });
   return gateConformance({ gate, harness });
 }
 

--- a/packages/gate/mcp.test.js
+++ b/packages/gate/mcp.test.js
@@ -6,7 +6,7 @@ import { gateMcpTool, gateMcpTools } from './mcp.js';
 
 function setup() {
   const harness = createEg1Harness();
-  const gate = createTrustedActionFirewall({ trustedKeys: [harness.publicKey] });
+  const gate = createTrustedActionFirewall({ trustedKeys: [harness.publicKey], approverKeys: harness.approverKeys });
   return { harness, gate, action: harness.action };
 }
 

--- a/packages/go-verify/trust_receipt.go
+++ b/packages/go-verify/trust_receipt.go
@@ -83,6 +83,32 @@ func verifyClassAOverDigestGo(wa map[string]any, digest []byte, pubB64u string) 
 	return ecdsa.VerifyASN1(pub, h[:], sig)
 }
 
+func trustReceiptCanonicalProfileOK(receipt map[string]any) bool {
+	leaf := map[string]any{}
+	for k, v := range receipt {
+		if k != "log_proof" && k != "approver_key_proofs" {
+			leaf[k] = v
+		}
+	}
+	if !IsCanonicalizable(leaf) {
+		return false
+	}
+	if lp := getMap(receipt["log_proof"]); lp != nil {
+		if cp := getMap(lp["checkpoint"]); cp != nil {
+			signedCP := map[string]any{}
+			for k, v := range cp {
+				if k != "log_signature" {
+					signedCP[k] = v
+				}
+			}
+			if !IsCanonicalizable(signedCP) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // VerifyTrustReceipt verifies an EP §6.2 Trust Receipt offline. opts keys:
 // approverKeys (map of approver_key_id -> {public_key,key_class,valid_from,valid_to}),
 // logPublicKey (string).
@@ -102,6 +128,9 @@ func VerifyTrustReceipt(receipt map[string]any, opts map[string]any) TrustReceip
 		return TrustReceiptResult{false, checks}
 	}
 	if len(contexts) == 0 || len(signoffs) == 0 {
+		return TrustReceiptResult{false, checks}
+	}
+	if !trustReceiptCanonicalProfileOK(receipt) {
 		return TrustReceiptResult{false, checks}
 	}
 
@@ -218,7 +247,18 @@ func VerifyTrustReceipt(receipt map[string]any, opts map[string]any) TrustReceip
 					leaf[k] = v
 				}
 			}
-			checks["inclusion"] = VerifyMerkleAnchor(sha256HexOf(leaf), ipath, hexStrip(cp["root_hash"]))
+			merkleAlg := getStr(lp, "alg")
+			if merkleAlg == "" {
+				merkleAlg = getStr(cp, "merkle_alg")
+			}
+			if merkleAlg == MerkleV2Alg {
+				leafHash := leafHashV2(Canonicalize(leaf))
+				checks["inclusion"] = hexStrip(lp["leaf_hash"]) == leafHash && verifyMerkleAnchorMode(leafHash, ipath, hexStrip(cp["root_hash"]), true)
+			} else if opts != nil && (opts["allowLegacyMerkle"] == true || opts["allowLegacyTrustReceiptMerkle"] == true) {
+				checks["inclusion"] = VerifyMerkleAnchor(sha256HexOf(leaf), ipath, hexStrip(cp["root_hash"]))
+			} else {
+				checks["inclusion"] = false
+			}
 			logSig := getStr(cp, "log_signature")
 			if logPublicKey != "" && logSig != "" {
 				signedCP := map[string]any{}

--- a/packages/issue/index.d.ts
+++ b/packages/issue/index.d.ts
@@ -152,6 +152,7 @@ export interface LogConfig {
 }
 
 export function canonicalize(value: unknown): string;
+export function isCanonicalizable(value: unknown): boolean;
 export function actionHash(action: ActionObject): string;
 export function policyHash(policy: Record<string, unknown>): string;
 

--- a/packages/issue/index.js
+++ b/packages/issue/index.js
@@ -47,6 +47,20 @@ export function canonicalize(value) {
   return JSON.stringify(value);
 }
 
+export function isCanonicalizable(value) {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return true;
+  if (typeof value === 'number') return Number.isInteger(value) && Number.isSafeInteger(value);
+  if (Array.isArray(value)) return value.every(isCanonicalizable);
+  if (typeof value === 'object') return Object.values(value).every(isCanonicalizable);
+  return false;
+}
+
+function assertCanonicalizable(value, label) {
+  if (!isCanonicalizable(value)) {
+    throw new Error(`${label} is outside the EP canonicalization profile; encode non-integer quantities as strings`);
+  }
+}
+
 const sha256hex = (s) => crypto.createHash('sha256').update(s, 'utf8').digest('hex');
 const sha256Bytes = (s) => crypto.createHash('sha256').update(s, 'utf8').digest();
 const hashPair = (a, b) => { const s = [a, b].sort(); return sha256hex(s[0] + s[1]); };
@@ -521,6 +535,7 @@ export function merkleProofV2(leaves, leafIndex) {
  * @returns {{alg:'EP-MERKLE-v2', leaf_hash:string, merkle_proof:Array, merkle_root:string}}
  */
 export function buildReceiptAnchorV2(payload, priorLeaves = []) {
+  assertCanonicalizable(payload, 'buildReceiptAnchorV2 payload');
   const leaf = leafHashV2(canonicalize(payload));
   const leaves = [...priorLeaves, leaf];
   const { root, path } = merkleProofV2(leaves, leaves.length - 1);
@@ -548,6 +563,7 @@ export function assembleAuthorizationReceipt({ receiptId, action, contexts, sign
   if (!logPrivateKey || !log?.logKeyId) {
     throw new Error('assembleAuthorizationReceipt requires log.privateKey (or log.privateKeyB64u) and log.logKeyId');
   }
+  assertCanonicalizable({ action, contexts, signoffs }, 'Trust Receipt signed material');
 
   const receipt = {
     receipt_id: receiptId,
@@ -562,20 +578,25 @@ export function assembleAuthorizationReceipt({ receiptId, action, contexts, sign
     },
   };
 
-  // Leaf = canonical receipt WITHOUT log_proof / approver_key_proofs.
-  const leaf = sha256hex(canonicalize(receipt));
+  // Leaf = EP-MERKLE-v2(canonical receipt WITHOUT log_proof /
+  // approver_key_proofs). Keep Trust Receipt log leaves on the same
+  // domain-separated, positional tree as single-receipt anchors.
+  const leaf = leafHashV2(canonicalize(receipt));
   const leaves = [...(log.priorLeaves || []), leaf];
   const leafIndex = leaves.length - 1;
-  const { root, path } = merkleProof(leaves, leafIndex);
+  const { root, path } = merkleProofV2(leaves, leafIndex);
 
   const checkpoint = {
     tree_size: leaves.length,
     root_hash: `sha256:${root}`,
     log_key_id: log.logKeyId,
+    merkle_alg: 'EP-MERKLE-v2',
   };
   const log_signature = crypto.sign(null, sha256Bytes(canonicalize(checkpoint)), logPrivateKey).toString('base64url');
 
   receipt.log_proof = {
+    alg: 'EP-MERKLE-v2',
+    leaf_hash: `sha256:${leaf}`,
     leaf_index: leafIndex,
     inclusion_path: path,
     checkpoint: { ...checkpoint, log_signature },

--- a/packages/issue/test.js
+++ b/packages/issue/test.js
@@ -463,3 +463,26 @@ test('buildReceiptAnchorV2: a v2-anchored document verifies under verifyReceipt 
   lifted.signature = { algorithm: 'Ed25519', value: sign(lifted.payload) };
   assert.equal(verifyReceipt(lifted, pub).checks.anchor, false, 'anchor must not bind to a different payload');
 });
+
+test('issuer refuses non-I-JSON signed material before minting Trust Receipts or anchors', async () => {
+  const a = classBSigner('ep:key:k1', new Date().toISOString());
+  const badAction = { ...action, parameters: { amount: 2400000.25, currency: 'USD' } };
+  const contexts = buildContexts({
+    action: badAction,
+    policyHash: 'sha256:aa',
+    approvers: ['ep:approver:cfo'],
+    requiredApprovals: 1,
+    issuedAt: '2026-06-09T17:21:05Z',
+    expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+  });
+  const signoffs = await collectSignoffs(contexts, [a.signer]);
+  assert.throws(() => assembleAuthorizationReceipt({
+    receiptId: 'ep:receipt:bad-float',
+    action: badAction,
+    contexts,
+    signoffs,
+    committedAt: new Date().toISOString(),
+    log,
+  }), /canonicalization profile/);
+  assert.throws(() => buildReceiptAnchorV2({ amount: 1.25 }), /canonicalization profile/);
+});

--- a/packages/mcp-guard/index.js
+++ b/packages/mcp-guard/index.js
@@ -41,6 +41,7 @@ import crypto from 'node:crypto';
 const {
   verifyEmiliaReceipt,
   receiptChallenge,
+  evaluateReceiptAssurance,
 } = await import('@emilia-protocol/require-receipt').catch(() => import('../require-receipt/index.js'));
 
 // ---------------------------------------------------------------------------
@@ -80,29 +81,6 @@ export const GUARD_DECISIONS = Object.freeze({
   ALLOW_WITH_SIGNOFF: 'allow_with_signoff',
   DENY: 'deny',
 });
-
-const ASSURANCE_RANK = { software: 0, class_a: 1, quorum: 2 };
-
-function normalizeAssurance(value) {
-  return Object.prototype.hasOwnProperty.call(ASSURANCE_RANK, value) ? value : 'software';
-}
-
-function receiptAssuranceTier(doc) {
-  const payload = doc?.payload || {};
-  const q = payload.quorum || payload.claim?.quorum;
-  const signers = q && (q.signers || q.approvers);
-  const threshold = Number(q && (q.m ?? q.threshold ?? (Array.isArray(signers) ? signers.length : 0)));
-  if (q && Array.isArray(signers) && Number.isFinite(threshold) && threshold >= 2) {
-    const distinct = new Set(signers.map((s) => String(s))).size;
-    if (distinct >= 2) return 'quorum';
-  }
-  if (payload.signoff || payload.claim?.outcome === GUARD_DECISIONS.ALLOW_WITH_SIGNOFF) return 'class_a';
-  return 'software';
-}
-
-function assuranceMeets(have, need) {
-  return (ASSURANCE_RANK[normalizeAssurance(have)] ?? 0) >= (ASSURANCE_RANK[normalizeAssurance(need)] ?? 0);
-}
 
 // ---------------------------------------------------------------------------
 // Irreversibility classification
@@ -246,12 +224,12 @@ export function demandReceipt({ action, args = {}, meta = {}, verifyOpts = {} })
     };
   }
   const requiredTier = verifyOpts.assuranceClass || verifyOpts.assurance_class || 'software';
-  const haveTier = receiptAssuranceTier(doc);
-  if (!assuranceMeets(haveTier, requiredTier)) {
+  const assurance = evaluateReceiptAssurance(doc, requiredTier, verifyOpts);
+  if (!assurance.ok) {
     return {
       ok: false,
-      refusal: refusal(action, 'Receipt rejected: assurance_too_low.', {
-        rejected: { ok: false, reason: 'assurance_too_low', have_tier: haveTier, need_tier: requiredTier },
+      refusal: refusal(action, `Receipt rejected: ${assurance.reason}.`, {
+        rejected: { ok: false, reason: assurance.reason, have_tier: assurance.have, need_tier: assurance.need },
       }),
     };
   }
@@ -499,11 +477,16 @@ export function withMcpGuard(handler, options = {}) {
         rejected: selfCheck,
       });
     }
-    const issuedTier = receiptAssuranceTier(doc);
-    if (!assuranceMeets(issuedTier, requiredTier)) {
-      return refusal(action, 'Issued receipt failed assurance check: assurance_too_low.', {
+    const issuedAssurance = evaluateReceiptAssurance(doc, requiredTier, verifyOpts);
+    if (!issuedAssurance.ok) {
+      return refusal(action, `Issued receipt failed assurance check: ${issuedAssurance.reason}.`, {
         stage: 'issue',
-        rejected: { ok: false, reason: 'assurance_too_low', have_tier: issuedTier, need_tier: requiredTier },
+        rejected: {
+          ok: false,
+          reason: issuedAssurance.reason,
+          have_tier: issuedAssurance.have,
+          need_tier: issuedAssurance.need,
+        },
       });
     }
 

--- a/packages/python-verify/emilia_verify/__init__.py
+++ b/packages/python-verify/emilia_verify/__init__.py
@@ -598,6 +598,19 @@ def _verify_ed25519_over_digest(sig_b64u: Any, digest_bytes: bytes, pub_spki_b64
         return False
 
 
+def _trust_receipt_canonical_profile_error(receipt: dict) -> Optional[str]:
+    leaf_content = {k: v for k, v in receipt.items() if k not in ("log_proof", "approver_key_proofs")}
+    if not is_canonicalizable(leaf_content):
+        return "Trust Receipt body"
+    log_proof = receipt.get("log_proof")
+    checkpoint = log_proof.get("checkpoint") if isinstance(log_proof, dict) else None
+    if isinstance(checkpoint, dict):
+        signed_cp = {k: v for k, v in checkpoint.items() if k != "log_signature"}
+        if not is_canonicalizable(signed_cp):
+            return "Trust Receipt checkpoint"
+    return None
+
+
 def verify_trust_receipt(receipt: Any, opts: Optional[dict] = None) -> dict:
     """Offline EP §6.2 Trust Receipt verifier (I-D §6.3). Mirrors packages/verify
     verifyTrustReceipt; the PIP-007 attestation report is advisory and omitted
@@ -621,6 +634,9 @@ def verify_trust_receipt(receipt: Any, opts: Optional[dict] = None) -> dict:
         return fail("Missing action or action_hash")
     if not contexts or not signoffs:
         return fail("Missing contexts or signoffs")
+    profile_error = _trust_receipt_canonical_profile_error(receipt)
+    if profile_error:
+        return fail(f"{profile_error} is outside the EP canonicalization profile; encode non-integer quantities as strings")
 
     action_hash_hex = _sha256_hex(canonicalize(receipt["action"]))
     checks["action_hash"] = action_hash_hex == _hex_of(receipt.get("action_hash"))
@@ -683,8 +699,17 @@ def verify_trust_receipt(receipt: Any, opts: Optional[dict] = None) -> dict:
     lp = receipt.get("log_proof")
     if lp and lp.get("checkpoint") and isinstance(lp.get("inclusion_path"), list):
         leaf_content = {k: v for k, v in receipt.items() if k not in ("log_proof", "approver_key_proofs")}
-        leaf_hash = _sha256_hex(canonicalize(leaf_content))
-        checks["inclusion"] = verify_merkle_anchor(leaf_hash, lp["inclusion_path"], _hex_of(lp["checkpoint"].get("root_hash")))
+        merkle_alg = lp.get("alg") or (lp.get("checkpoint") or {}).get("merkle_alg")
+        if merkle_alg == MERKLE_V2_ALG:
+            leaf_hash = _leaf_hash_v2(canonicalize(leaf_content))
+            presented_leaf = _hex_of(lp.get("leaf_hash")) if lp.get("leaf_hash") else ""
+            checks["inclusion"] = (presented_leaf == leaf_hash) and verify_merkle_anchor(
+                leaf_hash, lp["inclusion_path"], _hex_of(lp["checkpoint"].get("root_hash")), v2=True)
+        elif opts.get("allowLegacyMerkle") is True or opts.get("allow_legacy_merkle") is True or opts.get("allowLegacyTrustReceiptMerkle") is True:
+            leaf_hash = _sha256_hex(canonicalize(leaf_content))
+            checks["inclusion"] = verify_merkle_anchor(leaf_hash, lp["inclusion_path"], _hex_of(lp["checkpoint"].get("root_hash")))
+        else:
+            checks["inclusion"] = False
         if log_public_key and lp["checkpoint"].get("log_signature"):
             signed_cp = {k: v for k, v in lp["checkpoint"].items() if k != "log_signature"}
             checks["checkpoint_signature"] = _verify_ed25519_over_digest(

--- a/packages/require-receipt/build-drop-in.mjs
+++ b/packages/require-receipt/build-drop-in.mjs
@@ -42,6 +42,7 @@ index = index.replace(gateReExport, '\n');
 const gateImport = /import \{[\s\S]*?\} from '\.\/index\.js';\n/;
 if (!gateImport.test(gate)) throw new Error('build-drop-in: gate.js import block not found — source changed; update the generator.');
 gate = gate.replace(gateImport, '').trimStart();
+gate = gate.replace(/\nexport \{ receiptAssuranceTier \};\n/, '\n');
 
 const body = `${index.trimEnd()}\n\n// ── inlined from gate.js ───────────────────────────────────────────────────\n\n${gate.trimEnd()}\n`;
 

--- a/packages/require-receipt/dist/emilia-gate.mjs
+++ b/packages/require-receipt/dist/emilia-gate.mjs
@@ -27,7 +27,7 @@
 //
 //   GENERATED — do not edit by hand. Regenerate with:
 //     npx @emilia-protocol/require-receipt   (or: node build-drop-in.mjs)
-//   source: @emilia-protocol/require-receipt@0.4.1  ·  content-sha256:ed1ce5337419db87
+//   source: @emilia-protocol/require-receipt@0.4.1  ·  content-sha256:dc952e178f03b850
 //   docs: https://www.emiliaprotocol.ai/gate   spec: draft-schrock-ep-authorization-receipts
 
 /**
@@ -56,6 +56,11 @@ export const RECEIPT_REQUIRED_HEADER = 'Receipt-Required';
 export const RECEIPT_PROOF_HEADER = 'X-EMILIA-Receipt';
 export const ACTION_RISK_MANIFEST_VERSION = 'EP-ACTION-RISK-MANIFEST-v0.1';
 export const DEFAULT_ACTION_RISK_MANIFEST = '/.well-known/agent-actions.json';
+export const ASSURANCE_TIERS = ['software', 'class_a', 'quorum'];
+export const ASSURANCE_PROOF_VERSION = 'EP-ASSURANCE-PROOF-v1';
+const ASSURANCE_RANK = { software: 0, class_a: 1, quorum: 2 };
+const FLAG_UP = 0x01;
+const FLAG_UV = 0x04;
 
 function canonicalize(v) {
   if (v === null || v === undefined) return JSON.stringify(v);
@@ -118,28 +123,137 @@ function isObject(v) {
   return v && typeof v === 'object' && !Array.isArray(v);
 }
 
-const MIDDLEWARE_ASSURANCE_RANK = { software: 0, class_a: 1, quorum: 2 };
-
-function receiptAssuranceTierForMiddleware(doc) {
-  const payload = doc?.payload || {};
-  const q = payload.quorum || payload.claim?.quorum;
-  const signers = q && (q.signers || q.approvers);
-  const threshold = Number(q && (q.m ?? q.threshold ?? (Array.isArray(signers) ? signers.length : 0)));
-  if (q && Array.isArray(signers) && Number.isFinite(threshold) && threshold >= 2) {
-    const distinct = new Set(signers.map((s) => String(s))).size;
-    if (distinct >= 2) return 'quorum';
-  }
-  if (payload.signoff || payload.claim?.outcome === 'allow_with_signoff') return 'class_a';
-  return 'software';
+function normalizeAssuranceClass(value) {
+  return ASSURANCE_TIERS.includes(value) ? value : 'software';
 }
 
-function middlewareAssuranceMeets(doc, required) {
-  const need = MIDDLEWARE_ASSURANCE_RANK[required] === undefined ? 'software' : required;
-  const have = receiptAssuranceTierForMiddleware(doc);
+function b64urlDecode(value) {
+  return Buffer.from(String(value || ''), 'base64url');
+}
+
+function sha256Bytes(value) {
+  return crypto.createHash('sha256').update(value).digest();
+}
+
+function sha256Hex(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function proofContext(doc) {
   return {
-    ok: (MIDDLEWARE_ASSURANCE_RANK[have] ?? 0) >= (MIDDLEWARE_ASSURANCE_RANK[need] ?? 0),
+    '@version': 'EP-ASSURANCE-CONTEXT-v1',
+    receipt_id: doc?.payload?.receipt_id || null,
+    claim_hash: `sha256:${sha256Hex(canonicalize(doc?.payload?.claim || {}))}`,
+  };
+}
+
+function verifyEd25519Digest(signature, digest, publicKeyB64u) {
+  try {
+    const pub = crypto.createPublicKey({ key: b64urlDecode(publicKeyB64u), format: 'der', type: 'spki' });
+    return crypto.verify(null, digest, pub, b64urlDecode(signature));
+  } catch {
+    return false;
+  }
+}
+
+function verifyWebAuthnDigest(webauthn, digest, publicKeyB64u) {
+  try {
+    if (!webauthn || typeof webauthn !== 'object') return false;
+    const authData = b64urlDecode(webauthn.authenticator_data);
+    const clientDataBytes = b64urlDecode(webauthn.client_data_json);
+    if (authData.length < 37) return false;
+    const flags = authData[32];
+    if ((flags & FLAG_UP) !== FLAG_UP || (flags & FLAG_UV) !== FLAG_UV) return false;
+    const clientData = JSON.parse(clientDataBytes.toString('utf8'));
+    if (clientData.type !== 'webauthn.get') return false;
+    if (clientData.challenge !== Buffer.from(digest).toString('base64url')) return false;
+    const signedData = Buffer.concat([authData, sha256Bytes(clientDataBytes)]);
+    const pub = crypto.createPublicKey({ key: b64urlDecode(publicKeyB64u), format: 'der', type: 'spki' });
+    return crypto.verify('sha256', signedData, pub, b64urlDecode(webauthn.signature));
+  } catch {
+    return false;
+  }
+}
+
+function normalizeApproverKeys(input) {
+  if (!input || typeof input !== 'object') return {};
+  return input;
+}
+
+function verifyPinnedAssuranceProof(doc, opts = {}) {
+  const proof = doc?.payload?.assurance_proof || doc?.assurance_proof;
+  if (!proof || typeof proof !== 'object') return { ok: false, tier: 'software', reason: 'assurance_proof_required' };
+  if (proof['@version'] !== ASSURANCE_PROOF_VERSION) {
+    return { ok: false, tier: 'software', reason: 'assurance_proof_bad_version' };
+  }
+  const approverKeys = normalizeApproverKeys(opts.approverKeys || opts.approver_keys);
+  const signoffs = Array.isArray(proof.signoffs) ? proof.signoffs : [];
+  if (!signoffs.length) return { ok: false, tier: 'software', reason: 'assurance_proof_missing_signoffs' };
+
+  const context = proofContext(doc);
+  const contextHash = `sha256:${sha256Hex(canonicalize(context))}`;
+  if (proof.context_hash && proof.context_hash !== contextHash) {
+    return { ok: false, tier: 'software', reason: 'assurance_context_mismatch' };
+  }
+  const digest = Buffer.from(contextHash.replace(/^sha256:/, ''), 'hex');
+  const valid = [];
+  for (const s of signoffs) {
+    const keyId = s?.approver_key_id;
+    const entry = keyId ? approverKeys[keyId] : null;
+    if (!entry?.public_key) continue;
+    const keyClass = s.key_class || entry.key_class || 'B';
+    const ok = keyClass === 'A'
+      ? verifyWebAuthnDigest(s.webauthn, digest, entry.public_key)
+      : verifyEd25519Digest(s.signature, digest, entry.public_key);
+    if (!ok) continue;
+    valid.push({ approver: String(s.approver || keyId), keyClass });
+  }
+  if (!valid.length) return { ok: false, tier: 'software', reason: 'assurance_proof_invalid' };
+  const distinctApprovers = new Set(valid.map((s) => s.approver));
+  const threshold = Number(proof.threshold ?? proof.m ?? 1);
+  if (Number.isFinite(threshold) && threshold >= 2 && distinctApprovers.size >= threshold && valid.length >= threshold) {
+    return { ok: true, tier: 'quorum', reason: 'assurance_proof_verified' };
+  }
+  if (valid.some((s) => s.keyClass === 'A')) {
+    return { ok: true, tier: 'class_a', reason: 'assurance_proof_verified' };
+  }
+  return { ok: true, tier: 'software', reason: 'assurance_proof_verified' };
+}
+
+function normalizeVerifierResult(result) {
+  if (typeof result === 'string') return { ok: true, tier: normalizeAssuranceClass(result), reason: 'custom_assurance_verifier' };
+  if (result && typeof result === 'object') {
+    return {
+      ok: result.ok !== false,
+      tier: normalizeAssuranceClass(result.tier || result.have || result.assuranceClass),
+      reason: result.reason || 'custom_assurance_verifier',
+    };
+  }
+  return { ok: false, tier: 'software', reason: 'custom_assurance_verifier_failed' };
+}
+
+export function receiptAssuranceTier(doc, opts = {}) {
+  const custom = typeof opts.verifyAssurance === 'function'
+    ? normalizeVerifierResult(opts.verifyAssurance(doc, { requiredTier: 'quorum' }))
+    : null;
+  if (custom?.ok) return custom.tier;
+  return verifyPinnedAssuranceProof(doc, opts).tier;
+}
+
+export function evaluateReceiptAssurance(doc, required, opts = {}) {
+  const need = normalizeAssuranceClass(required);
+  if (need === 'software') return { ok: true, have: 'software', need, reason: 'software_receipt' };
+  const custom = typeof opts.verifyAssurance === 'function'
+    ? normalizeVerifierResult(opts.verifyAssurance(doc, { requiredTier: need }))
+    : null;
+  const proof = custom || verifyPinnedAssuranceProof(doc, opts);
+  const have = normalizeAssuranceClass(proof.tier);
+  const rankOk = (ASSURANCE_RANK[have] ?? 0) >= (ASSURANCE_RANK[need] ?? 0);
+  return {
+    ok: proof.ok === true && rankOk,
     have,
     need,
+    reason: proof.ok === true && !rankOk ? 'assurance_too_low' : (proof.reason || (proof.ok ? 'assurance_ok' : 'assurance_proof_required')),
   };
 }
 
@@ -342,15 +456,15 @@ export function requireEmiliaReceipt(opts = {}) {
       return res.status(status).json({ ...receiptChallenge(action, `Receipt rejected: ${v.reason}.`, challengeOpts), rejected: v });
     }
     if (opts.assuranceClass || opts.assurance_class) {
-      const tier = middlewareAssuranceMeets(doc, opts.assuranceClass || opts.assurance_class);
+      const tier = evaluateReceiptAssurance(doc, opts.assuranceClass || opts.assurance_class, opts);
       if (!tier.ok) {
         res.setHeader(RECEIPT_REQUIRED_HEADER, receiptRequiredHeader(challengeOpts));
         if (status === LEGACY_RECEIPT_REQUIRED_STATUS) {
           res.setHeader('WWW-Authenticate', `EMILIA realm="agent-actions"${action ? `, action="${action}"` : ''}`);
         }
         return res.status(status).json({
-          ...receiptChallenge(action, 'Receipt rejected: assurance_too_low.', challengeOpts),
-          rejected: { ok: false, reason: 'assurance_too_low', have_tier: tier.have, need_tier: tier.need },
+          ...receiptChallenge(action, `Receipt rejected: ${tier.reason}.`, challengeOpts),
+          rejected: { ok: false, reason: tier.reason, have_tier: tier.have, need_tier: tier.need },
         });
       }
     }
@@ -465,31 +579,12 @@ function normalizeTarget(target) {
   return String(target);
 }
 
-export const ASSURANCE_TIERS = ['software', 'class_a', 'quorum'];
 const TIER_RANK = { software: 0, class_a: 1, quorum: 2 };
 
-function normalizeAssuranceClass(value) {
-  return ASSURANCE_TIERS.includes(value) ? value : 'software';
+function normalizeGateAssuranceClass(value) {
+  return Object.prototype.hasOwnProperty.call(TIER_RANK, value) ? value : 'software';
 }
 
-/**
- * Conservative tier earned by the receipt itself.
- * - software: a valid software-held receipt.
- * - class_a: a human signoff receipt (`allow_with_signoff` or explicit signoff).
- * - quorum: explicit quorum evidence with threshold >= 2 and >= 2 distinct humans.
- */
-export function receiptAssuranceTier(doc) {
-  const p = doc?.payload || {};
-  const q = p.quorum || p.claim?.quorum;
-  const signers = q && (q.signers || q.approvers);
-  const threshold = Number(q && (q.m ?? q.threshold ?? (Array.isArray(signers) ? signers.length : 0)));
-  if (q && Array.isArray(signers) && Number.isFinite(threshold) && threshold >= 2) {
-    const distinct = new Set(signers.map((s) => String(s))).size;
-    if (distinct >= 2) return 'quorum';
-  }
-  if (p.signoff || p.claim?.outcome === 'allow_with_signoff') return 'class_a';
-  return 'software';
-}
 
 /**
  * Build a hardened Receipt-Required gate for one action type.
@@ -522,6 +617,9 @@ export function makeReceiptGate(opts = {}) {
     manifestUrl,
     assuranceClass,
     quorum,
+    approverKeys,
+    approver_keys,
+    verifyAssurance,
     store = inMemoryStore(),
   } = opts;
 
@@ -536,7 +634,7 @@ export function makeReceiptGate(opts = {}) {
     return t === null ? base : `${base}:${t}`;
   };
 
-  const requiredTier = normalizeAssuranceClass(assuranceClass);
+  const requiredTier = normalizeGateAssuranceClass(assuranceClass);
   const challengeOpts = () => ({ statusCode, manifestUrl, assuranceClass: requiredTier, quorum, maxAgeSec });
 
   function refuse(boundAction, reason) {
@@ -567,9 +665,9 @@ export function makeReceiptGate(opts = {}) {
     const v = verifyEmiliaReceipt(receipt, { trustedKeys, allowInlineKey, action: boundAction, maxAgeSec, allowedOutcomes });
     if (!v.ok) return refuse(boundAction, v.reason); // sanitized: reason code only
 
-    const haveTier = receiptAssuranceTier(receipt);
-    if ((TIER_RANK[haveTier] ?? 0) < (TIER_RANK[requiredTier] ?? 0)) {
-      return refuse(boundAction, 'assurance_too_low');
+    const assurance = evaluateReceiptAssurance(receipt, requiredTier, { approverKeys, approver_keys, verifyAssurance });
+    if (!assurance.ok || (TIER_RANK[assurance.have] ?? 0) < (TIER_RANK[requiredTier] ?? 0)) {
+      return refuse(boundAction, assurance.reason || 'assurance_too_low');
     }
 
     if (store.has(v.receipt_id) || inflight.has(v.receipt_id)) return refuse(boundAction, 'replay_refused');

--- a/packages/require-receipt/gate.js
+++ b/packages/require-receipt/gate.js
@@ -23,6 +23,8 @@ import {
   verifyEmiliaReceipt,
   receiptChallenge,
   RECEIPT_REQUIRED_STATUS,
+  evaluateReceiptAssurance,
+  receiptAssuranceTier,
 } from './index.js';
 
 /** Default in-memory consumed-store. Process-local — pass a shared/durable store
@@ -38,31 +40,13 @@ function normalizeTarget(target) {
   return String(target);
 }
 
-export const ASSURANCE_TIERS = ['software', 'class_a', 'quorum'];
 const TIER_RANK = { software: 0, class_a: 1, quorum: 2 };
 
-function normalizeAssuranceClass(value) {
-  return ASSURANCE_TIERS.includes(value) ? value : 'software';
+function normalizeGateAssuranceClass(value) {
+  return Object.prototype.hasOwnProperty.call(TIER_RANK, value) ? value : 'software';
 }
 
-/**
- * Conservative tier earned by the receipt itself.
- * - software: a valid software-held receipt.
- * - class_a: a human signoff receipt (`allow_with_signoff` or explicit signoff).
- * - quorum: explicit quorum evidence with threshold >= 2 and >= 2 distinct humans.
- */
-export function receiptAssuranceTier(doc) {
-  const p = doc?.payload || {};
-  const q = p.quorum || p.claim?.quorum;
-  const signers = q && (q.signers || q.approvers);
-  const threshold = Number(q && (q.m ?? q.threshold ?? (Array.isArray(signers) ? signers.length : 0)));
-  if (q && Array.isArray(signers) && Number.isFinite(threshold) && threshold >= 2) {
-    const distinct = new Set(signers.map((s) => String(s))).size;
-    if (distinct >= 2) return 'quorum';
-  }
-  if (p.signoff || p.claim?.outcome === 'allow_with_signoff') return 'class_a';
-  return 'software';
-}
+export { receiptAssuranceTier };
 
 /**
  * Build a hardened Receipt-Required gate for one action type.
@@ -95,6 +79,9 @@ export function makeReceiptGate(opts = {}) {
     manifestUrl,
     assuranceClass,
     quorum,
+    approverKeys,
+    approver_keys,
+    verifyAssurance,
     store = inMemoryStore(),
   } = opts;
 
@@ -109,7 +96,7 @@ export function makeReceiptGate(opts = {}) {
     return t === null ? base : `${base}:${t}`;
   };
 
-  const requiredTier = normalizeAssuranceClass(assuranceClass);
+  const requiredTier = normalizeGateAssuranceClass(assuranceClass);
   const challengeOpts = () => ({ statusCode, manifestUrl, assuranceClass: requiredTier, quorum, maxAgeSec });
 
   function refuse(boundAction, reason) {
@@ -140,9 +127,9 @@ export function makeReceiptGate(opts = {}) {
     const v = verifyEmiliaReceipt(receipt, { trustedKeys, allowInlineKey, action: boundAction, maxAgeSec, allowedOutcomes });
     if (!v.ok) return refuse(boundAction, v.reason); // sanitized: reason code only
 
-    const haveTier = receiptAssuranceTier(receipt);
-    if ((TIER_RANK[haveTier] ?? 0) < (TIER_RANK[requiredTier] ?? 0)) {
-      return refuse(boundAction, 'assurance_too_low');
+    const assurance = evaluateReceiptAssurance(receipt, requiredTier, { approverKeys, approver_keys, verifyAssurance });
+    if (!assurance.ok || (TIER_RANK[assurance.have] ?? 0) < (TIER_RANK[requiredTier] ?? 0)) {
+      return refuse(boundAction, assurance.reason || 'assurance_too_low');
     }
 
     if (store.has(v.receipt_id) || inflight.has(v.receipt_id)) return refuse(boundAction, 'replay_refused');

--- a/packages/require-receipt/gate.test.js
+++ b/packages/require-receipt/gate.test.js
@@ -31,6 +31,20 @@ function mint(actionType, { outcome = 'allow_with_signoff', quorum = null } = {}
   return { '@version': 'EP-RECEIPT-v1', payload, signature: { algorithm: 'Ed25519', value }, public_key: pub };
 }
 
+function fixtureAssurance(doc) {
+  const claim = doc?.payload?.claim || {};
+  const q = claim.quorum;
+  const signers = Array.isArray(q?.signers) ? q.signers : [];
+  const threshold = Number(q?.threshold ?? q?.m ?? 0);
+  if (threshold >= 2 && new Set(signers).size >= threshold) {
+    return { ok: true, tier: 'quorum', reason: 'fixture_assurance_verified' };
+  }
+  if (claim.outcome === 'allow_with_signoff') {
+    return { ok: true, tier: 'class_a', reason: 'fixture_assurance_verified' };
+  }
+  return { ok: true, tier: 'software', reason: 'fixture_assurance_verified' };
+}
+
 const gate = () => makeReceiptGate({ action: 'db.records.delete', allowInlineKey: true, maxAgeSec: 900 });
 
 test('missing receipt -> 428 challenge, no rejected detail', async () => {
@@ -126,11 +140,23 @@ test('assuranceClass=class_a refuses a software-only receipt', async () => {
     throw new Error('should not run');
   });
   assert.equal(r.ok, false);
-  assert.equal(r.body.rejected.reason, 'assurance_too_low');
+  assert.equal(r.body.rejected.reason, 'assurance_proof_required');
 });
 
-test('assuranceClass=quorum refuses a single human signoff', async () => {
+test('assuranceClass=quorum refuses self-asserted high assurance without proof', async () => {
   const g = makeReceiptGate({ action: 'deploy.production', assuranceClass: 'quorum', allowInlineKey: true });
+  const rc = mint('deploy.production', {
+    quorum: { threshold: 2, signers: ['ep:approver:a', 'ep:approver:b'] },
+  });
+  const r = await g.run(rc, {}, async () => {
+    throw new Error('should not run');
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.body.rejected.reason, 'assurance_proof_required');
+});
+
+test('assuranceClass=quorum refuses a verified single human signoff', async () => {
+  const g = makeReceiptGate({ action: 'deploy.production', assuranceClass: 'quorum', allowInlineKey: true, verifyAssurance: fixtureAssurance });
   const rc = mint('deploy.production');
   const r = await g.run(rc, {}, async () => {
     throw new Error('should not run');
@@ -140,7 +166,7 @@ test('assuranceClass=quorum refuses a single human signoff', async () => {
 });
 
 test('assuranceClass=quorum accepts threshold-2 distinct-human quorum evidence', async () => {
-  const g = makeReceiptGate({ action: 'deploy.production', assuranceClass: 'quorum', allowInlineKey: true });
+  const g = makeReceiptGate({ action: 'deploy.production', assuranceClass: 'quorum', allowInlineKey: true, verifyAssurance: fixtureAssurance });
   const rc = mint('deploy.production', {
     quorum: { threshold: 2, signers: ['ep:approver:a', 'ep:approver:b'] },
   });
@@ -152,5 +178,8 @@ test('assuranceClass=quorum accepts threshold-2 distinct-human quorum evidence',
 test('receiptAssuranceTier does not count duplicate quorum signers', () => {
   assert.equal(receiptAssuranceTier({
     payload: { claim: { outcome: 'allow_with_signoff', quorum: { threshold: 2, signers: ['same', 'same'] } } },
-  }), 'class_a');
+  }), 'software');
+  assert.equal(receiptAssuranceTier({
+    payload: { claim: { outcome: 'allow_with_signoff', quorum: { threshold: 2, signers: ['same', 'same'] } } },
+  }, { verifyAssurance: fixtureAssurance }), 'class_a');
 });

--- a/packages/require-receipt/index.js
+++ b/packages/require-receipt/index.js
@@ -24,6 +24,11 @@ export const RECEIPT_REQUIRED_HEADER = 'Receipt-Required';
 export const RECEIPT_PROOF_HEADER = 'X-EMILIA-Receipt';
 export const ACTION_RISK_MANIFEST_VERSION = 'EP-ACTION-RISK-MANIFEST-v0.1';
 export const DEFAULT_ACTION_RISK_MANIFEST = '/.well-known/agent-actions.json';
+export const ASSURANCE_TIERS = ['software', 'class_a', 'quorum'];
+export const ASSURANCE_PROOF_VERSION = 'EP-ASSURANCE-PROOF-v1';
+const ASSURANCE_RANK = { software: 0, class_a: 1, quorum: 2 };
+const FLAG_UP = 0x01;
+const FLAG_UV = 0x04;
 
 function canonicalize(v) {
   if (v === null || v === undefined) return JSON.stringify(v);
@@ -86,28 +91,137 @@ function isObject(v) {
   return v && typeof v === 'object' && !Array.isArray(v);
 }
 
-const MIDDLEWARE_ASSURANCE_RANK = { software: 0, class_a: 1, quorum: 2 };
-
-function receiptAssuranceTierForMiddleware(doc) {
-  const payload = doc?.payload || {};
-  const q = payload.quorum || payload.claim?.quorum;
-  const signers = q && (q.signers || q.approvers);
-  const threshold = Number(q && (q.m ?? q.threshold ?? (Array.isArray(signers) ? signers.length : 0)));
-  if (q && Array.isArray(signers) && Number.isFinite(threshold) && threshold >= 2) {
-    const distinct = new Set(signers.map((s) => String(s))).size;
-    if (distinct >= 2) return 'quorum';
-  }
-  if (payload.signoff || payload.claim?.outcome === 'allow_with_signoff') return 'class_a';
-  return 'software';
+function normalizeAssuranceClass(value) {
+  return ASSURANCE_TIERS.includes(value) ? value : 'software';
 }
 
-function middlewareAssuranceMeets(doc, required) {
-  const need = MIDDLEWARE_ASSURANCE_RANK[required] === undefined ? 'software' : required;
-  const have = receiptAssuranceTierForMiddleware(doc);
+function b64urlDecode(value) {
+  return Buffer.from(String(value || ''), 'base64url');
+}
+
+function sha256Bytes(value) {
+  return crypto.createHash('sha256').update(value).digest();
+}
+
+function sha256Hex(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function proofContext(doc) {
   return {
-    ok: (MIDDLEWARE_ASSURANCE_RANK[have] ?? 0) >= (MIDDLEWARE_ASSURANCE_RANK[need] ?? 0),
+    '@version': 'EP-ASSURANCE-CONTEXT-v1',
+    receipt_id: doc?.payload?.receipt_id || null,
+    claim_hash: `sha256:${sha256Hex(canonicalize(doc?.payload?.claim || {}))}`,
+  };
+}
+
+function verifyEd25519Digest(signature, digest, publicKeyB64u) {
+  try {
+    const pub = crypto.createPublicKey({ key: b64urlDecode(publicKeyB64u), format: 'der', type: 'spki' });
+    return crypto.verify(null, digest, pub, b64urlDecode(signature));
+  } catch {
+    return false;
+  }
+}
+
+function verifyWebAuthnDigest(webauthn, digest, publicKeyB64u) {
+  try {
+    if (!webauthn || typeof webauthn !== 'object') return false;
+    const authData = b64urlDecode(webauthn.authenticator_data);
+    const clientDataBytes = b64urlDecode(webauthn.client_data_json);
+    if (authData.length < 37) return false;
+    const flags = authData[32];
+    if ((flags & FLAG_UP) !== FLAG_UP || (flags & FLAG_UV) !== FLAG_UV) return false;
+    const clientData = JSON.parse(clientDataBytes.toString('utf8'));
+    if (clientData.type !== 'webauthn.get') return false;
+    if (clientData.challenge !== Buffer.from(digest).toString('base64url')) return false;
+    const signedData = Buffer.concat([authData, sha256Bytes(clientDataBytes)]);
+    const pub = crypto.createPublicKey({ key: b64urlDecode(publicKeyB64u), format: 'der', type: 'spki' });
+    return crypto.verify('sha256', signedData, pub, b64urlDecode(webauthn.signature));
+  } catch {
+    return false;
+  }
+}
+
+function normalizeApproverKeys(input) {
+  if (!input || typeof input !== 'object') return {};
+  return input;
+}
+
+function verifyPinnedAssuranceProof(doc, opts = {}) {
+  const proof = doc?.payload?.assurance_proof || doc?.assurance_proof;
+  if (!proof || typeof proof !== 'object') return { ok: false, tier: 'software', reason: 'assurance_proof_required' };
+  if (proof['@version'] !== ASSURANCE_PROOF_VERSION) {
+    return { ok: false, tier: 'software', reason: 'assurance_proof_bad_version' };
+  }
+  const approverKeys = normalizeApproverKeys(opts.approverKeys || opts.approver_keys);
+  const signoffs = Array.isArray(proof.signoffs) ? proof.signoffs : [];
+  if (!signoffs.length) return { ok: false, tier: 'software', reason: 'assurance_proof_missing_signoffs' };
+
+  const context = proofContext(doc);
+  const contextHash = `sha256:${sha256Hex(canonicalize(context))}`;
+  if (proof.context_hash && proof.context_hash !== contextHash) {
+    return { ok: false, tier: 'software', reason: 'assurance_context_mismatch' };
+  }
+  const digest = Buffer.from(contextHash.replace(/^sha256:/, ''), 'hex');
+  const valid = [];
+  for (const s of signoffs) {
+    const keyId = s?.approver_key_id;
+    const entry = keyId ? approverKeys[keyId] : null;
+    if (!entry?.public_key) continue;
+    const keyClass = s.key_class || entry.key_class || 'B';
+    const ok = keyClass === 'A'
+      ? verifyWebAuthnDigest(s.webauthn, digest, entry.public_key)
+      : verifyEd25519Digest(s.signature, digest, entry.public_key);
+    if (!ok) continue;
+    valid.push({ approver: String(s.approver || keyId), keyClass });
+  }
+  if (!valid.length) return { ok: false, tier: 'software', reason: 'assurance_proof_invalid' };
+  const distinctApprovers = new Set(valid.map((s) => s.approver));
+  const threshold = Number(proof.threshold ?? proof.m ?? 1);
+  if (Number.isFinite(threshold) && threshold >= 2 && distinctApprovers.size >= threshold && valid.length >= threshold) {
+    return { ok: true, tier: 'quorum', reason: 'assurance_proof_verified' };
+  }
+  if (valid.some((s) => s.keyClass === 'A')) {
+    return { ok: true, tier: 'class_a', reason: 'assurance_proof_verified' };
+  }
+  return { ok: true, tier: 'software', reason: 'assurance_proof_verified' };
+}
+
+function normalizeVerifierResult(result) {
+  if (typeof result === 'string') return { ok: true, tier: normalizeAssuranceClass(result), reason: 'custom_assurance_verifier' };
+  if (result && typeof result === 'object') {
+    return {
+      ok: result.ok !== false,
+      tier: normalizeAssuranceClass(result.tier || result.have || result.assuranceClass),
+      reason: result.reason || 'custom_assurance_verifier',
+    };
+  }
+  return { ok: false, tier: 'software', reason: 'custom_assurance_verifier_failed' };
+}
+
+export function receiptAssuranceTier(doc, opts = {}) {
+  const custom = typeof opts.verifyAssurance === 'function'
+    ? normalizeVerifierResult(opts.verifyAssurance(doc, { requiredTier: 'quorum' }))
+    : null;
+  if (custom?.ok) return custom.tier;
+  return verifyPinnedAssuranceProof(doc, opts).tier;
+}
+
+export function evaluateReceiptAssurance(doc, required, opts = {}) {
+  const need = normalizeAssuranceClass(required);
+  if (need === 'software') return { ok: true, have: 'software', need, reason: 'software_receipt' };
+  const custom = typeof opts.verifyAssurance === 'function'
+    ? normalizeVerifierResult(opts.verifyAssurance(doc, { requiredTier: need }))
+    : null;
+  const proof = custom || verifyPinnedAssuranceProof(doc, opts);
+  const have = normalizeAssuranceClass(proof.tier);
+  const rankOk = (ASSURANCE_RANK[have] ?? 0) >= (ASSURANCE_RANK[need] ?? 0);
+  return {
+    ok: proof.ok === true && rankOk,
     have,
     need,
+    reason: proof.ok === true && !rankOk ? 'assurance_too_low' : (proof.reason || (proof.ok ? 'assurance_ok' : 'assurance_proof_required')),
   };
 }
 
@@ -310,15 +424,15 @@ export function requireEmiliaReceipt(opts = {}) {
       return res.status(status).json({ ...receiptChallenge(action, `Receipt rejected: ${v.reason}.`, challengeOpts), rejected: v });
     }
     if (opts.assuranceClass || opts.assurance_class) {
-      const tier = middlewareAssuranceMeets(doc, opts.assuranceClass || opts.assurance_class);
+      const tier = evaluateReceiptAssurance(doc, opts.assuranceClass || opts.assurance_class, opts);
       if (!tier.ok) {
         res.setHeader(RECEIPT_REQUIRED_HEADER, receiptRequiredHeader(challengeOpts));
         if (status === LEGACY_RECEIPT_REQUIRED_STATUS) {
           res.setHeader('WWW-Authenticate', `EMILIA realm="agent-actions"${action ? `, action="${action}"` : ''}`);
         }
         return res.status(status).json({
-          ...receiptChallenge(action, 'Receipt rejected: assurance_too_low.', challengeOpts),
-          rejected: { ok: false, reason: 'assurance_too_low', have_tier: tier.have, need_tier: tier.need },
+          ...receiptChallenge(action, `Receipt rejected: ${tier.reason}.`, challengeOpts),
+          rejected: { ok: false, reason: tier.reason, have_tier: tier.have, need_tier: tier.need },
         });
       }
     }

--- a/packages/verify/README.md
+++ b/packages/verify/README.md
@@ -153,9 +153,12 @@ operator using only its published discovery surfaces.
 ```js
 import { verifyFederatedReceipt, verifyFederatedReceiptOffline } from '@emilia-protocol/verify';
 
-// Online: resolves the issuer's keys from signature.key_discovery and
-// checks its revocation surface.
-const verdict = await verifyFederatedReceipt(receipt);
+// Online: resolves the issuer's keys from a caller-pinned discovery URL and
+// checks its revocation surface. Treat receipt.signature.key_discovery as a
+// hint, not a trust root.
+const verdict = await verifyFederatedReceipt(receipt, {
+  keyDiscoveryUrl: 'https://op-a.example/.well-known/ep-keys.json',
+});
 // { accepted, verified, revoked, signer, keyMatched: 'current'|'historical', checks }
 
 // Air-gapped: supply the issuer's ep-keys.json + revocation set yourself.

--- a/packages/verify/index.js
+++ b/packages/verify/index.js
@@ -776,6 +776,21 @@ function buildAttestationReport(contexts) {
   return { present: true, consistent, issues };
 }
 
+function trustReceiptCanonicalProfileError(receipt) {
+  const leafContent = { ...receipt };
+  delete leafContent.log_proof;
+  delete leafContent.approver_key_proofs;
+  if (!isCanonicalizable(leafContent)) return 'Trust Receipt body';
+
+  const checkpoint = receipt?.log_proof?.checkpoint;
+  if (checkpoint && typeof checkpoint === 'object') {
+    const signedCheckpoint = { ...checkpoint };
+    delete signedCheckpoint.log_signature;
+    if (!isCanonicalizable(signedCheckpoint)) return 'Trust Receipt checkpoint';
+  }
+  return null;
+}
+
 /**
  * Verify a Trust Receipt (I-D Section 6.2) fully offline — the Section 6.3
  * algorithm. All six steps; fails closed on any missing input.
@@ -817,6 +832,10 @@ export function verifyTrustReceipt(receipt, opts = {}) {
   const signoffs = Array.isArray(receipt.signoffs) ? receipt.signoffs : [];
   if (!receipt.action || !receipt.action_hash) return fail('Missing action or action_hash');
   if (contexts.length === 0 || signoffs.length === 0) return fail('Missing contexts or signoffs');
+  const profileError = trustReceiptCanonicalProfileError(receipt);
+  if (profileError) {
+    return fail(`${profileError} is outside the EP canonicalization profile; encode non-integer quantities as strings`);
+  }
 
   // ── Step 1: recompute the action hash from the canonical Action Object ────
   const actionHashHex = sha256(canonicalize(receipt.action));
@@ -914,8 +933,20 @@ export function verifyTrustReceipt(receipt, opts = {}) {
     const leafContent = { ...receipt };
     delete leafContent.log_proof;
     delete leafContent.approver_key_proofs;
-    const leafHash = sha256(canonicalize(leafContent));
-    checks.inclusion = verifyMerkleAnchor(leafHash, lp.inclusion_path, hexOf(lp.checkpoint.root_hash));
+    const merkleAlg = lp.alg || lp.checkpoint?.merkle_alg || null;
+    if (merkleAlg === MERKLE_V2_ALG) {
+      const leafHash = leafHashV2(canonicalize(leafContent));
+      const presentedLeaf = lp.leaf_hash ? hexOf(lp.leaf_hash) : '';
+      checks.inclusion = presentedLeaf === leafHash
+        && verifyMerkleAnchor(leafHash, lp.inclusion_path, hexOf(lp.checkpoint.root_hash), { v2: true });
+      if (presentedLeaf !== leafHash) errors.push('Trust Receipt log_proof leaf_hash does not bind this receipt');
+    } else if (opts.allowLegacyMerkle === true || opts.allowLegacyTrustReceiptMerkle === true) {
+      const leafHash = sha256(canonicalize(leafContent));
+      checks.inclusion = verifyMerkleAnchor(leafHash, lp.inclusion_path, hexOf(lp.checkpoint.root_hash));
+    } else {
+      checks.inclusion = false;
+      errors.push('Trust Receipt log_proof must use EP-MERKLE-v2');
+    }
     if (!checks.inclusion) errors.push('Merkle inclusion proof does not reconstruct the checkpoint root');
 
     if (logPublicKey && lp.checkpoint.log_signature) {

--- a/packages/verify/trust-receipt.test.js
+++ b/packages/verify/trust-receipt.test.js
@@ -32,6 +32,12 @@ function canonicalize(value) {
 }
 const sha256hex = (s) => crypto.createHash('sha256').update(s, 'utf8').digest('hex');
 const hashPair = (a, b) => { const s = [a, b].sort(); return sha256hex(s[0] + s[1]); };
+const leafHashV2 = (canonical) => crypto.createHash('sha256')
+  .update(Buffer.concat([Buffer.from([0x00]), Buffer.from(canonical, 'utf8')]))
+  .digest('hex');
+const hashPairV2 = (left, right) => crypto.createHash('sha256')
+  .update(Buffer.concat([Buffer.from([0x01]), Buffer.from(left, 'utf8'), Buffer.from(right, 'utf8')]))
+  .digest('hex');
 
 // ── fixture actors ───────────────────────────────────────────────────────────
 function ed25519() {
@@ -120,13 +126,19 @@ function buildReceipt(mutate = {}) {
     consumption: { nonce: 'n-consume', state: 'COMMITTED', committed_at: mutate.committed_at || '2026-06-09T17:25:02Z' },
   };
 
-  // Build the log: leaf = hash of canonical receipt without log_proof.
-  const leaf = sha256hex(canonicalize(receipt));
+  // Build the log: default leaf = EP-MERKLE-v2(canonical receipt without log_proof).
+  const legacyMerkle = mutate.legacyMerkle === true;
+  const leaf = legacyMerkle ? sha256hex(canonicalize(receipt)) : leafHashV2(canonicalize(receipt));
   const sibling1 = sha256hex('other-leaf-1');
   const sibling2 = sha256hex('other-subtree');
-  const level1 = hashPair(leaf, sibling1);
-  const root = hashPair(level1, sibling2);
-  const checkpoint = { tree_size: 4, root_hash: `sha256:${root}`, log_key_id: 'ep:log:test#1' };
+  const level1 = legacyMerkle ? hashPair(leaf, sibling1) : hashPairV2(leaf, sibling1);
+  const root = legacyMerkle ? hashPair(level1, sibling2) : hashPairV2(level1, sibling2);
+  const checkpoint = {
+    tree_size: 4,
+    root_hash: `sha256:${root}`,
+    log_key_id: 'ep:log:test#1',
+    ...(legacyMerkle ? {} : { merkle_alg: 'EP-MERKLE-v2' }),
+  };
   const log_signature = crypto.sign(
     null,
     crypto.createHash('sha256').update(canonicalize(checkpoint), 'utf8').digest(),
@@ -134,6 +146,7 @@ function buildReceipt(mutate = {}) {
   ).toString('base64url');
 
   receipt.log_proof = {
+    ...(legacyMerkle ? {} : { alg: 'EP-MERKLE-v2', leaf_hash: `sha256:${leaf}` }),
     leaf_index: 0,
     inclusion_path: [
       { hash: sibling1, position: 'right' },
@@ -176,6 +189,13 @@ test('step 1 — a tampered action parameter fails the action hash', () => {
   const r = verifyTrustReceipt(receipt, OPTS);
   assert.equal(r.checks.action_hash, false);
   assert.equal(r.valid, false);
+});
+
+test('step 1 — non-I-JSON signed material is rejected before Trust Receipt hashing', () => {
+  const receipt = buildReceipt({ action: { parameters: { amount: 2400000.25, currency: 'USD' } } });
+  const r = verifyTrustReceipt(receipt, OPTS);
+  assert.equal(r.valid, false);
+  assert.match(r.errors.join(' '), /canonicalization profile/);
 });
 
 // ── step 2: context commitments ──────────────────────────────────────────────
@@ -276,6 +296,26 @@ test('step 5 — a broken inclusion path fails', () => {
   assert.equal(r.valid, false);
 });
 
+test('step 5 — a legacy Trust Receipt Merkle proof is opt-in only', () => {
+  const receipt = buildReceipt({ legacyMerkle: true });
+  const strictDefault = verifyTrustReceipt(receipt, OPTS);
+  assert.equal(strictDefault.checks.inclusion, false);
+  assert.match(strictDefault.errors.join(' '), /EP-MERKLE-v2/);
+  assert.equal(strictDefault.valid, false);
+
+  const legacyAllowed = verifyTrustReceipt(receipt, { ...OPTS, allowLegacyTrustReceiptMerkle: true });
+  assert.equal(legacyAllowed.checks.inclusion, true, JSON.stringify(legacyAllowed.errors));
+});
+
+test('step 5 — a v2 Trust Receipt leaf_hash must bind this receipt', () => {
+  const receipt = buildReceipt();
+  receipt.log_proof.leaf_hash = `sha256:${sha256hex('not-this-receipt')}`;
+  const r = verifyTrustReceipt(receipt, OPTS);
+  assert.equal(r.checks.inclusion, false);
+  assert.match(r.errors.join(' '), /leaf_hash/);
+  assert.equal(r.valid, false);
+});
+
 test('step 5 — a checkpoint signed by a different log key fails', () => {
   const r = verifyTrustReceipt(buildReceipt(), { approverKeys: KEYS, logPublicKey: ed25519().pub });
   assert.equal(r.checks.checkpoint_signature, false);
@@ -359,7 +399,7 @@ test('PIP-007 — an over-cap statement is SHOULD-flagged; the receipt still ver
 });
 
 test('PIP-007 — unknown members and policy_rule-without-basis are SHOULD-flagged; signature unaffected', () => {
-  const att = { escalation_trigger: 'policy_rule', confidence: 0.9 }; // missing policy_basis + extra member
+  const att = { escalation_trigger: 'policy_rule', confidence: 'high' }; // missing policy_basis + extra member
   const r = verifyTrustReceipt(buildReceipt({ attestation: att }), OPTS);
   assert.equal(r.valid, true);
   assert.equal(r.checks.signoff_signatures, true);

--- a/tests/guarded-replay.test.js
+++ b/tests/guarded-replay.test.js
@@ -21,10 +21,10 @@ const trustedKeyB64u = publicKey.export({ type: 'spki', format: 'der' }).toStrin
 // NOTE: pass `omitCreatedAt: true` to actually drop created_at. A destructuring
 // default (`createdAt = ...`) fires on an explicit `undefined`, so it cannot be
 // used to omit the field — hence the explicit flag.
-function mint(action, { createdAt, receiptId, omitCreatedAt = false } = {}) {
+function mint(action, { createdAt, receiptId, omitCreatedAt = false, omitReceiptId = false } = {}) {
   const ts = createdAt || new Date().toISOString();
   const payload = {
-    receipt_id: receiptId || `rcpt_test_${crypto.randomBytes(6).toString('hex')}`,
+    ...(omitReceiptId ? {} : { receipt_id: receiptId || `rcpt_test_${crypto.randomBytes(6).toString('hex')}` }),
     subject: 'agent:test',
     ...(omitCreatedAt ? {} : { created_at: ts }),
     claim: { action_type: action, outcome: 'allow_with_signoff', approver: 'ep:approver:test' },
@@ -59,6 +59,14 @@ describe('/api/v1/guarded replay + freshness', () => {
 
   afterEach(() => {
     delete process.env.EP_TRUSTED_ISSUER_KEYS;
+  });
+
+  it('REFUSES a verified receipt with no receipt_id (cannot enforce one-time consumption)', async () => {
+    const doc = mint('payment.release', { omitReceiptId: true });
+    const res = await POST(guardedRequest(doc));
+    expect(res.status).toBe(402);
+    const body = await res.json();
+    expect(body.rejected?.reason).toBe('missing_receipt_id');
   });
 
   it('allows a valid, action-bound receipt', async () => {

--- a/tests/http-api-conformance.test.js
+++ b/tests/http-api-conformance.test.js
@@ -26,7 +26,7 @@ const canon = (v) => (v === null || v === undefined ? JSON.stringify(v)
     : typeof v === 'object' ? `{${Object.keys(v).sort().map((k) => JSON.stringify(k) + ':' + canon(v[k])).join(',')}}`
       : JSON.stringify(v));
 
-function mint(action, { outcome = 'allow_with_signoff', quorum = null } = {}) {
+function mint(action, { outcome = 'allow_with_signoff', quorum = null, extra = {} } = {}) {
   const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
   const pub = publicKey.export({ type: 'spki', format: 'der' }).toString('base64url');
   const payload = {
@@ -38,6 +38,7 @@ function mint(action, { outcome = 'allow_with_signoff', quorum = null } = {}) {
       outcome,
       approver: 'ep:approver:http-redteam',
       ...(quorum ? { quorum } : {}),
+      ...extra,
     },
   };
   const value = crypto.sign(null, Buffer.from(canon(payload), 'utf8'), privateKey).toString('base64url');
@@ -135,21 +136,27 @@ describe('HTTP/API Receipt Required conformance', () => {
         emilia_receipt: mint(action.action, { outcome: 'allow' }),
       }));
       expect(software.status).toBe(428);
-      expect((await software.json()).rejected.reason).toBe('assurance_too_low');
+      expect((await software.json()).rejected.reason).toBe('assurance_proof_required');
 
       if (action.assurance_class === 'quorum') {
         const singleHuman = await POST(request({
           demo: action.id,
-          emilia_receipt: mint(action.action),
+          emilia_receipt: mint(action.action, {
+            extra: { policy_id: action.policy_id, assurance_class: action.assurance_class },
+          }),
         }));
         expect(singleHuman.status).toBe(428);
         expect((await singleHuman.json()).rejected.reason).toBe('assurance_too_low');
 
+        const signed = await POST(request({
+          demo: action.id,
+          sign_demo_receipt: true,
+          approver: 'ep:approver:quorum-fixture',
+        }));
+        const { receipt } = await signed.json();
         const quorum = await POST(request({
           demo: action.id,
-          emilia_receipt: mint(action.action, {
-            quorum: { threshold: 2, signers: ['ep:approver:a', 'ep:approver:b'] },
-          }),
+          emilia_receipt: receipt,
         }));
         expect(quorum.status).toBe(200);
       }

--- a/tests/mcp-guard-boundary.test.js
+++ b/tests/mcp-guard-boundary.test.js
@@ -35,6 +35,12 @@ function mint(action, { outcome = 'allow_with_signoff', quorum = null } = {}) {
   return { '@version': 'EP-RECEIPT-v1', payload, signature: { algorithm: 'Ed25519', value }, public_key: pub };
 }
 
+function fixtureAssurance(doc) {
+  const claim = doc?.payload?.claim || {};
+  if (claim.outcome === 'allow_with_signoff') return { ok: true, tier: 'class_a', reason: 'fixture_assurance_verified' };
+  return { ok: true, tier: 'software', reason: 'fixture_assurance_verified' };
+}
+
 describe('@emilia-protocol/mcp-guard boundary hardening', () => {
   it('does not let attacker-controlled __ep.irreversible=false downgrade trusted policy', () => {
     expect(classifyToolCall('delete_repo', { __ep: { irreversible: false } }, {
@@ -76,7 +82,7 @@ describe('@emilia-protocol/mcp-guard boundary hardening', () => {
     const refused = demandReceipt({
       action,
       args: { __ep: { receipt: software } },
-      verifyOpts: { allowInlineKey: true, assuranceClass: 'class_a' },
+      verifyOpts: { allowInlineKey: true, assuranceClass: 'class_a', verifyAssurance: fixtureAssurance },
     });
     expect(refused.ok).toBe(false);
     expect(refused.refusal.rejected.reason).toBe('assurance_too_low');
@@ -84,7 +90,7 @@ describe('@emilia-protocol/mcp-guard boundary hardening', () => {
     const classA = demandReceipt({
       action,
       args: { __ep: { receipt: mint(action) } },
-      verifyOpts: { allowInlineKey: true, assuranceClass: 'class_a' },
+      verifyOpts: { allowInlineKey: true, assuranceClass: 'class_a', verifyAssurance: fixtureAssurance },
     });
     expect(classA.ok).toBe(true);
   });
@@ -96,7 +102,7 @@ describe('@emilia-protocol/mcp-guard boundary hardening', () => {
       return { deleted: true };
     }, {
       annotations: { delete_repo: { irreversible: true, action: 'github.repo.delete' } },
-      verifyOpts: { allowInlineKey: true },
+      verifyOpts: { allowInlineKey: true, verifyAssurance: fixtureAssurance },
     });
 
     const res = await guarded('delete_repo', {
@@ -124,7 +130,7 @@ describe('@emilia-protocol/mcp-guard boundary hardening', () => {
     const res = await guarded('delete_repo', { repo: 'prod' });
     expect(res.ep_refused).toBe(true);
     expect(res.stage).toBe('issue');
-    expect(res.rejected.reason).toBe('assurance_too_low');
+    expect(res.rejected.reason).toBe('assurance_proof_required');
     expect(ran).toBe(false);
   });
 });

--- a/tests/npm-provenance-workflows.test.js
+++ b/tests/npm-provenance-workflows.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const WORKFLOW_DIR = path.join(ROOT, '.github', 'workflows');
+
+describe('npm publish workflows', () => {
+  it('publish npm packages with OIDC provenance enabled', () => {
+    const findings = [];
+    for (const name of fs.readdirSync(WORKFLOW_DIR)) {
+      if (!/\.(yml|yaml)$/.test(name)) continue;
+      const file = path.join(WORKFLOW_DIR, name);
+      const text = fs.readFileSync(file, 'utf8');
+      if (!text.includes('npm publish')) continue;
+      for (const line of text.split('\n').filter((l) => l.includes('npm publish'))) {
+        if (!line.includes('--provenance')) {
+          findings.push(`${name}: ${line.trim()} missing --provenance`);
+        }
+      }
+      if (!/id-token:\s*write/.test(text)) {
+        findings.push(`${name}: missing permissions.id-token: write`);
+      }
+    }
+    expect(findings).toEqual([]);
+  });
+});

--- a/tests/public-body-limits.test.js
+++ b/tests/public-body-limits.test.js
@@ -18,6 +18,7 @@ const Operators = await import('../app/api/operators/apply/route.js');
 const PilotRequest = await import('../app/api/pilot/request/route.js');
 const Checkout = await import('../app/api/checkout/route.js');
 const Guarded = await import('../app/api/v1/guarded/route.js');
+const TrustGate = await import('../app/api/trust/gate/route.js');
 const DemoReceipt = await import('../app/api/demo/require-receipt/route.js');
 const DemoX402 = await import('../app/api/demo/x402/route.js');
 const Mcp = await import('../app/api/mcp/[transport]/route.js');
@@ -54,6 +55,7 @@ describe('public POST body limits', () => {
     ['pilot/request', PilotRequest.POST, '/api/pilot/request', 17 * 1024],
     ['checkout', Checkout.POST, '/api/checkout', 3 * 1024],
     ['v1/guarded', Guarded.POST, '/api/v1/guarded?action=payment.release', 257 * 1024],
+    ['trust/gate', TrustGate.POST, '/api/trust/gate', 257 * 1024],
     ['demo/require-receipt', DemoReceipt.POST, '/api/demo/require-receipt', 257 * 1024],
     ['demo/x402', DemoX402.POST, '/api/demo/x402', 257 * 1024],
     ['mcp', Mcp.POST, '/api/mcp/mcp', 257 * 1024],

--- a/tests/public-npx-provenance.test.js
+++ b/tests/public-npx-provenance.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const SCAN_DIRS = ['README.md', 'docs', 'app', 'public', 'create-ep-app', 'infrastructure'];
+const BANNED = [
+  /\bnpx\s+create-ep-app\b/g,
+  /\bnpx\s+ep-conformance-test\b/g,
+  /\bnpm\s+create\s+ep-app\b/g,
+];
+
+function* walk(p) {
+  const full = path.join(ROOT, p);
+  if (!fs.existsSync(full)) return;
+  const stat = fs.statSync(full);
+  if (stat.isFile()) {
+    if (/\.(md|mdx|js|jsx|ts|tsx|mjs|yaml|yml|txt|html)$/.test(full)) yield full;
+    return;
+  }
+  for (const entry of fs.readdirSync(full)) {
+    if (entry === 'node_modules' || entry === '.next' || entry === 'archive') continue;
+    yield* walk(path.join(p, entry));
+  }
+}
+
+describe('public command provenance', () => {
+  it('does not tell users to run unowned bare npx packages', () => {
+    const findings = [];
+    for (const file of SCAN_DIRS.flatMap((p) => [...walk(p)])) {
+      const text = fs.readFileSync(file, 'utf8');
+      for (const re of BANNED) {
+        for (const match of text.matchAll(re)) {
+          findings.push(`${path.relative(ROOT, file)}: ${match[0]}`);
+        }
+      }
+    }
+    expect(findings).toEqual([]);
+  });
+});

--- a/tests/receipt-required.test.js
+++ b/tests/receipt-required.test.js
@@ -58,6 +58,18 @@ function mint(action, { outcome = 'allow_with_signoff', quorum = null } = {}) {
   return { '@version': 'EP-RECEIPT-v1', payload, signature: { algorithm: 'Ed25519', value }, public_key: publicKeyB64u };
 }
 
+function fixtureAssurance(doc) {
+  const claim = doc?.payload?.claim || {};
+  const q = claim.quorum || {};
+  const signers = Array.isArray(q.signers) ? q.signers : [];
+  const threshold = Number(q.threshold ?? q.m ?? 0);
+  if (threshold >= 2 && new Set(signers).size >= threshold) {
+    return { ok: true, tier: 'quorum', reason: 'fixture_assurance_verified' };
+  }
+  if (claim.outcome === 'allow_with_signoff') return { ok: true, tier: 'class_a', reason: 'fixture_assurance_verified' };
+  return { ok: true, tier: 'software', reason: 'fixture_assurance_verified' };
+}
+
 describe('Action Risk Manifest', () => {
   const manifest = readJson('public/.well-known/agent-actions.json');
 
@@ -159,10 +171,17 @@ describe('Receipt Required challenge', () => {
     });
     expect(nextRan).toBe(false);
     expect(res.statusCode).toBe(RECEIPT_REQUIRED_STATUS);
-    expect(res.body.rejected.reason).toBe('assurance_too_low');
+    expect(res.body.rejected.reason).toBe('assurance_proof_required');
 
     const ok = fakeResponse();
-    gate({
+    const verifiedGate = requireEmiliaReceipt({
+      action: 'deploy.production',
+      statusCode: RECEIPT_REQUIRED_STATUS,
+      allowInlineKey: true,
+      assuranceClass: 'quorum',
+      verifyAssurance: fixtureAssurance,
+    });
+    verifiedGate({
       headers: {},
       body: {
         emilia_receipt: mint('deploy.production', {

--- a/tests/require-receipt-dropin.test.js
+++ b/tests/require-receipt-dropin.test.js
@@ -41,6 +41,18 @@ function mint(actionType, { outcome = 'allow_with_signoff', quorum = null } = {}
   return { '@version': 'EP-RECEIPT-v1', payload, signature: { algorithm: 'Ed25519', value }, public_key: pub };
 }
 
+function fixtureAssurance(doc) {
+  const claim = doc?.payload?.claim || {};
+  const q = claim.quorum || {};
+  const signers = Array.isArray(q.signers) ? q.signers : [];
+  const threshold = Number(q.threshold ?? q.m ?? 0);
+  if (threshold >= 2 && new Set(signers).size >= threshold) {
+    return { ok: true, tier: 'quorum', reason: 'fixture_assurance_verified' };
+  }
+  if (claim.outcome === 'allow_with_signoff') return { ok: true, tier: 'class_a', reason: 'fixture_assurance_verified' };
+  return { ok: true, tier: 'software', reason: 'fixture_assurance_verified' };
+}
+
 test('drop-in imports only node: builtins (genuinely dependency-free)', () => {
   const src = readFileSync(dropInPath, 'utf8');
   const specifiers = [...src.matchAll(/^\s*(?:import|export)\b[^\n]*\bfrom\s+['"]([^'"]+)['"]/gm)].map((m) => m[1]);
@@ -77,13 +89,19 @@ test('drop-in enforces assuranceClass, including quorum', async () => {
 
   const software = await gate.run(mint('deploy.production', { outcome: 'allow' }), {}, async () => 'should-not-run');
   expect(software.ok).toBe(false);
-  expect(software.body.rejected.reason).toBe('assurance_too_low');
+  expect(software.body.rejected.reason).toBe('assurance_proof_required');
 
   const classA = await gate.run(mint('deploy.production'), {}, async () => 'should-not-run');
   expect(classA.ok).toBe(false);
-  expect(classA.body.rejected.reason).toBe('assurance_too_low');
+  expect(classA.body.rejected.reason).toBe('assurance_proof_required');
 
-  const quorum = await gate.run(mint('deploy.production', {
+  const verifiedGate = makeReceiptGate({
+    action: 'deploy.production',
+    assuranceClass: 'quorum',
+    allowInlineKey: true,
+    verifyAssurance: fixtureAssurance,
+  });
+  const quorum = await verifiedGate.run(mint('deploy.production', {
     quorum: { threshold: 2, signers: ['ep:approver:a', 'ep:approver:b'] },
   }), {}, async () => 'deployed');
   expect(quorum.ok).toBe(true);

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -28,7 +28,10 @@ export default defineConfig({
     // examples/** are reference implementations with their own node:test suites
     // (e.g. robot-sidecar) — same reason as packages/**: run via `node --test`,
     // not vitest, which would otherwise fail with "No test suite found".
-    exclude: ['e2e/**', '**/node_modules/**', 'dist/**', '.next/**', 'packages/**', 'apps/**', 'examples/**', 'receipt-required-pr-kit/**'],
+    // .claude/.serena are local agent scratch/worktree directories. They may
+    // contain stale copies of this repo with their own tests and env assumptions;
+    // collecting them would poison the canonical gate with non-source artifacts.
+    exclude: ['e2e/**', '**/node_modules/**', 'dist/**', '.next/**', '.claude/**', '.serena/**', 'packages/**', 'apps/**', 'examples/**', 'receipt-required-pr-kit/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov', 'html'],


### PR DESCRIPTION
Your security cluster was built on a **pre-merge base** (`eb9427a`, 5 commits behind main) and overlapped files already fixed by the merged #237/#241/#242. A straight push would have reverted those. This PR **reconciles** the cluster onto current `main`.

## New hardening (net-new — main hadn't touched these)
- **Merkle v2**: strict, domain-separated, payload-bound leaf hashes, byte-identical across **JS / Python / Go**.
- **I-JSON canonical** enforced for Trust Receipt signed material in both **issuer** and **verifier** ports.
- **Drop-in gates** no longer credit self-asserted Class-A/quorum — assurance requires proof-backed pinned-approver evidence (`packages/gate`, `require-receipt`, `mcp-guard`); dist/drop-in/Eve regenerated.
- **`/api/trust/gate`** byte-enforced body limits.
- Real scoped creator **`@emilia-protocol/create-ep-app`** + a policy test (`public-npx-provenance.test.js`) that forbids bare unowned `npx` in docs.

## Reconciliation calls (main already had a reviewed fix → kept main's to avoid regressing merged work)
| File | Decision | Why |
|---|---|---|
| `packages/verify/federation.js` + `federation.test.js` + `operator2/verify-live.mjs` | **kept main (#237)** | Main already refuses receipt-supplied discovery, pins issuers, hardens SSRF/redirect — and is the more complete impl. |
| `app/api/v1/guarded/route.js` | **kept main's durable store (#241) + layered in your `missing_receipt_id` refusal** | Your in-memory `Set` is single-process only; main's Supabase-backed store is cross-pod fail-closed. Your missing-id check is a genuine add. |
| 5 `publish-*.yml` | **kept main (#242)** | Already OIDC + provenance. |
| `create-ep-app/index.js` + 2 docs | **took yours** | Your no-bare-npx policy is stricter; kept your scoped `@emilia-protocol/create-ep-app`. |

## Verified on the reconciled tree
- `npm test` → **4,571 passed**, 29 skipped; branch coverage **88.03%** (gate ≥88%)
- `npm run conformance` → **JS/Python/Go agree** across all suites (incl. Merkle v2)
- `npm run lint` clean · `node --test packages/verify/trust-receipt.test.js packages/issue/test.js` → **56/56** · `git diff --check` clean

## Residual (your note, unchanged)
Closes the code-fixable findings. Does **not** add a multi-witness transparency/consistency-proof layer — "operator cannot equivocate without an external witness" is still an architecture step.

## Excluded
Homepage/CF-1 (already shipped in #243), ~30 experimental `public/hero/*` assets.

⚠️ **Residual honesty flag:** the create-ep-app docs present `npx @emilia-protocol/create-ep-app` as working, but there's no publish workflow for it in this PR — publish the scoped package (or it 404s). Not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)