### PR TITLE
fix: eliminate manual npm publish fallback

### DIFF
--- a/docs/operations/CREDENTIAL-ROTATION-CHECKLIST.md
+++ b/docs/operations/CREDENTIAL-ROTATION-CHECKLIST.md
@@ -54,7 +54,7 @@ identify which credential to revoke.
 
 ---
 
-## 2. npm token
+## 2. npm write credentials
 
 **Leaked value:** redacted — appears in the 2026-04-26 conversation
 transcript inside an `.npmrc` paste during the
@@ -63,37 +63,35 @@ transcript inside an `.npmrc` paste during the
 the most recent classic token in your account.
 **Scope:** `@emilia-protocol/*` packages
 
+Package publication uses GitHub Actions OIDC trusted publishing and the
+owner-approved workflow described in `NPM-PUBLISH-CHECKLIST.md`. A local or CI
+write token is not a supported fallback.
+
 ### Steps
 1. Open https://www.npmjs.com/settings/emiliaprotocol/tokens
-2. Identify the leaked token by its creation date (around the 1.0.0
-   publish on 2026-04-26) or by checking your local `~/.npmrc` for
-   the `_authToken=` value, then matching that prefix on the dashboard.
-3. Click "Revoke" → confirm.
-4. Create a fresh **Granular Access Token** (NOT a classic token):
-   - Name: `emilia-protocol-publish-2026-q2`
-   - Expiration: 90 days
-   - Permissions:
-     - Packages: `@emilia-protocol/*` → Read and write
-     - Organization: `emilia-protocol` → Read only
-   - IP allowlist: leave empty (you publish from variable IPs)
-   - 2FA: required for publish (already set)
-5. Save the new token in 1Password under "EMILIA Protocol — npm".
-6. If your local `~/.npmrc` has the leaked token, update it:
+2. Identify the leaked token by its creation date (around the 1.0.0 publish on
+   2026-04-26). Also identify every other active token with package-write or
+   organization-write permission; trusted publishing makes those credentials
+   unnecessary for releases.
+3. Revoke the leaked token and every unneeded write-capable token. Do not create
+   a replacement publish token.
+4. Remove any registry token from the user npm configuration:
    ```bash
-   # Confirm what's there
-   grep '^//registry.npmjs.org' ~/.npmrc
-   # Replace with the new token
-   npm login --scope=@emilia-protocol --auth-type=web
-   # OR manually:
-   echo "//registry.npmjs.org/:_authToken=NEW_TOKEN_VALUE" >> ~/.npmrc
+   npm config delete //registry.npmjs.org/:_authToken --location=user
    ```
+5. Read back all seven package trusted-publisher mappings with the commands in
+   `NPM-PUBLISH-CHECKLIST.md`. Use interactive web authentication for account
+   administration; never persist a package-write token for publication.
+6. Confirm repository and CI secrets do not contain `NPM_TOKEN` or another npm
+   registry write credential. A broken OIDC relationship must fail closed.
 
 ### Confirm done
 - [ ] Old token revoked on npmjs.com
-- [ ] New granular token created with 90-day expiry
-- [ ] New token stored in password manager
-- [ ] Local `~/.npmrc` updated
-- [ ] Test: `npm whoami` returns `emiliaprotocol`
+- [ ] All unneeded package/org write tokens revoked
+- [x] No replacement publish token created
+- [x] Local `~/.npmrc` contains no registry auth token (verified 2026-07-10)
+- [x] All seven OIDC trusted-publisher mappings read back correctly (verified 2026-07-10)
+- [x] No npm write credential is stored in GitHub Actions or Vercel (verified 2026-07-10)
 - [ ] Mark this checklist complete in the next commit message
 
 ---
@@ -102,7 +100,8 @@ the most recent classic token in your account.
 
 Send a one-line confirmation in our next message:
 
-> "Rotated DB password and npm token; old credentials revoked."
+> "Rotated the DB password; revoked npm write credentials and removed the local
+> token fallback."
 
 That's the verification step that closes the audit finding.
 

--- a/scripts/check-release-chain.mjs
+++ b/scripts/check-release-chain.mjs
@@ -63,6 +63,22 @@ export function validateReusableNpmWorkflowText(text) {
   return true;
 }
 
