### PR TITLE
security(gate): delegation-chain acyclicity + monotonic authority at ingest

### DIFF
--- a/formal/ep_delegation.als
+++ b/formal/ep_delegation.als
@@ -1,0 +1,146 @@
+/**
+ * EP-CAPABILITY-DELEGATION-v1 — Alloy Relational Model
+ *
+ * Formal model of the capability delegation chain and the ingest-time
+ * structural invariants the runtime validator enforces
+ * (packages/gate/capability-receipt.js -> assertDelegationChain). The TLA+
+ * capability model (formal/ep_capability.tla) surfaced that
+ * DelegationAuthorityNonIncreasing held only emergently via the runtime parent
+ * reserve guard, with no standalone chain-validation assertion — and that a
+ * hand-crafted envelope could carry a CYCLIC or authority-inflating chain and
+ * still pass shape/length validation. This model states the properties the
+ * hardened validator now checks directly, at ingest, on the chain alone:
+ *
+ *   - DelegationAcyclic          — no parent_capability_id recurs and no entry
+ *                                  is its own ancestor: the chain is a simple
+ *                                  path, never a cycle.
+ *   - DelegationIdsUnique        — no delegation_id recurs (each hop is a
+ *                                  distinct parent spend).
+ *   - LeafIsNotItsOwnAncestor    — the leaf capability never appears as a
+ *                                  parent in its own delegation chain.
+ *   - AuthorityNonIncreasing     — each hop grants at most what the hop that
+ *                                  delegated to it granted; authority is
+ *                                  monotonically non-increasing from root to
+ *                                  leaf. Holds standalone, independent of the
+ *                                  runtime reserve guard.
+ *
+ * Maps to code:
+ *   packages/gate/capability-receipt.js  — assertDelegationChain() ingest checks
+ *   packages/gate/capability-receipt.test.js
+ *                                        — cyclic / repeated-id / increasing-
+ *                                          amount / leaf-as-parent rejections
+ *   formal/ep_capability.tla             — DelegationAuthorityNonIncreasing
+ *
+ * STATUS: authored to the repo's Alloy convention (formal/ep_quorum.als,
+ * formal/ep_relations.als). NOT executed in this environment — the Alloy 6 jar
+ * (~80 MB) was not fetched here. Run per formal/RUN_ALLOY.md:
+ *   java -jar alloy.jar formal/ep_delegation.als   (Execute -> Check All Assertions)
+ */
+
+module ep_delegation
+
+-- ==========================================================================
+-- Signatures
+-- ==========================================================================
+
+-- A capability atom (identity). A delegation hop names the capability it
+-- delegates FROM as its parent.
+sig Cap {}
+
+-- A delegation identifier atom (the per-hop parent spend id).
+sig DelegId {}
+
+-- One delegation hop. `prev` points root-ward: the hop that delegated to this
+-- one (lone; the root hop has none). `amount` is the granted budget of this
+-- hop. This mirrors one entry of capability.delegation_chain.
+sig Entry {
+    parent: one Cap,       -- parent_capability_id
+    delegId: one DelegId,  -- delegation_id
+    amount: one Int,       -- granted amount (non-negative)
+    prev: lone Entry       -- the root-ward neighbouring hop
+}
+
+-- A capability's delegation chain: the leaf capability plus its ordered hops.
+sig Chain {
+    leaf:    one Cap,
+    entries: set Entry
+}
+
+-- ==========================================================================
+-- The ingest validator (mirrors assertDelegationChain's fail-closed checks)
+-- ==========================================================================
+
+-- The chain is a single linear order over its entries: prev stays inside the
+-- chain, is acyclic, has exactly one root (no prev) and no branching.
+pred linear[c: Chain] {
+    all e: c.entries | e.prev in c.entries
+    no  e: c.entries | e in e.^prev
+    lone e: c.entries | no e.prev
+    all e: c.entries | lone (e.~prev & c.entries)
+}
+
+-- No delegation_id recurs.
+pred distinctDelegIds[c: Chain] { all disj e1, e2: c.entries | e1.delegId != e2.delegId }
+
+-- No parent_capability_id recurs (a capability delegates at most once as a
+-- parent). Either repeat would be a cycle in the delegation graph.
+pred distinctParents[c: Chain] { all disj e1, e2: c.entries | e1.parent != e2.parent }
+
+-- The leaf capability never appears as a parent in its own chain.
+pred leafNotParent[c: Chain] { all e: c.entries | e.parent != c.leaf }
+
+-- Non-negative budgets, and each hop grants at most what its root-ward
+-- predecessor granted.
+pred monotonic[c: Chain] {
+    all e: c.entries | e.amount >= 0
+    all e: c.entries | some e.prev implies e.amount <= e.prev.amount
+}
+
+pred valid[c: Chain] {
+    linear[c]
+    distinctDelegIds[c]
+    distinctParents[c]
+    leafNotParent[c]
+    monotonic[c]
+}
+
+-- ==========================================================================
+-- Safety assertions
+-- ==========================================================================
+
+-- A valid chain is acyclic: no hop is its own ancestor and no parent recurs.
+assert DelegationAcyclic {
+    all c: Chain | valid[c] implies
+        ((no e: c.entries | e in e.^prev)
+         and (all disj e1, e2: c.entries | e1.parent != e2.parent))
+}
+check DelegationAcyclic for 6
+
+-- Delegation identifiers are unique within a valid chain.
+assert DelegationIdsUnique {
+    all c: Chain | valid[c] implies (all disj e1, e2: c.entries | e1.delegId != e2.delegId)
+}
+check DelegationIdsUnique for 6
+
+-- The leaf capability is never one of its own ancestors' parents.
+assert LeafIsNotItsOwnAncestor {
+    all c: Chain | valid[c] implies (all e: c.entries | e.parent != c.leaf)
+}
+check LeafIsNotItsOwnAncestor for 6
+
+-- Authority never grows along the chain: transitively, every hop grants no more
+-- than any of its root-ward ancestors — so the leaf-most hop can never exceed
+-- the root-most grant.
+assert AuthorityNonIncreasing {
+    all c: Chain | valid[c] implies
+        (all e: c.entries, a: e.^prev | e.amount <= a.amount)
+}
+check AuthorityNonIncreasing for 6 but 5 int
+
+-- ==========================================================================
+-- Non-vacuity: a genuine valid multi-hop chain exists.
+-- ==========================================================================
+pred showChain {
+    some c: Chain | valid[c] and #c.entries >= 2
+}
+run showChain for 6 but 5 int

--- a/packages/gate/capability-receipt.js
+++ b/packages/gate/capability-receipt.js
@@ -175,9 +175,33 @@ function capabilityEnvelopeFingerprint(capabilityReceipt) {
   }), 'utf8'))}`;
 }
 
-function assertDelegationChain(chain) {
+/**
+ * Validate a delegation chain at ingest time.
+ *
+ * Shape and bounded length are not sufficient: a hand-crafted envelope can
+ * carry a cyclic or authority-inflating chain and still be internally
+ * consistent. This validator enforces three structural invariants that every
+ * chain produced by {@link delegateCapabilityReceipt} satisfies and that no
+ * cyclic or forged chain can:
+ *
+ *   1. Acyclicity. Each delegation is a distinct parent spend, so a
+ *      delegation_id never recurs; a capability delegates at most once as a
+ *      parent, so a parent_capability_id never recurs. Either repeat is a cycle
+ *      in the delegation graph and is rejected. The leaf capability id (when
+ *      supplied) may never appear as one of its own ancestors' parents.
+ *   2. Monotonic authority. No hop may grant more than the hop that delegated
+ *      to it: amounts are non-increasing from root to leaf. This holds
+ *      standalone here, independent of the runtime parent reserve guard.
+ *
+ * Fail-closed: any violation throws and the caller treats the envelope as
+ * malformed. Signature and per-entry shape checks are unchanged.
+ */
+function assertDelegationChain(chain, capabilityId) {
   if (chain === undefined) return [];
   if (!Array.isArray(chain) || chain.length > MAX_DELEGATES) throw new TypeError('delegation_chain must be a bounded array');
+  const seenDelegationIds = new Set();
+  const seenParentIds = new Set();
+  let previousAmount = null;
   return chain.map((entry) => {
     if (!isRecord(entry)
         || typeof entry.delegation_id !== 'string'
@@ -189,6 +213,13 @@ function assertDelegationChain(chain) {
         || typeof entry.issued_at !== 'string') {
       throw new TypeError('delegation_chain contains an invalid signed entry');
     }
+    if (seenDelegationIds.has(entry.delegation_id)) throw new TypeError('delegation_chain repeats a delegation_id (cyclic or forged chain)');
+    if (seenParentIds.has(entry.parent_capability_id)) throw new TypeError('delegation_chain repeats a parent_capability_id (cyclic delegation)');
+    if (capabilityId !== undefined && entry.parent_capability_id === capabilityId) throw new TypeError('delegation_chain references the leaf capability as a parent (broken delegation link)');
+    if (previousAmount !== null && entry.amount > previousAmount) throw new TypeError('delegation_chain grants increasing authority (non-monotonic amount)');
+    seenDelegationIds.add(entry.delegation_id);
+    seenParentIds.add(entry.parent_capability_id);
+    previousAmount = entry.amount;
     return structuredClone(entry);
   });
 }
@@ -202,7 +233,7 @@ function assertCapabilityShape(capability) {
   validateCurrency(capability.budget.currency);
   validateExpiry(capability.expiry);
   validateThreshold(capability.threshold);
-  assertDelegationChain(capability.delegation_chain);
+  assertDelegationChain(capability.delegation_chain, capability.id);
   if (capability.consumed !== 0) throw new TypeError('capability consumed is issuer-initialized and must be zero');
   return true;
 }

--- a/packages/gate/capability-receipt.test.js
+++ b/packages/gate/capability-receipt.test.js
@@ -15,6 +15,7 @@ import {
   reconstructCapabilitySecret,
   splitCapabilitySecret,
   verifyCapabilityReceipt,
+  CAPABILITY_RECEIPT_VERSION,
 } from './capability-receipt.js';
 
 const NOW = Date.parse('2026-07-18T22:00:00.000Z');
@@ -333,4 +334,148 @@ test('postgres capability state also rejects a conflicting envelope', async () =
   assert.equal(await store.registerCapability(first.capabilityReceipt), true);
   assert.equal(await store.registerCapability(first.capabilityReceipt), true);
   assert.equal(await store.registerCapability(conflicting.capabilityReceipt), false);
+});
+
+const ISO = new Date(NOW - 500).toISOString();
+
+function chainEntry({ delegation_id, parent, delegate = 'operator', amount, currency = 'USD' }) {
+  return { delegation_id, parent_capability_id: parent, delegate_id: delegate, amount, currency, issued_at: ISO };
+}
+
+// Re-sign a mutated capability envelope with a trusted issuer key so the only
+// thing standing between a forged chain and acceptance is the structural
+// ingest check, not the signature.
+function resignEnvelope(capabilityReceipt, privateKey) {
+  const body = { '@version': CAPABILITY_RECEIPT_VERSION, base_receipt_id: capabilityReceipt.receipt.payload.receipt_id, capability: capabilityReceipt.capability };
+  capabilityReceipt.capability_signature.value = sign(null, Buffer.from(canonicalize(body)), privateKey).toString('base64url');
+  return capabilityReceipt;
+}
+
+test('a valid linear delegation chain mints and verifies', () => {
+  const keys = issuer();
+  const minted = mintCapabilityReceipt(keys.receipt, options({
+    issuerPrivateKey: keys.privateKey,
+    capabilityId: 'linear_leaf',
+    secret: Buffer.alloc(32, 20),
+    delegationChain: [
+      chainEntry({ delegation_id: 'd1', parent: 'root_cap', amount: 50 }),
+      chainEntry({ delegation_id: 'd2', parent: 'mid_cap', amount: 30 }),
+    ],
+  }));
+  assert.equal(verifyCapabilityReceipt(minted.capabilityReceipt, { trustedIssuerKeys: [keys.receipt.public_key] }).ok, true);
+  assert.equal(minted.capabilityReceipt.capability.delegation_chain.length, 2);
+});
+
+test('a real multi-hop delegation produces a chain that survives acyclicity ingest', async () => {
+  const keys = issuer();
+  const parent = mintCapabilityReceipt(keys.receipt, options({
+    issuerPrivateKey: keys.privateKey,
+    capabilityId: 'acyc_parent',
+    expiry: NOW + 40_000,
+    secret: Buffer.alloc(32, 21),
+  }));
+  const store = createMemoryCapabilityStore();
+  assert.equal(store.registerCapability(parent.capabilityReceipt), true);
+
+  const child = await delegateCapabilityReceipt({
+    parentCapabilityReceipt: parent.capabilityReceipt,
+    parentSecret: parent.secret,
+    issuerPrivateKey: keys.privateKey,
+    trustedIssuerKeys: [keys.receipt.public_key],
+    budget: { amount: 40, currency: 'USD' },
+    expiry: NOW + 30_000,
+    delegateId: 'acyc-child',
+    capabilityId: 'acyc_child',
+    secret: Buffer.alloc(32, 22),
+    store,
+    now: NOW,
+  });
+  assert.equal(child.ok, true);
+
+  const grandchild = await delegateCapabilityReceipt({
+    parentCapabilityReceipt: child.capabilityReceipt,
+    parentSecret: child.secret,
+    issuerPrivateKey: keys.privateKey,
+    trustedIssuerKeys: [keys.receipt.public_key],
+    budget: { amount: 20, currency: 'USD' },
+    expiry: NOW + 20_000,
+    delegateId: 'acyc-grandchild',
+    capabilityId: 'acyc_grandchild',
+    secret: Buffer.alloc(32, 23),
+    store,
+    now: NOW,
+  });
+  assert.equal(grandchild.ok, true);
+  const chain = grandchild.capabilityReceipt.capability.delegation_chain;
+  assert.equal(chain.length, 2);
+  // Distinct parents, non-increasing amount: a genuine chain is a simple path.
+  assert.equal(new Set(chain.map((e) => e.parent_capability_id)).size, 2);
+  assert.ok(chain[1].amount <= chain[0].amount);
+  assert.equal(verifyCapabilityReceipt(grandchild.capabilityReceipt, { trustedIssuerKeys: [keys.receipt.public_key] }).ok, true);
+});
+
+test('a cyclic delegation chain is rejected at ingest, even when validly signed', () => {
+  const keys = issuer();
+  const cyclic = [
+    chainEntry({ delegation_id: 'd1', parent: 'cap_A', amount: 50 }),
+    chainEntry({ delegation_id: 'd2', parent: 'cap_A', amount: 30 }), // cap_A recurs as parent
+  ];
+  // Minting refuses to construct the forged envelope.
+  assert.throws(
+    () => mintCapabilityReceipt(keys.receipt, options({ issuerPrivateKey: keys.privateKey, capabilityId: 'cyclic_leaf', delegationChain: cyclic })),
+    /repeats a parent_capability_id/,
+  );
+
+  // And a hand-crafted, correctly-signed envelope is still refused on ingest.
+  const good = mintCapabilityReceipt(keys.receipt, options({ issuerPrivateKey: keys.privateKey, capabilityId: 'cyclic_leaf', secret: Buffer.alloc(32, 24) }));
+  const forged = structuredClone(good.capabilityReceipt);
+  forged.capability.delegation_chain = cyclic;
+  resignEnvelope(forged, keys.privateKey);
+  const verified = verifyCapabilityReceipt(forged, { trustedIssuerKeys: [keys.receipt.public_key] });
+  assert.equal(verified.ok, false);
+  assert.equal(verified.reason, 'capability_malformed');
+});
+
+test('a repeated delegation_id is rejected as a cycle', () => {
+  const keys = issuer();
+  assert.throws(
+    () => mintCapabilityReceipt(keys.receipt, options({
+      issuerPrivateKey: keys.privateKey,
+      capabilityId: 'dupid_leaf',
+      delegationChain: [
+        chainEntry({ delegation_id: 'same', parent: 'cap_A', amount: 20 }),
+        chainEntry({ delegation_id: 'same', parent: 'cap_B', amount: 10 }),
+      ],
+    })),
+    /repeats a delegation_id/,
+  );
+});
+
+test('a delegation chain that grants increasing authority is rejected', () => {
+  const keys = issuer();
+  assert.throws(
+    () => mintCapabilityReceipt(keys.receipt, options({
+      issuerPrivateKey: keys.privateKey,
+      capabilityId: 'inflate_leaf',
+      delegationChain: [
+        chainEntry({ delegation_id: 'd1', parent: 'cap_A', amount: 30 }),
+        chainEntry({ delegation_id: 'd2', parent: 'cap_B', amount: 50 }), // 50 > 30
+      ],
+    })),
+    /increasing authority/,
+  );
+});
+
+test('a delegation chain naming the leaf capability as a parent is rejected as a broken link', () => {
+  const keys = issuer();
+  assert.throws(
+    () => mintCapabilityReceipt(keys.receipt, options({
+      issuerPrivateKey: keys.privateKey,
+      capabilityId: 'broken_leaf',
+      delegationChain: [
+        chainEntry({ delegation_id: 'd1', parent: 'broken_leaf', amount: 10 }), // parent == leaf id
+      ],
+    })),
+    /references the leaf capability as a parent/,
+  );
 });


### PR DESCRIPTION
## The gap

`packages/gate/capability-receipt.js` `assertDelegationChain` validated only chain length (`<= MAX_DELEGATES`) and per-entry shape. It performed **no cycle check** and no standalone authority check, and `mintCapabilityReceipt` / `delegateCapabilityReceipt` accept an arbitrary `delegation_chain`. A hand-crafted (or forged-but-validly-signed) envelope could carry a **cyclic** or **authority-inflating** chain and still verify. `DelegationAuthorityNonIncreasing` (surfaced by `formal/ep_capability.tla`) held only *emergently* via the runtime parent reserve guard, with no standalone `childAmount <= parentAmount` assertion at chain-validation time.

## The fix

Three fail-closed ingest invariants added to `assertDelegationChain`, checked on the chain alone (so they gate on both the mint path and the untrusted `verifyCapabilityReceipt` ingest path, before the signature is trusted):

1. **Acyclicity** — no `delegation_id` recurs (each hop is a distinct parent spend); no `parent_capability_id` recurs (a capability delegates at most once as a parent); the leaf `capability.id` never appears as a parent in its own chain. Any repeat is a cycle → reject.
2. **Monotonic authority** — amounts are non-increasing from root to leaf. Standalone, independent of the runtime reserve guard (which is retained, not weakened).

Existing signature and per-entry shape checks are unchanged.

## Tests (`node --test packages/gate`)

New cases: valid linear chain passes; a **real multi-hop** delegation (parent → child → grandchild via `delegateCapabilityReceipt`) passes acyclicity ingest; cyclic (repeated parent), repeated-`delegation_id`, increasing-amount, and leaf-as-parent chains are **rejected** — including a validly re-signed forged envelope, proving the structural check gates *before* trust.

Honesty check: the four rejection tests were confirmed to **pass through (no throw)** against the pre-change validator (reverted source, re-ran: 10 pass / 4 fail), then the hardened source was restored.

- Before (pre-change validator, new tests): 10 pass, 4 fail
- After: capability-receipt.test.js 14/14 pass; **full gate suite 631 pass, 0 fail**

## Formal

Adds `formal/ep_delegation.als` (Alloy) asserting `DelegationAcyclic`, `DelegationIdsUnique`, `LeafIsNotItsOwnAncestor`, `AuthorityNonIncreasing`, authored to the existing `formal/*.als` convention. **Not executed here** — the Alloy 6 jar (~80 MB) was not fetched in this environment; run per `formal/RUN_ALLOY.md`.

## Scope / deconfliction

Touches only `packages/gate/capability-receipt.js`, its test, and `formal/ep_delegation.als`. Does **not** touch the PR #292 capability-spend-enforcement guard surface. No shared count files edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)