### PR TITLE
Clarify LIT public-key encoding

### DIFF
--- a/examples/surface-binding-join/README.md
+++ b/examples/surface-binding-join/README.md
@@ -44,8 +44,8 @@ payload carries five items:
 
 1. **version + profile id** — the verify library knows how to parse; condition
    claims are a declaration by reference to the profile, not a list of internals;
-2. **key id** — hash of the raw public key the relying party pinned at
-   registration, so verification is a lookup, not a chain walk;
+2. **key id** — hash of the DER-encoded SPKI public key the relying party pinned
+   at registration, so verification is a lookup, not a chain walk;
 3. **condition claims** — phase-table style (`user-verified-at-mint`,
    `posture-at-build`, `checksum`); mint inputs need no runtime assertion, the
    signature existing is the proof they held;

--- a/examples/surface-binding-join/run-lit.mjs
+++ b/examples/surface-binding-join/run-lit.mjs
@@ -6,7 +6,7 @@
 //   1. version + profile id   - the verify library knows how to parse; condition
 //                               claims are a declaration BY REFERENCE to the
 //                               profile, not a list of internals.
-//   2. key id                 - hash of the raw public key the RP pinned at
+//   2. key id                 - hash of the DER-encoded SPKI key the RP pinned at
 //                               registration. Check #3 is a LOOKUP, not a chain
 //                               walk. No cert.
 //   3. condition claims       - phase-table style; only what can honestly be
@@ -40,11 +40,11 @@ const LIT_PROFILE_ID = 'winmagic-lit:profile-x@v1';
 const SIGNATURE_LENGTH = 64; // Ed25519
 
 // The WinMagic-LIT device key pair (the Live Key). In production this is
-// provisioned on the device; the PRIVATE key never leaves it, the raw PUBLIC
-// key (or its hash) is pinned by RPs at registration.
+// provisioned on the device; the PRIVATE key never leaves it, and the
+// DER-encoded SPKI public key (or its hash) is pinned by RPs at registration.
 const litDeviceKeys = crypto.generateKeyPairSync('ed25519');
 
-// 2. Key identifier: hash of the raw public key. What the RP pins; a lookup key.
+// 2. Key identifier: hash of the DER-encoded SPKI key. What the RP pins; a lookup key.
 const litKeyId = (publicKey) =>
   `sha256:${sha256hex(publicKey.export({ type: 'spki', format: 'der' }))}`;
 


### PR DESCRIPTION
Clarifies the LIT demo's key identifier precisely: the implementation hashes DER-encoded SPKI bytes, not an unspecified raw-key representation.\n\nVerification:\n- node examples/surface-binding-join/run-lit.mjs\n- git diff --check