### PR TITLE
feat(gate): forward migration for the Marvel durable capability store

### DIFF
--- a/scripts/db-contract.manifest.mjs
+++ b/scripts/db-contract.manifest.mjs
@@ -73,6 +73,10 @@ const SERVICE_ONLY_TABLES = [
   'revoked_commit_keys',
   'revoked_sessions',
   'session_cutoffs',
+  // Marvel durable capability store (packages/gate/capability-receipt.js):
+  // spending/budget state reached only through the service-role durable store.
+  'ep_capability_state',
+  'ep_capability_operations',
 ];
 
 export const contract = {
@@ -137,6 +141,10 @@ export const contract = {
       'status', 'reservation_expires_at', 'reservation_attempts', 'claim_attempts',
       'effect_contract_digest', 'retryable', 'provider_result'],
     scim_provisioning_tokens: ['tenant_id', 'token_hash', 'token_prefix', 'revoked_at'],
+    ep_capability_state: ['capability_id', 'capability_fingerprint', 'budget_amount',
+      'currency', 'consumed_amount', 'reserved_amount', 'expires_at'],
+    ep_capability_operations: ['operation_id', 'capability_id', 'amount', 'currency',
+      'status', 'reservation_token', 'reserved_at', 'committed_at'],
   },
 
   // Tables that MUST have RLS enabled. RLS off => hard FAIL.

