### PR TITLE
feat(gate): first-class CF-1 conformance harness + WYSIWYS copy honesty

### DIFF
--- a/app/fire-drill/cf-1/page.js
+++ b/app/fire-drill/cf-1/page.js
@@ -134,12 +134,14 @@ export default function CF1Page() {
               fontFamily: font.mono, fontSize: 12.5, lineHeight: 1.8, color: '#D6D3D1',
               background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)',
               borderRadius: 8, padding: 22, margin: '28px 0 0', overflowX: 'auto', whiteSpace: 'pre',
-            }}>{`node packages/gate/eg1.mjs   # prints "EG-1 Enforced" — the eight runtime checks`}</pre>
+            }}>{`node packages/gate/cf1.mjs   # prints "CF-1 Enforced" — the full firewall check set
+node packages/gate/eg1.mjs   # the eight EG-1 runtime checks alone`}</pre>
             <p style={{ ...styles.body, fontSize: 14, color: 'rgba(250,250,249,0.68)', maxWidth: 720, marginTop: 18 }}>
-              The dedicated wrong-authority and allow-all / deny-all negative checks are part of the
-              EMILIA Gate conformance suite. CF-1 is not a fraud score or a guarantee that the human
-              made a good decision. It proves the enforcement point exists, fails closed, and leaves
-              portable evidence.
+              CF-1 runs the eight EG-1 runtime checks plus three category checks — the action is
+              declared consequential, a gate pinned to the wrong authority cannot authorize, and the
+              allowed run emits reliance evidence that verifies offline. CF-1 is not a fraud score or a
+              guarantee that the human made a good decision. It proves the enforcement point exists,
+              fails closed, and leaves portable evidence.
             </p>
           </div>
         </section>

