### PR TITLE
fix: make npm artifacts reproducible across checkouts

### DIFF
--- a/docs/operations/NPM-PUBLISH-CHECKLIST.md
+++ b/docs/operations/NPM-PUBLISH-CHECKLIST.md
@@ -133,6 +133,7 @@ comparison. A pushed tag never starts a package publication workflow.
 
 - tested npm tarball or Python wheel and source distribution;
 - SHA-256/reproducibility manifest;
+- canonical npm file modes (`0644` for regular files, `0755` for declared package binaries);
 - `security/security-case.json`;
 - `conformance/conformance-manifest.json`;
 - GitHub artifact attestations bound to the workflow identity and source ref;

--- a/scripts/verify-reproducible-package.mjs
+++ b/scripts/verify-reproducible-package.mjs
@@ -26,15 +26,15 @@ export function verifyReproduciblePackage(packagePath = 'packages/verify', { out
   const packageDir = path.resolve(ROOT, packagePath);
   const packageJsonPath = path.join(packageDir, 'package.json');
   if (!fs.existsSync(packageJsonPath)) throw new Error(`package.json not found: ${packageJsonPath}`);
+  const metadata = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
   const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'ep-repro-pack-'));
+  const packEnv = { ...process.env, npm_config_ignore_scripts: 'true' };
 