+export function validateCredentialRotationGuideText(text) {
+  const normalized = text.replace(/\s+/g, ' ');
+  requireText(normalized, [
+    'A local or CI write token is not a supported fallback.',
+    'Do not create a replacement publish token.',
+    "npm config delete //registry.npmjs.org/:_authToken --location=user",
+    'A broken OIDC relationship must fail closed.',
+  ], 'credential rotation guide');
+  if (/Create a fresh[^\n]*Access Token/i.test(text)
+    || /_authToken=NEW_TOKEN/i.test(text)
+    || /New granular token created/i.test(text)) {
+    throw new Error('credential rotation guide reintroduces a publication-token fallback');
+  }
+  return true;
+}
+
 function validateNpmDirect(text, label) {
   requireText(text, [
     'npm run security-case:emit',
@@ -107,6 +123,10 @@ export function auditReleaseChain(root = ROOT) {
   }
   const pythonReadme = fs.readFileSync(path.join(root, 'packages/python-verify/README.md'), 'utf8');
   if (/\btwine\s+upload\b/.test(pythonReadme)) throw new Error('direct local PyPI upload instructions are forbidden');
+  validateCredentialRotationGuideText(fs.readFileSync(
+    path.join(root, 'docs/operations/CREDENTIAL-ROTATION-CHECKLIST.md'),
+    'utf8',
+  ));
   const registryPath = path.join(root, REGISTRY);
   const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
   if (registry['@version'] !== 'EP-RELEASE-PACKAGE-REGISTRY-v1' || !Array.isArray(registry.packages)) {

--- a/security/security-case.json
+++ b/security/security-case.json
@@ -1,7 +1,7 @@
 {
   "@version": "EP-SECURITY-CASE-RESOLVED-v2",
   "source": "security/claims.v1.json",
-  "evidence_bundle_sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c",
+  "evidence_bundle_sha256": "96cf5698e49bcdf8d01f90d5315c7bb8131c6bf74330ba4697e51d799d86b875",
   "claim_count": 13,
   "evidence_file_count": 62,
   "execution": {
@@ -225,7 +225,7 @@
     "security-evidence": {
       "kind": "content-addressed-evidence-bundle",
       "filename": "security-case-evidence.v1",
-      "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c",
+      "sha256": "96cf5698e49bcdf8d01f90d5315c7bb8131c6bf74330ba4697e51d799d86b875",
       "file_count": 62
     },
     "verify-sdk": {
@@ -342,7 +342,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
+          "sha256": "96cf5698e49bcdf8d01f90d5315c7bb8131c6bf74330ba4697e51d799d86b875"
         }
       ]
     },
@@ -464,7 +464,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
+          "sha256": "96cf5698e49bcdf8d01f90d5315c7bb8131c6bf74330ba4697e51d799d86b875"
         }
       ]
     },
@@ -608,7 +608,7 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "security-evidence",
-          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
+          "sha256": "96cf5698e49bcdf8d01f90d5315c7bb8131c6bf74330ba4697e51d799d86b875"
         }
       ]
     },
@@ -754,7 +754,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
+          "sha256": "96cf5698e49bcdf8d01f90d5315c7bb8131c6bf74330ba4697e51d799d86b875"
         }
       ]
     },
@@ -863,7 +863,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
+          "sha256": "96cf5698e49bcdf8d01f90d5315c7bb8131c6bf74330ba4697e51d799d86b875"
         }
       ]
     },
@@ -972,7 +972,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
+          "sha256": "96cf5698e49bcdf8d01f90d5315c7bb8131c6bf74330ba4697e51d799d86b875"
         }
       ]
     },
@@ -1104,7 +1104,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
+          "sha256": "96cf5698e49bcdf8d01f90d5315c7bb8131c6bf74330ba4697e51d799d86b875"
         }
       ]
     },
@@ -1211,7 +1211,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
+          "sha256": "96cf5698e49bcdf8d01f90d5315c7bb8131c6bf74330ba4697e51d799d86b875"
         }
       ]
     },
@@ -1314,7 +1314,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
+          "sha256": "96cf5698e49bcdf8d01f90d5315c7bb8131c6bf74330ba4697e51d799d86b875"
         }
       ]
     },
