### PR TITLE
chore(proof): resync proof-stats after #283 (test-count drift)

### DIFF
--- a/lib/proof-stats.json
+++ b/lib/proof-stats.json
@@ -1,8 +1,8 @@
 {
   "generatedAt": "2026-07-18T15:12:56.021Z",
   "tests": {
-    "total": 6349,
-    "files": 328,
+    "total": 6354,
+    "files": 329,
     "policy": "all platform-applicable cases must pass; platform-specific cases may skip"
   },
   "tla": {


### PR DESCRIPTION
#283 added a 5-case test file; the language-governance gate on main went red on the count drift (6349→6354 tests, 328→329 files). This resyncs `lib/proof-stats.json` to the CI-measured values. Only `tests.total` and `tests.files` change; verified against the failing CI run's own measured output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)