--- a/scripts/schema-security-audit.mjs
+++ b/scripts/schema-security-audit.mjs
@@ -144,8 +144,13 @@ export function readMigrationBundle(root = ROOT) {
 export function auditMigrationBundle(migrationFiles, schemaContract = contract) {
   const files = migrationFiles.map((entry) => ({ file: entry.file, sql: entry.sql }));
   const statements = files.flatMap((entry) => statementsFor(entry.sql));
-  const invariantFile = files.find((entry) => entry.file.endsWith('_fortress_db_security_invariants.sql'));
-  const invariantStatements = invariantFile ? statementsFor(invariantFile.sql) : [];
+  // Fortress reassertions are forward-only: a service-only table added AFTER the
+  // first fortress migration reasserts its ACL/RLS in a LATER fortress file.
+  // Union the statements across ALL fortress files so a new one counts, while
+  // the invariant strength is unchanged — every table's revoke must still appear
+  // in some fortress migration in the checked-in source.
+  const invariantFiles = files.filter((entry) => entry.file.endsWith('_fortress_db_security_invariants.sql'));
+  const invariantStatements = invariantFiles.flatMap((entry) => statementsFor(entry.sql));
   const failures = [];
   const checks = [];
   const source = files.map((entry) => `${entry.file}\n${entry.sql}`).join('\n');
@@ -156,7 +161,7 @@ export function auditMigrationBundle(migrationFiles, schemaContract = contract) 
     else failures.push({ name, detail: detail || 'invariant failed' });
   };
 
-  check('fortress reconciliation migration present', () => Boolean(invariantFile));
+  check('fortress reconciliation migration present', () => invariantFiles.length > 0);
 
   for (const table of schemaContract.rlsRequired) {
     check(`RLS enabled: ${table}`, () => statements.some((statement) =>

--- a/supabase/migrations/20260718190000_marvel_capability_store.sql
+++ b/supabase/migrations/20260718190000_marvel_capability_store.sql
@@ -1,0 +1,66 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Marvel durable capability store — forward migration for the Gate's
+-- budget/spending state tables.
+--
+-- packages/gate/capability-receipt.js defines createPostgresCapabilityStore()
+-- and the DDL for two tables (CAPABILITY_STATE_DDL), but shipping that code
+-- does not create the tables in a database. This migration is that DDL, applied
+-- as a tracked Supabase migration, plus the EP service-role security posture
+-- (RLS enabled, no anon/authenticated/PUBLIC access) that every server-only
+-- table in this project carries.
+--
+-- The table shape is copied VERBATIM from CAPABILITY_STATE_DDL so the durable
+-- store's CAPABILITY_SQL (register / reserveState / commitState / insert /
+-- commit operation) runs against exactly the schema it was written for. The
+-- budget invariants (consumed + reserved <= budget) are enforced by that SQL
+-- under a FOR UPDATE lock on the state row; the column CHECKs here are the
+-- database-side floor (non-negative amounts, valid status, fingerprint shape).
+
+CREATE TABLE IF NOT EXISTS ep_capability_state (
+  capability_id TEXT PRIMARY KEY,
+  capability_fingerprint TEXT NOT NULL CHECK (capability_fingerprint ~ '^sha256:[0-9a-f]{64}$'),
+  budget_amount BIGINT NOT NULL CHECK (budget_amount >= 0),
+  currency TEXT NOT NULL,
+  consumed_amount BIGINT NOT NULL DEFAULT 0 CHECK (consumed_amount >= 0),
+  reserved_amount BIGINT NOT NULL DEFAULT 0 CHECK (reserved_amount >= 0),
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+-- Compat hedge carried from CAPABILITY_STATE_DDL: a no-op on this fresh table
+-- (the column is already present with its NOT NULL CHECK above), present so the
+-- migration and the code's own DDL stay byte-aligned.
+ALTER TABLE ep_capability_state ADD COLUMN IF NOT EXISTS capability_fingerprint TEXT;
+
+CREATE TABLE IF NOT EXISTS ep_capability_operations (
+  operation_id TEXT PRIMARY KEY,
+  capability_id TEXT NOT NULL REFERENCES ep_capability_state(capability_id),
+  amount BIGINT NOT NULL CHECK (amount > 0),
+  currency TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('reserved', 'committed')),
+  reservation_token TEXT NOT NULL,
+  outcome TEXT,
+  reserved_at TIMESTAMPTZ NOT NULL,
+  committed_at TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS ep_capability_operations_capability_idx
+  ON ep_capability_operations(capability_id);
+
+-- ── Service-role-only security posture ───────────────────────────────────────
+-- These tables hold spending/budget state reached only through the Gate's
+-- server-side durable store (service_role). RLS is enabled with NO policy, so
+-- anon/authenticated are denied every row; service_role bypasses RLS. The table
+-- ACL is a separate Data-API gate (mig 113 precedent), so anon/authenticated/
+-- PUBLIC are also revoked at the grant level. This mirrors SERVICE_ONLY_TABLES
+-- in scripts/db-contract.manifest.mjs, to which both tables are added.
+ALTER TABLE ep_capability_state ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ep_capability_operations ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON ep_capability_state FROM anon, authenticated, PUBLIC;
+REVOKE ALL ON ep_capability_operations FROM anon, authenticated, PUBLIC;
+GRANT ALL ON ep_capability_state TO service_role;
+GRANT ALL ON ep_capability_operations TO service_role;
+
+COMMENT ON TABLE ep_capability_state IS
+  'Marvel durable capability budget state (createPostgresCapabilityStore). Service-role only; RLS-enabled deny-all. One row per capability: budget/consumed/reserved under a FOR UPDATE lock.';
+COMMENT ON TABLE ep_capability_operations IS
+  'Marvel durable capability spend operations. Service-role only. reserved -> committed, keyed by operation_id, fenced by reservation_token.';

--- a/supabase/migrations/20260718200000_fortress_db_security_invariants.sql
+++ b/supabase/migrations/20260718200000_fortress_db_security_invariants.sql
@@ -1,0 +1,22 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Migration version: 20260718200000
+--
+-- Fortress database security invariants — capability-store reassertion.
+--
+-- Forward-only continuation of 20260718145410_fortress_db_security_invariants.sql
+-- for the service-only tables added after it: the Marvel durable capability
+-- store (ep_capability_state, ep_capability_operations, migration 20260718190000).
+-- Idempotent reassertion of the same access model those tables already carry —
+-- RLS on, no anon/authenticated/PUBLIC table grant. Unlike the Release Lock
+-- tables (RPC-only), the capability store is queried directly by the service-role
+-- durable store, so service_role KEEPS its table grant here.
+
+-- ── Reassert RLS ─────────────────────────────────────────────────────────────
+ALTER TABLE public.ep_capability_state ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.ep_capability_operations ENABLE ROW LEVEL SECURITY;
+
+-- ── Reassert no public/anon/authenticated table ACL (service_role retained) ──
+REVOKE ALL ON TABLE public.ep_capability_state FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON TABLE public.ep_capability_operations FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.ep_capability_state TO service_role;
+GRANT ALL ON TABLE public.ep_capability_operations TO service_role;


### PR DESCRIPTION
## What

Creates `ep_capability_state` and `ep_capability_operations` — the Marvel durable capability (budget/spending) store — as a tracked Supabase migration, and adds them to the schema-security contract.

## Why

`packages/gate/capability-receipt.js` defines `createPostgresCapabilityStore()` and `CAPABILITY_STATE_DDL`, but shipping that code never created the tables. The durable spending store had **no schema in any database** — verified missing in prod. Deploying code doesn't run its embedded DDL.

## The migration

- Table shape copied **verbatim** from `CAPABILITY_STATE_DDL` so the store's `CAPABILITY_SQL` (register / reserveState / commitState / insert / commit-operation) runs against exactly the schema it was written for.
- **Service-role security posture** added on top of the bare DDL — the bare DDL had none: RLS enabled deny-all, `anon`/`authenticated`/`PUBLIC` revoked at the grant level, `service_role` granted. Both tables added to `SERVICE_ONLY_TABLES` in `db-contract.manifest.mjs`, so the live `schema:security` gate now requires their existence, RLS, and no-anon ACLs.

## Applied + proven against live prod

Applied to `xmiiwehtivksdjbultym`, journal reconciled to the filename timestamp. Then smoke-tested the money-safety invariants against the **live tables** with the exact `CAPABILITY_SQL`, all in a rolled-back transaction:

| Invariant | Result |
|---|---|
| reserve within budget | succeeds |
| overspend (reserve > available) | refused — `reserveState` matches 0 rows |
| commit a reserved op | succeeds |
| double-commit / replay | refused — status no longer `reserved` |
| wrong `reservation_token` commit | refused |
| budget math (600 consumed + 100 reserved → 300 available) | exact |
| `CHECK(amount > 0)` | rejects zero |

Tables left empty; RLS on both; zero anon/authenticated/PUBLIC grants.

## Scope boundary (important)

This makes the durable primitive **production-ready**. It does **not** wire the Gate to it: `createGate` does not accept a `capabilityStore`, and nothing calls `reserveSpend`/`commitSpend` outside the module and its tests. Connecting the Gate's spend-enforcement path to this store is a **separate feature** (deciding where in the guard loop budget is reserved/committed) — deliberately not invented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)