-  function pack(label) {
-    const destination = path.join(scratch, label);
-    fs.mkdirSync(destination);
-    const run = spawnSync(npm, ['pack', packageDir, '--json', '--pack-destination', destination], {
+  function runPack(args, label) {
+    const run = spawnSync(npm, ['pack', ...args, '--json'], {
       cwd: ROOT,
       encoding: 'utf8',
-      env: { ...process.env, npm_config_ignore_scripts: 'true' },
+      env: packEnv,
     });
     if (run.status !== 0) {
       throw new Error(`npm pack ${label} failed:\n${run.stderr || run.stdout}`);
@@ -48,24 +48,62 @@ export function verifyReproduciblePackage(packagePath = 'packages/verify', { out
     if (!Array.isArray(report) || report.length !== 1 || typeof report[0].filename !== 'string') {
       throw new Error(`npm pack ${label} returned an unexpected report`);
     }
-    const bytes = fs.readFileSync(path.join(destination, report[0].filename));
+    return report[0];
+  }
+
+  function stageCanonicalPackage() {
+    const inventory = runPack([packageDir, '--dry-run'], 'inventory');
+    const stage = path.join(scratch, 'canonical-input');
+    const binValues = typeof metadata.bin === 'string'
+      ? [metadata.bin]
+      : metadata.bin && typeof metadata.bin === 'object'
+        ? Object.values(metadata.bin)
+        : [];
+    const executablePaths = new Set(binValues.map((value) => String(value).replace(/^\.\//, '')));
+    fs.mkdirSync(stage, { recursive: true, mode: 0o755 });
+    for (const entry of inventory.files || []) {
+      if (!entry || typeof entry.path !== 'string' || path.isAbsolute(entry.path)) {
+        throw new Error('npm pack inventory contains a malformed path');
+      }
+      const relative = entry.path.split('/').join(path.sep);
+      const source = path.resolve(packageDir, relative);
+      if (!source.startsWith(`${packageDir}${path.sep}`)) {
+        throw new Error(`npm pack inventory escapes package root: ${entry.path}`);
+      }
+      const sourceStat = fs.lstatSync(source);
+      if (!sourceStat.isFile()) {
+        throw new Error(`npm pack inventory requires a regular file: ${entry.path}`);
+      }
+      const target = path.join(stage, relative);
+      fs.mkdirSync(path.dirname(target), { recursive: true, mode: 0o755 });
+      fs.copyFileSync(source, target);
+      fs.chmodSync(target, executablePaths.has(entry.path) ? 0o755 : 0o644);
+    }
+    return stage;
+  }
+
+  function pack(packageInput, label) {
+    const destination = path.join(scratch, label);
+    fs.mkdirSync(destination);
+    const report = runPack([packageInput, '--pack-destination', destination], label);
+    const bytes = fs.readFileSync(path.join(destination, report.filename));
     return {
       bytes,
-      filename: report[0].filename,
-      files: (report[0].files || []).map((entry) => `${entry.path}:${entry.size}`).sort(),
+      filename: report.filename,
+      files: (report.files || []).map((entry) => `${entry.path}:${entry.size}:${entry.mode}`).sort(),
       sha256: crypto.createHash('sha256').update(bytes).digest('hex'),
     };
   }
 
   try {
-    const first = pack('first');
-    const second = pack('second');
+    const canonicalInput = stageCanonicalPackage();
+    const first = pack(canonicalInput, 'first');
+    const second = pack(canonicalInput, 'second');
     if (first.filename !== second.filename) throw new Error('pack filenames differ');
     if (JSON.stringify(first.files) !== JSON.stringify(second.files)) throw new Error('pack file manifests differ');
     if (!first.bytes.equals(second.bytes)) {
       throw new Error(`package bytes differ: ${first.sha256} != ${second.sha256}`);
     }
-    const metadata = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
     let artifactPath = null;
     if (outDir) {
       const destination = path.resolve(ROOT, outDir);

--- a/security/claims.v1.json
+++ b/security/claims.v1.json
@@ -346,7 +346,7 @@
     },
     {
       "claim_id": "verify-package-is-byte-reproducible",
-      "statement": "The verify SDK packs twice to byte-identical tarballs, and the publish workflow attests and publishes that exact tarball before comparing the registry copy byte-for-byte.",
+      "statement": "The verify SDK canonicalizes package file modes, packs twice to byte-identical tarballs, and the publish workflow attests and publishes that exact tarball before comparing the registry copy byte-for-byte.",
       "acceptance_roots": ["GitHub Actions OIDC identity", "npm trusted-publisher configuration", "pinned GitHub Actions revisions"],
       "enforcement_path": [
         { "language": "javascript", "file": "scripts/verify-reproducible-package.mjs", "symbol": "verifyReproduciblePackage", "exported": true },
@@ -366,6 +366,7 @@
       ],
       "tests": [
         { "file": "tests/release-reproducibility.test.js", "title": "packs @emilia-protocol/verify twice to byte-identical tarballs", "runner": "vitest" },
+        { "file": "tests/release-reproducibility.test.js", "title": "normalizes source file modes across independent package checkouts", "runner": "vitest" },
         { "file": "tests/release-reproducibility.test.js", "title": "rejects a one-byte registry artifact substitution", "runner": "vitest" }
       ],
       "operational_evidence": [

--- a/security/security-case.json
+++ b/security/security-case.json
@@ -1,7 +1,7 @@
 {
   "@version": "EP-SECURITY-CASE-RESOLVED-v2",
   "source": "security/claims.v1.json",
-  "evidence_bundle_sha256": "be7a930a686096e4046567e4fda4dc12fccf0f54fca5527a05bfb3ef14ddaf9e",
+  "evidence_bundle_sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c",
   "claim_count": 13,
   "evidence_file_count": 62,
   "execution": {
@@ -189,6 +189,7 @@
           "accepts a PyPI sdist only when every published byte matches",
           "accepts a PyPI wheel only when every published byte matches",
           "accepts a registry artifact only when every published byte matches",
+          "normalizes source file modes across independent package checkouts",
           "packs @emilia-protocol/verify twice to byte-identical tarballs",
           "rejects a one-byte PyPI sdist substitution",
           "rejects a one-byte PyPI wheel substitution",
@@ -224,7 +225,7 @@
     "security-evidence": {
       "kind": "content-addressed-evidence-bundle",
       "filename": "security-case-evidence.v1",
-      "sha256": "be7a930a686096e4046567e4fda4dc12fccf0f54fca5527a05bfb3ef14ddaf9e",
+      "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c",
       "file_count": 62
     },
     "verify-sdk": {
@@ -341,7 +342,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "be7a930a686096e4046567e4fda4dc12fccf0f54fca5527a05bfb3ef14ddaf9e"
+          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
         }
       ]
     },
@@ -463,7 +464,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "be7a930a686096e4046567e4fda4dc12fccf0f54fca5527a05bfb3ef14ddaf9e"
+          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
         }
       ]
     },
@@ -607,7 +608,7 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "security-evidence",
-          "sha256": "be7a930a686096e4046567e4fda4dc12fccf0f54fca5527a05bfb3ef14ddaf9e"
+          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
         }
       ]
     },
@@ -753,7 +754,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "be7a930a686096e4046567e4fda4dc12fccf0f54fca5527a05bfb3ef14ddaf9e"
+          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
         }
       ]
     },
@@ -862,7 +863,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "be7a930a686096e4046567e4fda4dc12fccf0f54fca5527a05bfb3ef14ddaf9e"
+          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
         }
       ]
     },