--- a/app/page.js
+++ b/app/page.js
@@ -67,7 +67,7 @@ const HOW_IT_WORKS = [
 // hidden in an EMILIA-integrated path. Each line names the attack it closes.
 const BINDINGS = [
   { n: '01', accent: color.green, label: 'Reject before mutation',   body: 'Consume must succeed before the write runs. An unauthorized action is stopped, not logged after the fact.' },
-  { n: '02', accent: color.blue,  label: 'Exact-action binding',     body: 'Action hash plus a WYSIWYS display hash close “signed the wrong thing” — the human signs the exact action they saw.' },
+  { n: '02', accent: color.blue,  label: 'Exact-action binding',     body: 'The receipt binds the action hash, and (with the experimental display-attestation profile) a hash of the rendered context — narrowing the “signed the wrong thing” gap between the bytes signed and what the approver saw.' },
   { n: '03', accent: color.gold,  label: 'Policy binding',           body: 'The receipt binds the policy content that was in force, not just a policy name or version label.' },
   { n: '04', accent: color.green, label: 'Authority binding',        body: 'Holding a credential is separate from holding permission to approve. The authority registry proves the signer was allowed to.' },
   { n: '05', accent: color.blue,  label: 'Class-A enforcement',      body: 'High-risk actions require a passkey / WebAuthn device signoff — or stronger. Weaker assurance fails closed.' },

--- a/packages/gate/cf1-conformance.js
+++ b/packages/gate/cf1-conformance.js
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * CF-1 Consequence Firewall Conformance — the category badge above EG-1.
+ *
+ * EG-1 answers "does this integration ENFORCE the gate?" (eight runtime checks).
+ * CF-1 answers the category question "is this a Consequence Firewall?" — EG-1's
+ * eight checks PLUS the three that make the category claim honest:
+ *
+ *   - consequential_action_declared: the action is declared high-risk /
+ *     receipt-required by policy or manifest, not gated only by default-deny.
+ *   - wrong_authority_refused: a gate pinned to the WRONG issuer key cannot be
+ *     talked into authorizing — trust is pinned by the relying party, never
+ *     taken from the receipt-carried signer.
+ *   - evidence_verifies_offline: an allowed run emits a reliance packet a third
+ *     party can verify offline (verdict "rely" + the execution proof binds the
+ *     authorization decision, recomputable without trusting the operator).
+ *
+ * Pure module: composes eg1-conformance.js only (no import of index.js, so no
+ * cycle). `runCf1` is param-driven (an `invoke` for the gate under test, a
+ * `wrongInvoke` for a sibling gate pinned to the wrong key, the harness, and the
+ * resolved manifest requirement). `cf1Conformance` / `cf1ConformanceSelfTest`
+ * in index.js wire real gates to it.
+ */
+import { EG1_CHECKS, runEg1 } from './eg1-conformance.js';
+
+export const CF1_VERSION = 'CF-1';
+
+// The nine CF-1 checks: the declaration bookend, the eight EG-1 runtime checks,
+// then the two that distinguish a firewall from an enforced gate.
+export const CF1_CHECKS = Object.freeze([
+  { id: 'consequential_action_declared', title: 'action declared consequential (receipt required by policy/manifest)' },
+  ...EG1_CHECKS.map((c) => ({ id: c.id, title: c.title })),
+  { id: 'wrong_authority_refused', title: 'gate pinned to the wrong authority cannot authorize' },
+  { id: 'evidence_verifies_offline', title: 'allowed run emits reliance evidence verifiable offline' },
+]);
+
+/**
+ * Drive a subject through the CF-1 checks and return a JSON report.
+ * @param {object} o
+ * @param {(scenario:object)=>Promise<object>} o.invoke   the gate under test
+ * @param {(scenario:object)=>Promise<object>} [o.wrongInvoke] a sibling gate pinned to a DIFFERENT (wrong) issuer key
+ * @param {object} o.harness      from createEg1Harness()
+ * @param {object} [o.action]     the high-risk action (defaults to the harness action)
+ * @param {object} [o.requirement] the manifest requirement resolved for this action (findActionRequirement)
+ */
+export async function runCf1({ invoke, wrongInvoke, harness, action, requirement } = {}) {
+  if (typeof invoke !== 'function') throw new Error('runCf1 requires an invoke(scenario) function');
+  if (!harness || typeof harness.mint !== 'function') throw new Error('runCf1 requires a harness from createEg1Harness()');
+  const act = action || harness.action;
+
+  // The eight EG-1 runtime checks (missing / weak-assurance / execution-drift /
+  // valid-runs / replay / tamper / execution-proof / reliance-packet).
+  const eg1 = await runEg1({ invoke, harness, action: act });
+  const results = {};
+  for (const c of eg1.checks) results[c.id] = { pass: c.pass, observed: c.observed };
+
+  // consequential_action_declared — policy/manifest classifies the action as
+  // requiring a receipt (not merely caught by a default-deny fallback).
+  results.consequential_action_declared = {
+    pass: requirement ? requirement.receipt_required === true : false,
+    observed: {
+      receipt_required: requirement?.receipt_required ?? null,
+      assurance_class: requirement?.assurance_class ?? null,
+      action_type: requirement?.action_type ?? null,
+    },
+  };
+
+  // wrong_authority_refused — a gate pinned to a different key rejects a valid
+  // receipt. Proves trust is pinned by the relying party, not receipt-carried.
+  let wrongPass = false;
+  let wrongObserved = { skipped: true };
+  if (typeof wrongInvoke === 'function') {
+    const rr = await wrongInvoke({ receipt: harness.mint({ outcome: 'allow_with_signoff' }), observedAction: act });
+    wrongPass = rr.allowed === false;
+    wrongObserved = { allowed: !!rr.allowed, status: rr.status ?? null, reason: rr.reason ?? null };
+  }
+  results.wrong_authority_refused = { pass: wrongPass, observed: wrongObserved };
+
+  // evidence_verifies_offline — a fresh valid run yields a "rely" reliance
+  // packet whose execution proof binds the authorization decision. A third
+  // party recomputes that binding offline; no operator trust required.
+  const vr = await invoke({ receipt: harness.mint({ outcome: 'allow_with_signoff' }), observedAction: act });
+  const binds = !!vr.execution?.authorizes_decision && !!vr.decisionHash
+    && vr.execution.authorizes_decision === vr.decisionHash;
+  const offlineOk = vr.allowed === true
+    && String(vr.packet?.verdict || '').toLowerCase() === 'rely'
+    && binds;
+  results.evidence_verifies_offline = {
+    pass: offlineOk,
+    observed: { allowed: !!vr.allowed, verdict: vr.packet?.verdict ?? null, binds },
+  };
+
+  const checks = CF1_CHECKS.map((c) => ({ id: c.id, title: c.title, ...results[c.id] }));
+  const passedCount = checks.filter((c) => c.pass).length;
+  const passed = passedCount === checks.length;
+  return {
+    standard: CF1_VERSION,
+    passed,
+    badge: passed ? 'CF-1 Enforced' : 'CF-1 not earned',
+    summary: { passed: passedCount, total: checks.length },
+    eg1: { passed: eg1.passed, summary: eg1.summary },
+    checks,
+    generated_at: new Date(harness.now ? harness.now() : Date.now()).toISOString(),
+  };
+}
+
+export default { CF1_VERSION, CF1_CHECKS, runCf1 };

--- a/packages/gate/cf1.mjs
+++ b/packages/gate/cf1.mjs
@@ -1,0 +1,45 @@
+/**
+ * CF-1 Consequence Firewall Conformance — runnable proof. Run: node cf1.mjs [--json]
+ *
+ * Self-certifies the reference EMILIA Gate against the CF-1 checks: the eight
+ * EG-1 runtime checks plus the three category checks (action declared
+ * consequential, wrong-authority refused, evidence verifiable offline).
+ *
+ * An adopter earns CF-1 by pointing this at THEIR integration: build your gate
+ * trusting `harness.publicKey`, a sibling gate trusting a different key, and
+ * pass both to cf1Conformance():
+ *
+ *   import { createEg1Harness, cf1Conformance, createTrustedActionFirewall,
+ *            createDefaultActionRiskManifest } from '@emilia-protocol/gate';
+ *   const harness = createEg1Harness();
+ *   const gate = createTrustedActionFirewall({ trustedKeys: [harness.publicKey] });
+ *   const wrongGate = createTrustedActionFirewall({ trustedKeys: [createEg1Harness().publicKey] });
+ *   const report = await cf1Conformance({ gate, wrongGate, harness, manifest: createDefaultActionRiskManifest() });
+ *
+ * Exit code is 0 only if all checks pass — CI-friendly.
+ * @license Apache-2.0
+ */
+import { cf1ConformanceSelfTest } from './index.js';
+
+const report = await cf1ConformanceSelfTest();
+
+if (process.argv.includes('--json')) {
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(report, null, 2));
+  process.exit(report.passed ? 0 : 1);
+}
+
+const G = (s) => `\x1b[32m${s}\x1b[0m`;
+const R = (s) => `\x1b[31m${s}\x1b[0m`;
+const line = (s) => console.log(s);
+
+line('='.repeat(66));
+line('  CF-1 Conformance — is this integration a Consequence Firewall?');
+line('='.repeat(66));
+for (const c of report.checks) {
+  line(`  ${c.pass ? G('PASS') : R('FAIL')}  ${c.title}`);
+}
+line('  ' + '-'.repeat(62));
+line(`  ${report.passed ? G(`✓ ${report.badge}`) : R(`✗ ${report.badge}`)}  (${report.summary.passed}/${report.summary.total})`);
+line('='.repeat(66));
+process.exit(report.passed ? 0 : 1);

--- a/packages/gate/cf1.test.js
+++ b/packages/gate/cf1.test.js
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createTrustedActionFirewall,
+  createDefaultActionRiskManifest,
+  createEg1Harness,
+  cf1Conformance,
+  cf1ConformanceSelfTest,
+  CF1_CHECKS,
+  EG1_DEFAULT_SELECTOR,
+} from './index.js';
+
+test('CF-1: the reference gate self-certifies (all checks pass)', async () => {
+  const report = await cf1ConformanceSelfTest();
+  assert.equal(report.standard, 'CF-1');
+  assert.equal(report.passed, true, JSON.stringify(report.checks.filter((c) => !c.pass), null, 2));
+  assert.equal(report.badge, 'CF-1 Enforced');
+  assert.equal(report.summary.passed, CF1_CHECKS.length);
+  for (const c of report.checks) assert.equal(c.pass, true, `check failed: ${c.id}`);
+});
+
+test('CF-1: report enumerates every defined check exactly once', async () => {
+  const report = await cf1ConformanceSelfTest();
+  const ids = report.checks.map((c) => c.id).sort();
+  assert.deepEqual(ids, CF1_CHECKS.map((c) => c.id).sort());
+});
+
+test('CF-1: includes the three category checks beyond EG-1', async () => {
+  const ids = CF1_CHECKS.map((c) => c.id);
+  for (const id of ['consequential_action_declared', 'wrong_authority_refused', 'evidence_verifies_offline']) {
+    assert.ok(ids.includes(id), `CF-1 must define ${id}`);
+  }
+});
+
+test('CF-1: a gate that trusts the WRONG authority cannot earn the badge', async () => {
+  const harness = createEg1Harness();
+  const manifest = createDefaultActionRiskManifest();
+  // The gate under test trusts the WRONG key → every valid receipt is rejected.
+  const wrongHarness = createEg1Harness();
+  const gate = createTrustedActionFirewall({ trustedKeys: [wrongHarness.publicKey], approverKeys: wrongHarness.approverKeys });
+  const report = await cf1Conformance({ gate, harness, manifest, selector: EG1_DEFAULT_SELECTOR, action: harness.action });
+  assert.equal(report.passed, false);
+  const byId = Object.fromEntries(report.checks.map((c) => [c.id, c]));
+  // A wrong-trust gate refuses the valid receipt → valid_classA_runs fails.
+  assert.equal(byId.valid_classA_runs.pass, false);
+});
+
+test('CF-1: an action the manifest does not declare consequential fails the declaration check', async () => {
+  const harness = createEg1Harness();
+  const manifest = createDefaultActionRiskManifest();
+  const gate = createTrustedActionFirewall({ trustedKeys: [harness.publicKey], approverKeys: harness.approverKeys });
+  const wrongHarness = createEg1Harness();
+  const wrongGate = createTrustedActionFirewall({ trustedKeys: [wrongHarness.publicKey], approverKeys: wrongHarness.approverKeys });
+  // A selector the default manifest does not guard → no requirement resolved.
+  const report = await cf1Conformance({
+    gate, wrongGate, harness, manifest,
+    selector: { protocol: 'mcp', tool: 'not_a_declared_action' },
+    action: harness.action,
+  });
+  const byId = Object.fromEntries(report.checks.map((c) => [c.id, c]));
+  assert.equal(byId.consequential_action_declared.pass, false);
+});

