### PR TITLE
security(pilot): refuse observe-mode sandbox keys at the control plane (Strix Critical)

### DIFF
--- a/app/api/pilot/sandbox/provision/route.js
+++ b/app/api/pilot/sandbox/provision/route.js
@@ -61,6 +61,10 @@ export async function POST(request) {
         api_key_hash: keyHash,
         public_key: publicKeyB64,
         private_key_encrypted: seal(privateKeyB64),
+        // Observe-scope marker: this self-serve key runs traffic through the
+        // gate and reads its own report, but is refused at the control plane
+        // (SSO/SCIM/tenant admin). See lib/auth/observe-scope.js.
+        metadata: { pilot_sandbox: true, scope: 'observe' },
       })
       .select('id')
       .single();
@@ -75,6 +79,8 @@ export async function POST(request) {
       key_hash: keyHash,
       key_prefix: apiKey.slice(0, 16),
       label: 'Pilot sandbox key',
+      // No control-plane permissions: an observe-mode sandbox key holds none.
+      permissions: [],
     });
     if (keyError) {
       logger.error('[pilot/sandbox] api_keys insert failed:', keyError);

--- a/app/api/scim/v2/provisioning-token/route.js
+++ b/app/api/scim/v2/provisioning-token/route.js
@@ -10,6 +10,7 @@ import { epProblem } from '@/lib/errors';
 import { logger } from '@/lib/logger.js';
 import { generateScimToken, hashScimToken } from '@/lib/scim/auth';
 import { readEpJson } from '@/lib/http/route-body';
+import { refuseObserveScope } from '@/lib/auth/observe-scope';
 
 const BASE = 'https://www.emiliaprotocol.ai';
 const MAX_BODY_BYTES = 32 * 1024;
@@ -17,6 +18,7 @@ const MAX_BODY_BYTES = 32 * 1024;
 export async function POST(request) {
   const auth = await authenticateRequest(request);
   if (auth.error) return epProblem(auth.status || 401, auth.code || 'unauthorized', auth.error);
+  { const denied = refuseObserveScope(auth, epProblem); if (denied) return denied; }
   const tenantId = authEntityId(auth);
   // Confirmed tenant -> protocol-org mapping (#6): the SCIM token provisions into
   // the minting entity's organization. Approvers enroll under this same org, so
@@ -68,6 +70,7 @@ export async function POST(request) {
 export async function GET(request) {
   const auth = await authenticateRequest(request);
   if (auth.error) return epProblem(auth.status || 401, auth.code || 'unauthorized', auth.error);
+  { const denied = refuseObserveScope(auth, epProblem); if (denied) return denied; }
   const tenantId = authEntityId(auth);
   const supabase = getGuardedClient();
 

--- a/app/api/sso/connections/route.js
+++ b/app/api/sso/connections/route.js
@@ -11,12 +11,14 @@ import { seal } from '@/lib/crypto/secret-box';
 import { epProblem } from '@/lib/errors';
 import { readEpJson } from '@/lib/http/route-body';
 import { logger } from '@/lib/logger.js';
+import { refuseObserveScope } from '@/lib/auth/observe-scope';
 
 const MAX_BODY_BYTES = 256 * 1024;
 
 export async function POST(request) {
   const auth = await authenticateRequest(request);
   if (auth.error) return epProblem(auth.status || 401, auth.code || 'unauthorized', auth.error);
+  { const denied = refuseObserveScope(auth, epProblem); if (denied) return denied; }
   const tenant = authEntityId(auth);
 
   const parsed = await readEpJson(request, MAX_BODY_BYTES);
@@ -77,6 +79,7 @@ export async function POST(request) {
 export async function GET(request) {
   const auth = await authenticateRequest(request);
   if (auth.error) return epProblem(auth.status || 401, auth.code || 'unauthorized', auth.error);
+  { const denied = refuseObserveScope(auth, epProblem); if (denied) return denied; }
   const tenant = authEntityId(auth);
   const { connections, error } = await listConnections(tenant);
   if (error) return epProblem(503, 'config_read_failed', 'Could not list SSO connections');

--- a/lib/auth/observe-scope.js
+++ b/lib/auth/observe-scope.js
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Observe-scope guard for the control plane.
+//
+// The self-serve pilot bootstrap (POST /api/pilot/sandbox/provision) mints a
+// real ep_live_ API key so anyone can run traffic through the guard in OBSERVE
+// mode and pull a "what would have required approval" report. That key must
+// never reach the CONTROL PLANE (minting SCIM provisioning tokens, configuring
+// SSO connections, or any other tenant-administration surface): a public
+// observe-mode credential that could stand up directory sync or federation is a
+// privilege-escalation pivot, not a sandbox.
+//
+// Pilot keys are marked at mint with entity.metadata.scope === 'observe' (and
+// metadata.pilot_sandbox === true). authenticateRequest() returns the full
+// entity row as auth.entity (RPC resolve_authenticated_actor, migration 125),
+// so the marker is visible to every route without a schema change. This guard
+// is fail-closed on the marker: it refuses the marked scope and lets everything
+// else through, so no real tenant is affected.
+
+/**
+ * @param {{ entity?: { metadata?: unknown } }} auth  the result of authenticateRequest()
+ * @returns {boolean} true when this credential is an observe-mode pilot sandbox key
+ */
+export function isObserveScoped(auth) {
+  const meta = auth && auth.entity && typeof auth.entity === 'object'
+    ? auth.entity.metadata
+    : null;
+  if (!meta || typeof meta !== 'object') return false;
+  return meta.scope === 'observe' || meta.pilot_sandbox === true;
+}
+
+/**
+ * Fail-closed control-plane guard. Returns a 403 epProblem Response when the
+ * caller is an observe-mode pilot key, or null when the caller may proceed.
+ *
+ * @param {object} auth  the result of authenticateRequest()
+ * @param {(status:number, code:string, detail:string) => Response} epProblem
+ * @returns {Response|null}
+ */
+export function refuseObserveScope(auth, epProblem) {
+  if (isObserveScoped(auth)) {
+    return epProblem(
+      403,
+      'observe_scope_forbidden',
+      'This is an observe-mode pilot sandbox key. It can run actions through the gate and read its own report, but it cannot access the control plane (SSO, SCIM, or tenant administration).',
+    );
+  }
+  return null;
+}

--- a/tests/pilot-sandbox-controlplane-scope.test.js
+++ b/tests/pilot-sandbox-controlplane-scope.test.js
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Regression for the Strix full-stack Critical (2026-07-18): a public
+// observe-mode pilot key could be pivoted into SCIM directory administration
+// and the SSO control plane. The observe-scope guard closes that pivot while
+// leaving real tenant keys untouched.
+
+import { describe, it, expect } from 'vitest';
+import { isObserveScoped, refuseObserveScope } from '../lib/auth/observe-scope.js';
+
+const epProblem = (status, code, detail) => ({ status, code, detail });
+
+const pilotAuth = {
+  entity: { entity_id: 'ep_entity_x', metadata: { pilot_sandbox: true, scope: 'observe' } },
+  permissions: [],
+};
+const scopeOnly = { entity: { metadata: { scope: 'observe' } } };
+const tenantAuth = {
+  entity: { entity_id: 'ep_entity_real', metadata: { plan: 'enterprise' } },
+  permissions: ['admin'],
+};
+const noMeta = { entity: { entity_id: 'ep_entity_bare' } };
+
+describe('observe-scope control-plane guard', () => {
+  it('flags a pilot-provisioned key as observe-scoped', () => {
+    expect(isObserveScoped(pilotAuth)).toBe(true);
+    expect(isObserveScoped(scopeOnly)).toBe(true);
+  });
+
+  it('does not flag a real tenant key or a key without metadata', () => {
+    expect(isObserveScoped(tenantAuth)).toBe(false);
+    expect(isObserveScoped(noMeta)).toBe(false);
+    expect(isObserveScoped({})).toBe(false);
+    expect(isObserveScoped(null)).toBe(false);
+  });
+
+  it('refuses a pilot key at the control plane with a 403 and a named reason', () => {
+    const denied = refuseObserveScope(pilotAuth, epProblem);
+    expect(denied).not.toBeNull();
+    expect(denied.status).toBe(403);
+    expect(denied.code).toBe('observe_scope_forbidden');
+  });
+
+  it('lets a real tenant key through (returns null)', () => {
+    expect(refuseObserveScope(tenantAuth, epProblem)).toBeNull();
+    expect(refuseObserveScope(noMeta, epProblem)).toBeNull();
+  });
+
+  it('fails closed on a poisoned metadata type', () => {
+    expect(isObserveScoped({ entity: { metadata: 'observe' } })).toBe(false); // string, not object
+    expect(isObserveScoped({ entity: { metadata: ['observe'] } })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Closes the Strix full-stack Critical (2026-07-18)

**The pivot:** `POST /api/pilot/sandbox/provision` is a public, unauthenticated endpoint that mints a real `ep_live_` API key (self-serve observe-mode pilot). `POST /api/scim/v2/provisioning-token` and `/api/sso/connections` were gated only on "is this any valid key," with no permission/scope check. So a public observe-mode key could be pivoted into **SCIM directory administration** and **SSO control-plane** configuration.

## Fix (fail-closed, zero blast radius)
- **Mark pilot keys at mint:** `entity.metadata = { pilot_sandbox: true, scope: 'observe' }` and `api_keys.permissions = []`. `resolve_authenticated_actor` (migration 125) already returns the full entity row as `auth.entity`, so the marker reaches every route **with no schema migration**.
- **`lib/auth/observe-scope.js`:** a fail-closed guard that refuses *only* the observe marker. Real tenant keys carry no such marker and are untouched.
- **Gate the two `ep_live_`-authed control-plane routes** (SCIM token mint POST+GET, SSO connections POST+GET) with a `403 observe_scope_forbidden`.
- **Regression test** (`tests/pilot-sandbox-controlplane-scope.test.js`): pivot refused, tenant keys allowed, poisoned-metadata type fails closed.

The pilot observe-mode flow (run traffic through the gate, read its own report) is **unchanged**.

## Verification
- Unit test: 5/5 pass locally.
- Lint: 0 errors on changed files.
- `next build` reached and resolved all changed files cleanly (local full build blocked only by unrelated missing deps in a stale worktree `node_modules`; CI runs the authoritative build here).

## Not in scope (follow-up)
This closes the **Critical** pivot. The broader pentest "routes authenticate valid keys but don't enforce the permission model" (High findings) warrants a deny-by-default `requirePermission` sweep across the control plane, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)