@@ -971,7 +972,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "be7a930a686096e4046567e4fda4dc12fccf0f54fca5527a05bfb3ef14ddaf9e"
+          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
         }
       ]
     },
@@ -1103,7 +1104,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "be7a930a686096e4046567e4fda4dc12fccf0f54fca5527a05bfb3ef14ddaf9e"
+          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
         }
       ]
     },
@@ -1210,7 +1211,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "be7a930a686096e4046567e4fda4dc12fccf0f54fca5527a05bfb3ef14ddaf9e"
+          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
         }
       ]
     },
@@ -1313,7 +1314,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "be7a930a686096e4046567e4fda4dc12fccf0f54fca5527a05bfb3ef14ddaf9e"
+          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
         }
       ]
     },
@@ -1447,13 +1448,13 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "security-evidence",
-          "sha256": "be7a930a686096e4046567e4fda4dc12fccf0f54fca5527a05bfb3ef14ddaf9e"
+          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
         }
       ]
     },
     {
       "claim_id": "verify-package-is-byte-reproducible",
-      "statement": "The verify SDK packs twice to byte-identical tarballs, and the publish workflow attests and publishes that exact tarball before comparing the registry copy byte-for-byte.",
+      "statement": "The verify SDK canonicalizes package file modes, packs twice to byte-identical tarballs, and the publish workflow attests and publishes that exact tarball before comparing the registry copy byte-for-byte.",
       "acceptance_roots": [
         "GitHub Actions OIDC identity",
         "npm trusted-publisher configuration",
@@ -1520,6 +1521,11 @@
         },
         {
           "file": "tests/release-reproducibility.test.js",
+          "title": "normalizes source file modes across independent package checkouts",
+          "runner": "vitest"
+        },
+        {
+          "file": "tests/release-reproducibility.test.js",
           "title": "rejects a one-byte registry artifact substitution",
           "runner": "vitest"
         }
@@ -1558,7 +1564,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "be7a930a686096e4046567e4fda4dc12fccf0f54fca5527a05bfb3ef14ddaf9e"
+          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
         }
       ]
     },
@@ -1692,7 +1698,7 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "security-evidence",
-          "sha256": "be7a930a686096e4046567e4fda4dc12fccf0f54fca5527a05bfb3ef14ddaf9e"
+          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
         }
       ]
     },
@@ -1944,7 +1950,7 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "security-evidence",
-          "sha256": "be7a930a686096e4046567e4fda4dc12fccf0f54fca5527a05bfb3ef14ddaf9e"
+          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
         }
       ]
     }