--- a/packages/gate/index.js
+++ b/packages/gate/index.js
@@ -38,6 +38,7 @@ import { DEFAULT_GATE_MANIFEST, HIGH_RISK_ACTION_PACKS, createDefaultActionRiskM
 import { hashCanonical, verifyExecutionBinding } from './execution-binding.js';
 import { buildReliancePacket } from './reliance-packet.js';
 import { createEg1Harness, makeGateInvoke, runEg1, EG1_DEFAULT_SELECTOR } from './eg1-conformance.js';
+import { CF1_VERSION, CF1_CHECKS, runCf1 } from './cf1-conformance.js';
 import { createKeyRegistry, asKeyRegistry } from './key-registry.js';
 import { classifyRetention, buildRetentionExport } from './retention.js';
 
@@ -52,6 +53,7 @@ export {
   EG1_VERSION, EG1_CHECKS, EG1_DEFAULT_ACTION, EG1_DEFAULT_SELECTOR,
   createEg1Harness, makeGateInvoke, runEg1,
 } from './eg1-conformance.js';
+export { CF1_VERSION, CF1_CHECKS, runCf1 } from './cf1-conformance.js';
 export const ASSURANCE_TIERS = ['software', 'class_a', 'quorum'];
 const TIER_RANK = { software: 0, class_a: 1, quorum: 2 };
 
@@ -385,6 +387,48 @@ export async function gateConformanceSelfTest({ now } = {}) {
   return gateConformance({ gate, harness });
 }
 
+/**
+ * CF-1 (Consequence Firewall) conformance for an existing gate. Runs the eight
+ * EG-1 runtime checks plus the three CF-1 category checks: the action is
+ * declared consequential by the manifest, a gate pinned to the WRONG issuer key
+ * refuses a valid receipt, and the allowed run emits offline-verifiable reliance
+ * evidence. The `gate` MUST trust `harness.publicKey`; `wrongGate` MUST trust a
+ * DIFFERENT key (otherwise wrong_authority_refused cannot be demonstrated).
+ * @param {object} o
+ * @param {object} o.gate       an EMILIA Gate trusting harness.publicKey
+ * @param {object} [o.wrongGate] a sibling gate trusting a different (wrong) key
+ * @param {object} o.harness    from createEg1Harness()
+ * @param {object} [o.manifest] the action-risk manifest (to resolve the requirement)
+ * @param {object} [o.selector] the manifest selector for the action
+ * @param {object} [o.action]   the high-risk action to exercise
+ */
+export async function cf1Conformance({ gate, wrongGate, harness, manifest = null, selector = EG1_DEFAULT_SELECTOR, action } = {}) {
+  if (!gate || typeof gate.run !== 'function') throw new Error('cf1Conformance requires a gate built trusting harness.publicKey');
+  if (!harness) throw new Error('cf1Conformance requires the harness whose key the gate trusts');
+  const act = action || harness.action;
+  const invoke = makeGateInvoke(gate, { selector, action: act });
+  const wrongInvoke = (wrongGate && typeof wrongGate.run === 'function')
+    ? makeGateInvoke(wrongGate, { selector, action: act }) : undefined;
+  const requirement = manifest ? findActionRequirement(manifest, selector) : null;
+  return runCf1({ invoke, wrongInvoke, harness, action: act, requirement });
+}
+
+/**
+ * Self-certify the reference gate against CF-1: a default Trusted Action
+ * Firewall trusting a fresh harness key, a sibling firewall trusting a DIFFERENT
+ * key (for wrong_authority_refused), and the default action-risk manifest (for
+ * consequential_action_declared). The canonical "reference gate earns CF-1"
+ * proof — runnable as a CLI (`cf1.mjs`).
+ */
+export async function cf1ConformanceSelfTest({ now } = {}) {
+  const harness = createEg1Harness({ now });
+  const manifest = createDefaultActionRiskManifest();
+  const gate = createTrustedActionFirewall({ trustedKeys: [harness.publicKey], approverKeys: harness.approverKeys, now });
+  const wrongHarness = createEg1Harness({ now });
+  const wrongGate = createTrustedActionFirewall({ trustedKeys: [wrongHarness.publicKey], approverKeys: wrongHarness.approverKeys, now });
+  return cf1Conformance({ gate, wrongGate, harness, manifest, selector: EG1_DEFAULT_SELECTOR, action: harness.action });
+}
+
 export default {
   createGate,
   createTrustedActionFirewall,
@@ -396,6 +440,11 @@ export default {
   HIGH_RISK_ACTION_PACKS,
   gateConformance,
   gateConformanceSelfTest,
+  cf1Conformance,
+  cf1ConformanceSelfTest,
+  CF1_VERSION,
+  CF1_CHECKS,
+  runCf1,
   createEg1Harness,
   runEg1,
   createKeyRegistry,


### PR DESCRIPTION
Closes gaps #2 (CF-1 harness) and #5 (WYSIWYS overclaim) from the productization review. Gaps #1 (manifest v0.2) and #4 (JSON schema) are handled in parallel in the main checkout (`action-control-manifest.js`) — this PR deliberately does **not** touch them. RR-2/RR-3 (#3) declined as badge sprawl (folded into CF-1; RR-1 stays the entry rail).

## CF-1 harness (`@emilia-protocol/gate`)
- `runCf1()` + `cf1Conformance({gate, wrongGate, harness, manifest})` + `cf1ConformanceSelfTest()` — the eight EG-1 runtime checks **plus** three category checks: `consequential_action_declared`, `wrong_authority_refused`, `evidence_verifies_offline`.
- `cf1.mjs` runnable CLI → **CF-1 Enforced 11/11**, CI exit code.
- `/fire-drill/cf-1` reference-proof now points at the runnable harness.

## WYSIWYS honesty
Homepage binding 02 softened to "binds the action hash + (experimental) rendered-context hash, **narrowing** the gap" — matches `EP-WYSIWYS-SPEC`'s experimental status.

## Verified
- `node packages/gate/cf1.mjs` → 11/11 CF-1 Enforced
- `node --test` gate + eg1 + cf1 → **27/27**
- `vitest` public-claims + homepage-category → **22/22**
- `next lint` clean · `next build` OK

## Coordination
Only `packages/gate/index.js` overlaps the parallel action-control work (additive export block) — trivial merge when that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)