@@ -1448,7 +1448,7 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "security-evidence",
-          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
+          "sha256": "96cf5698e49bcdf8d01f90d5315c7bb8131c6bf74330ba4697e51d799d86b875"
         }
       ]
     },
@@ -1564,7 +1564,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
+          "sha256": "96cf5698e49bcdf8d01f90d5315c7bb8131c6bf74330ba4697e51d799d86b875"
         }
       ]
     },
@@ -1698,7 +1698,7 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "security-evidence",
-          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
+          "sha256": "96cf5698e49bcdf8d01f90d5315c7bb8131c6bf74330ba4697e51d799d86b875"
         }
       ]
     },
@@ -1950,7 +1950,7 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "security-evidence",
-          "sha256": "40fa566ec63981a56170e5988069e553895456f548a89a741cb991c28787f67c"
+          "sha256": "96cf5698e49bcdf8d01f90d5315c7bb8131c6bf74330ba4697e51d799d86b875"
         }
       ]
     }
@@ -2146,7 +2146,7 @@
     },
     {
       "path": "scripts/check-release-chain.mjs",
-      "sha256": "87e4d5f645bf9ab902d7440cd91e738f0aa656d3f5d76e480aa8d56b0ed636a8"
+      "sha256": "1359ebb8ad1ce3cacba2d9d82b9b22e1db50b5d257bab524a7c037c952098610"
     },
     {
       "path": "scripts/python-artifact-integrity.mjs",
@@ -2194,7 +2194,7 @@
     },
     {
       "path": "tests/release-chain-coverage.test.js",
-      "sha256": "aae1aa3bb7cb3e4159b540e1b57bcee6400687010378c3317d2267cf25f97bf1"
+      "sha256": "f7eb3a4efca584b8c5919ca2eb967c180a35016ac9f76313605d9a7e168bae06"
     },
     {
       "path": "tests/release-reproducibility.test.js",

--- a/tests/release-chain-coverage.test.js
+++ b/tests/release-chain-coverage.test.js
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { auditReleaseChain, validateReusableNpmWorkflowText } from '../scripts/check-release-chain.mjs';
+import {
+  auditReleaseChain,
+  validateCredentialRotationGuideText,
+  validateReusableNpmWorkflowText,
+} from '../scripts/check-release-chain.mjs';
 
 describe('release-chain coverage', () => {
   it('every declared npm and PyPI package uses the complete verifiable release chain', () => {
@@ -12,5 +16,14 @@ describe('release-chain coverage', () => {
     const workflow = readFileSync('.github/workflows/_publish-npm-package.yml', 'utf8');
     const weakened = workflow.replace('cmp "$TESTED_TARBALL" "registry-copy/$REGISTRY_TARBALL"', 'true # comparison removed');
     expect(() => validateReusableNpmWorkflowText(weakened)).toThrow(/registry-copy/);
+  });
+
+  it('refuses credential-rotation guidance that restores a manual publish token', () => {
+    const guide = readFileSync('docs/operations/CREDENTIAL-ROTATION-CHECKLIST.md', 'utf8');
+    const weakened = guide.replace(
+      'a replacement publish token.',
+      'a fresh Granular Access Token.',
+    );
+    expect(() => validateCredentialRotationGuideText(weakened)).toThrow(/credential rotation guide/);
   });
 });


### PR DESCRIPTION
## What changed

- replace stale credential-rotation instructions that created a new npm write token with OIDC-only guidance
- make the release-chain audit fail if the guide reintroduces a local or CI publication-token fallback
- regenerate the machine-verifiable security case

## Operational hardening completed

- removed the npm registry credential from the local user config
- deleted the unused repository Actions secret `NPM_TOKEN`
- verified no npm publishing credential name exists in the linked Vercel environment

The npm dashboard still has granular tokens that the CLI masks and cannot revoke by ID; dashboard revocation remains an explicit owner-authenticated action. No package was published.

## Verification

- `npm run check:release-chain`
- `npx vitest run tests/release-chain-coverage.test.js tests/release-reproducibility.test.js tests/release-approval.test.js tests/npm-provenance-workflows.test.js` (19 passed)
- `npm run security-case:emit` (13 claims, 62 evidence files)
- `git diff --check`