@@ -2152,7 +2158,7 @@
     },
     {
       "path": "scripts/verify-reproducible-package.mjs",
-      "sha256": "6b4604555e6968beac82cca563522699e11846eea567c75636b83b232c2f0362"
+      "sha256": "8ecab8e057e95dfcdb2451196f712d38eb2379538b3653fa0af0d08465faf841"
     },
     {
       "path": "scripts/verify-reproducible-wheel.mjs",
@@ -2164,7 +2170,7 @@
     },
     {
       "path": "security/claims.v1.json",
-      "sha256": "37e33d1266741bc7ead4798c8c4c4ca9472d5739ae838fe98f5bab3e72683373"
+      "sha256": "74f9a695512f04a076fff0ccd396d8f4508ff9110e3b3d3b00ca3ede517bccd5"
     },
     {
       "path": "security/vectors.v1.json",
@@ -2192,7 +2198,7 @@
     },
     {
       "path": "tests/release-reproducibility.test.js",
-      "sha256": "718443bbc7a524fd06a38ba5cb77864ac93da0ce0bb61ddd1f82192b4c5f1f6a"
+      "sha256": "63e7bab42d6d671c2bee2dd0a462bc959218dd7686a4f6da69878704da479571"
     },
     {
       "path": "tests/reliance-kernel.test.js",

--- a/tests/release-reproducibility.test.js
+++ b/tests/release-reproducibility.test.js
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { assertArtifactBytesMatch, verifyReproduciblePackage } from '../scripts/verify-reproducible-package.mjs';
 import { assertPythonArtifactBytesMatch } from '../scripts/python-artifact-integrity.mjs';
 
@@ -11,6 +13,36 @@ describe('release byte reproducibility', () => {
     expect(result.filename).toBe(`emilia-protocol-verify-${result.version}.tgz`);
     expect(result.sha256).toMatch(/^[0-9a-f]{64}$/);
     expect(result.fileCount).toBeGreaterThan(0);
+  });
+
+  it('normalizes source file modes across independent package checkouts', () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'ep-pack-modes-'));
+    const makePackage = (name, sourceMode, binMode) => {
+      const target = path.join(root, name);
+      mkdirSync(target);
+      writeFileSync(path.join(target, 'package.json'), JSON.stringify({
+        name: 'mode-stability-fixture',
+        version: '1.0.0',
+        files: ['index.js', 'cli.js'],
+        bin: { fixture: 'cli.js' },
+      }));
+      writeFileSync(path.join(target, 'index.js'), 'export const value = 1;\n');
+      writeFileSync(path.join(target, 'cli.js'), '#!/usr/bin/env node\nconsole.log("ok");\n');
+      chmodSync(path.join(target, 'index.js'), sourceMode);
+      chmodSync(path.join(target, 'cli.js'), binMode);
+      return target;
+    };
+    try {
+      const restricted = makePackage('restricted', 0o600, 0o700);
+      const conventional = makePackage('conventional', 0o644, 0o755);
+      const first = verifyReproduciblePackage(restricted);
+      const second = verifyReproduciblePackage(conventional);
+      expect(first.sha256).toBe(second.sha256);
+      expect(statSync(path.join(restricted, 'index.js')).mode & 0o777).toBe(0o600);
+      expect(statSync(path.join(restricted, 'cli.js')).mode & 0o777).toBe(0o700);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('accepts a registry artifact only when every published byte matches', () => {


### PR DESCRIPTION
## Finding

The merged-main A+ completion audit built the TypeScript SDK from the same Git tree in two independent worktrees. Each worktree packed twice reproducibly, but the cross-worktree tarballs differed because two source files were mode `0600` in one checkout and `0644` in the other. The old same-worktree test could not detect that false green.

## Fix

- inventory npm's exact declared package files with scripts disabled;
- copy only those files into a temporary canonical staging tree;
- normalize regular files to `0644` and declared `bin` targets to `0755`;
- reject path escapes, symlinks, and non-regular inventory entries;
- pack the canonical staging tree twice;
- bind file modes into the reproducibility manifest;
- add a regression that builds byte-identical packages under conflicting source modes and requires identical tarballs without mutating either source checkout.

## Verified

- cross-worktree TypeScript SDK: identical `sha256:89caa26e696e47167b3149655c83d36d77e11011560e3a7a5ba7c9d20da729d1`;
- all seven npm packages reproduce under canonical staging;
- 18 focused release-control tests pass;
- security case: 13 executable claims, 62 hashed evidence files, execution passed;
- release-chain inventory: 10/10 packages pass;
- no registry publication or package tag created.
