### PR TITLE
formal(tamarin): gate standalone receipt-core and quorum-core models in CI

### DIFF
--- a/.github/workflows/tamarin.yml
+++ b/.github/workflows/tamarin.yml
@@ -44,3 +44,57 @@ jobs:
             formal/tamarin/composed-output.txt
             formal/tamarin/run-output/*.txt
           retention-days: 90
+
+  receipt-core:
+    # Same pinned arm64-only prover digest as composed-reliance; runs the
+    # standalone receipt-core component model so it is gated independently of
+    # the composition (audit GAP 10).
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Verify pinned model bytes
+        working-directory: formal/tamarin
+        run: |
+          echo 'de5eee9b40790baadb22d42cdfff921c5fb2edf10ac6e041d3f8a786f0f0343e  ep_receipt_core.spthy' | sha256sum -c -
+          echo 'd1e46b6ba20f845e93342e1118a1d42f087c174902e1634870adb05159a6b063  run-receipt-core.sh' | sha256sum -c -
+      - name: Run every receipt-core proof obligation independently
+        working-directory: formal/tamarin
+        shell: bash
+        run: sh ./run-receipt-core.sh | tee receipt-output.txt
+      - name: Upload complete prover output
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: tamarin-receipt-core-output
+          path: |
+            formal/tamarin/receipt-output.txt
+            formal/tamarin/run-output-receipt/*.txt
+          retention-days: 90
+
+  quorum-core:
+    # Same pinned arm64-only prover digest as composed-reliance; runs the
+    # standalone quorum-core component model so it is gated independently of
+    # the composition (audit GAP 10).
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Verify pinned model bytes
+        working-directory: formal/tamarin
+        run: |
+          echo '399e4f739b6bfbecb9a7fc83bdbe12ecb0f900dc77aaecaf790b8cb36d152dbb  ep_quorum_core.spthy' | sha256sum -c -
+          echo '3dcaf37a0d1fa047bc655319ee35959b3f4ee6fc6afde358b7487eb5227691d7  run-quorum.sh' | sha256sum -c -
+      - name: Run every quorum-core proof obligation independently
+        working-directory: formal/tamarin
+        shell: bash
+        run: sh ./run-quorum.sh | tee quorum-output.txt
+      - name: Upload complete prover output
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: tamarin-quorum-core-output
+          path: |
+            formal/tamarin/quorum-output.txt
+            formal/tamarin/run-output-quorum/*.txt
+          retention-days: 90

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ reports/mutation/
 /release-artifacts/
 /registry-copy/
 formal/tamarin/run-output/
+formal/tamarin/run-output-receipt/
+formal/tamarin/run-output-quorum/
 
 # Supabase CLI local cache — these change per-developer and per-link
 supabase/.temp/

--- a/formal/tamarin/run-quorum.sh
+++ b/formal/tamarin/run-quorum.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+set -eu
+
+IMAGE='lmandrelli/tamarin-prover-and-batch@sha256:dff2af961e192e2b8eef3faa0484a0075c380b476bd0e79c160a5619b2519083'
+MODEL='ep_quorum_core.spthy'
+OUT_DIR="${TAMARIN_OUT_DIR:-run-output-quorum}"
+
+VERIFIED_LEMMAS='executable_quorum
+quorum_requires_two_distinct_uv_gated_signatures
+initiator_cannot_self_approve
+no_single_signer_fills_quorum
+commit_requires_signature_over_that_action'
+
+FALSIFIED_LEMMAS=''
+
+mkdir -p "$OUT_DIR"
+rm -f "$OUT_DIR"/*.txt
+
+run_lemma() {
+  lemma="$1"
+  expected="$2"
+  output="$OUT_DIR/$lemma.txt"
+  echo "Proving $lemma (expected: $expected)"
+  docker run --rm \
+    -v "$PWD:/work" -w /work \
+    "$IMAGE" \
+    tamarin-prover --derivcheck-timeout=300 --prove="$lemma" "$MODEL" \
+    > "$output" 2>&1
+
+  grep -Fq 'All wellformedness checks were successful.' "$output"
+  if [ "$expected" = verified ]; then
+    grep -Eq "^  $lemma \\([^)]*\\): verified" "$output"
+  else
+    grep -Eq "^  $lemma \\([^)]*\\): falsified - found trace" "$output"
+  fi
+  grep -E "^  $lemma \\(" "$output" | tail -n 1
+}
+
+for lemma in $VERIFIED_LEMMAS; do
+  run_lemma "$lemma" verified
+done
+
+for lemma in $FALSIFIED_LEMMAS; do
+  run_lemma "$lemma" falsified
+done
+
+echo 'All quorum-core proof obligations passed.'

--- a/formal/tamarin/run-receipt-core.sh
+++ b/formal/tamarin/run-receipt-core.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+set -eu
+
+IMAGE='lmandrelli/tamarin-prover-and-batch@sha256:dff2af961e192e2b8eef3faa0484a0075c380b476bd0e79c160a5619b2519083'
+MODEL='ep_receipt_core.spthy'
+OUT_DIR="${TAMARIN_OUT_DIR:-run-output-receipt}"
+
+VERIFIED_LEMMAS='executable_honest_receipt
+core_authenticity_uv_gated
+no_replay_across_actions
+injective_acceptance_with_consumption'
+
+FALSIFIED_LEMMAS='unchecked_acceptance_is_injective'
+
+mkdir -p "$OUT_DIR"
+rm -f "$OUT_DIR"/*.txt
+
+run_lemma() {
+  lemma="$1"
+  expected="$2"
+  output="$OUT_DIR/$lemma.txt"
+  echo "Proving $lemma (expected: $expected)"
+  docker run --rm \
+    -v "$PWD:/work" -w /work \
+    "$IMAGE" \
+    tamarin-prover --derivcheck-timeout=300 --prove="$lemma" "$MODEL" \
+    > "$output" 2>&1
+
+  grep -Fq 'All wellformedness checks were successful.' "$output"
+  if [ "$expected" = verified ]; then
+    grep -Eq "^  $lemma \\([^)]*\\): verified" "$output"
+  else
+    grep -Eq "^  $lemma \\([^)]*\\): falsified - found trace" "$output"
+  fi
+  grep -E "^  $lemma \\(" "$output" | tail -n 1
+}
+
+for lemma in $VERIFIED_LEMMAS; do
+  run_lemma "$lemma" verified
+done
+
+for lemma in $FALSIFIED_LEMMAS; do
+  run_lemma "$lemma" falsified
+done
+
+echo 'All receipt-core proof obligations passed.'


### PR DESCRIPTION
## What

Closes the audit **GAP 10** residual on the Tamarin symbolic proofs. The composed reliance model (`ep_reliance_composed.spthy`) is already CI-gated via `run-composed.sh`, but the two standalone component models were **not** each individually checked in CI:

- `ep_receipt_core.spthy`
- `ep_quorum_core.spthy`

A regression to either component model could land unnoticed, since only the composition was verified on every push.

## Change

- Add `run-receipt-core.sh` and `run-quorum.sh`, each a byte-for-byte mirror of `run-composed.sh`: same pinned prover digest, one named lemma per pinned-container invocation against the same model bytes, wellformedness assertion, per-lemma verdict grep, exit nonzero on any mismatch.
- Add two CI jobs to `.github/workflows/tamarin.yml` (`receipt-core`, `quorum-core`), each pinning **both** the model and its runner by `sha256sum -c`, on the same `ubuntu-24.04-arm` runner that matches the arm64-only prover manifest.
- `.gitignore` the new local run-output dirs.

Expected verdicts are taken from the model READMEs as ground truth:

| Model | Verified lemmas | Falsified (deliberate comparison) |
|---|---|---|
| receipt-core | executable_honest_receipt, core_authenticity_uv_gated, no_replay_across_actions, injective_acceptance_with_consumption | unchecked_acceptance_is_injective |
| quorum-core | executable_quorum, quorum_requires_two_distinct_uv_gated_signatures, initiator_cannot_self_approve, no_single_signer_fills_quorum, commit_requires_signature_over_that_action | (none) |

## Verification (ran locally, pinned image)

Both runners executed with the exact pinned digest `sha256:dff2af96…519083` on arm64. All 10 obligations reproduced the README verdicts and step counts:

```
receipt-core:
  executable_honest_receipt (exists-trace): verified (8 steps)
  core_authenticity_uv_gated (all-traces): verified (12 steps)
  no_replay_across_actions (all-traces): verified (12 steps)
  injective_acceptance_with_consumption (all-traces): verified (6 steps)
  unchecked_acceptance_is_injective (all-traces): falsified - found trace (10 steps)
quorum-core:
  executable_quorum (exists-trace): verified (12 steps)
  quorum_requires_two_distinct_uv_gated_signatures (all-traces): verified (20 steps)
  initiator_cannot_self_approve (all-traces): verified (4 steps)
  no_single_signer_fills_quorum (all-traces): verified (4 steps)
  commit_requires_signature_over_that_action (all-traces): verified (7 steps)
```

Scope note: does not touch PR #292's guard/capability surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)