### PR TITLE
security(fuzz): continuous adversarial fuzzing harness (audit GAP 7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,24 @@ jobs:
       - name: Next.js production build
         run: npx next build
 
+  # ── Job 2b: Continuous adversarial fuzzing (audit GAP 7) ─────────
+  # A seeded, deterministic property fuzzer for the concurrency-sensitive
+  # surfaces. The async-guard bypass was a parallel-consumption race; this
+  # bounded fixed-seed batch drives many interleaved reserve/commit and
+  # consume-once attempts against the REAL capability and consumption stores
+  # every push and asserts the safety invariants. A regression fails at a named
+  # seed the author can replay locally. The deeper nightly sweep is documented
+  # in fuzz/README.md. No product deps, no network — Node built-ins only.
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 20
+      - name: Run the bounded fixed-seed fuzz batch (<60s)
+        run: node fuzz/ci-batch.mjs
+
   # ── Job 3: Write discipline ──────────────────────────────────────
   write-discipline:
     runs-on: ubuntu-latest

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -7,15 +7,25 @@ sensitive surfaces of the protocol.
 
 The async-guard bypass was a **parallel-consumption race**: a check-then-act
 window between reading a budget / consumption record and mutating it, so two
-concurrent attempts could both pass the check. A property fuzzer that drives
-many interleaved reserve/commit and consume-once attempts against the real
-stores and asserts the safety invariants after every scenario catches that bug
-class before it ships.
+concurrent attempts could both pass the check.
 
-The harness is **not** a no-op. Its `invariant()` primitive was verified to fire
-on a deliberately-broken store with exactly this race (an `await` between the
-budget read and the mutation): 50 concurrent bids of 60 against a budget of 100
-committed a total of 3000, and the check flagged `committed-sum=3000 > budget`.
+Two complementary drivers, honest about what each covers:
+
+- **`concurrent-race`** (the real race detector). Fires every op via
+  `Promise.all` true concurrency. If a store method ever has an internal
+  check-then-act `await`, concurrent calls interleave INSIDE it and over-commit.
+  Against the shipped atomic store it passes — it is a **regression guard**: a
+  reintroduced non-atomic reserve/commit would make it fail in CI. Its teeth are
+  proven in `race-teeth.selftest.mjs`: the same driver run against a deliberately
+  non-atomic store (an `await` between the budget read and the mutation) fires
+  the over-budget invariant, and against the real store it stays clean.
+- **`capability-race`** / **`handshake-consume`** (invariant regression tests).
+  These interleave at whole-METHOD boundaries under `interleave()`, which awaits
+  each step. Because the store methods are run-to-completion atomic, this does
+  NOT manufacture an intra-method race; it is a deterministic accounting /
+  linearizability guard over the real stores plus adversarial ops (double-commit,
+  forged token, over-budget bids). Stated plainly so no one mistakes it for a
+  concurrency race detector — that is `concurrent-race`'s job.
 
 ## Determinism
 
@@ -23,6 +33,9 @@ committed a total of 3000, and the check flagged `committed-sum=3000 > budget`.
 - The interleaving scheduler (`interleave`) draws every scheduling decision from
   that same seeded RNG and awaits each step to completion, so interleaving
   happens only at operation-step boundaries and the whole run is reproducible.
+  The `concurrent` driver (used by `concurrent-race`) instead fires all op
+  sequences via `Promise.all`; it is deterministic in verdict because the store
+  methods are atomic, and its teeth are proven by the self-test.
 - No `Math.random`, no `Date.now`: the stores take an injectable `now`, and the
   batch pins it to a fixed logical clock.
 - Capability ids and reservation tokens are `node:crypto` UUIDs and so differ

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,111 @@
+# Continuous adversarial fuzzing (audit GAP 7)
+
+A seeded, deterministic, CI-runnable property fuzzer for the concurrency-
+sensitive surfaces of the protocol.
+
+## Why this exists
+
+The async-guard bypass was a **parallel-consumption race**: a check-then-act
+window between reading a budget / consumption record and mutating it, so two
+concurrent attempts could both pass the check. A property fuzzer that drives
+many interleaved reserve/commit and consume-once attempts against the real
+stores and asserts the safety invariants after every scenario catches that bug
+class before it ships.
+
+The harness is **not** a no-op. Its `invariant()` primitive was verified to fire
+on a deliberately-broken store with exactly this race (an `await` between the
+budget read and the mutation): 50 concurrent bids of 60 against a budget of 100
+committed a total of 3000, and the check flagged `committed-sum=3000 > budget`.
+
+## Determinism
+
+- The RNG is `mulberry32`, seeded from an integer. Same seed → same stream.
+- The interleaving scheduler (`interleave`) draws every scheduling decision from
+  that same seeded RNG and awaits each step to completion, so interleaving
+  happens only at operation-step boundaries and the whole run is reproducible.
+- No `Math.random`, no `Date.now`: the stores take an injectable `now`, and the
+  batch pins it to a fixed logical clock.
+- Capability ids and reservation tokens are `node:crypto` UUIDs and so differ
+  run to run, but they are opaque to every invariant — the PASS/FAIL verdict is
+  stable for a given seed. (`--seed 7` twice drives the identical 6515 ops.)
+
+## Targets
+
+Both targets import and drive the **actual shipped modules**, never a reimpl.
+
+### `capability-race` — `packages/gate/capability-receipt.js`
+
+Mints a fresh capability, registers it in `createMemoryCapabilityStore()`, then
+interleaves N randomized spend operations (reserve → commit) plus a seeded mix
+of adversarial operations (double-commit, forged-token commit). Invariants:
+
+- `total-committed<=budget` — checked on both an independently-tracked committed
+  sum and the store's own `consumed_amount` (never trusting the store's
+  self-report alone).
+- `no-double-commit` — a committed operation cannot commit again; distinct
+  committed operations only.
+- `unique-reservation-tokens-among-commits`.
+- `consumed-monotonic` — the consumed counter never decreases.
+- `consumed+reserved<=budget` at settle.
+- `consumed==sum-of-committed-amounts`.
+
+### `handshake-consume` — `packages/gate/store.js`
+
+**Scope, stated honestly.** The production handshake consume-once guarantee
+(`lib/handshake/consume.js`) is enforced inside PostgreSQL — the
+`consume_handshake_atomic` RPC takes `FOR UPDATE` on the handshake row and a
+`UNIQUE` constraint on `handshake_id` makes a second consume a `23505` error
+(migrations 074 / 085). That path needs a live Supabase/Postgres and is **not**
+runnable in a CI fuzz harness, so this target does not pretend to drive it.
+
+What it drives is the real, shipped, in-process consumption store that enforces
+the identical invariant the handshake DB path mirrors — a key authorizes exactly
+one action, once. `MemoryConsumptionStore` and `createDurableConsumptionStore`
+are imported unmodified. The durable scenario runs several independent store
+instances over one shared backend (the fleet model: many pods, one Redis/
+Postgres). Invariants:
+
+- `consume-once` — across all concurrent consumers of a single key, exactly one
+  succeeds.
+- `no-consume-after-commit` — a spent key never consumes again.
+- `reservation-ownership-fenced` — a non-owner store cannot commit another
+  store's reservation.
+
+## Running
+
+```sh
+# One target, one seed, replayable:
+node fuzz/harness.mjs capability-race --seed 7 --iterations 300
+
+# A seed range:
+node fuzz/harness.mjs handshake-consume --seeds 1..30 --iterations 300
+
+# The exact bounded batch CI runs on every push (finishes in ~1.5s locally):
+node fuzz/ci-batch.mjs
+```
+
+On the first invariant violation the harness prints the target, seed, iteration,
+invariant, detail, and the exact replay command, then exits non-zero.
+
+## CI
+
+The `fuzz` job in `.github/workflows/ci.yml` runs `node fuzz/ci-batch.mjs` on
+every push and pull request. The batch is fixed-seed and time-bounded
+(`capability-race` and `handshake-consume`, seeds 1..24 × 250 iterations each;
+~1.5s locally, well under the 60s budget) so it is a deterministic gate, not a
+flaky one.
+
+### Nightly-deeper (documented, not yet scheduled)
+
+A deeper sweep — wider seed range and higher iteration counts, e.g.
+
+```sh
+node fuzz/harness.mjs capability-race   --seeds 1..500 --iterations 2000
+node fuzz/harness.mjs handshake-consume --seeds 1..500 --iterations 2000
+```
+
+is intended to run on a nightly `schedule:` trigger so a rare interleaving that
+the bounded per-push batch does not reach still gets exercised daily. Wire it as
+a separate scheduled workflow (or a `schedule:`-gated job) rather than adding
+minutes to the per-push path. A failing nightly seed is reproducible with the
+same `--seed` locally.

--- a/fuzz/ci-batch.mjs
+++ b/fuzz/ci-batch.mjs
@@ -21,6 +21,7 @@ const harness = join(HERE, 'harness.mjs');
 // [target, seedsSpec, iterationsPerSeed]
 const BATCH = [
   ['capability-race', '1..24', 250],
+  ['concurrent-race', '1..24', 250],
   ['handshake-consume', '1..24', 250],
 ];
 

--- a/fuzz/ci-batch.mjs
+++ b/fuzz/ci-batch.mjs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bounded, fixed-seed fuzz batch for the per-push CI job (audit GAP 7).
+//
+// Deterministic and time-bounded: the same seeds and iteration counts run on
+// every push, so a regression that breaks a concurrency invariant fails CI at a
+// named seed the author can replay locally with:
+//
+//   node fuzz/harness.mjs <target> --seed <SEED> --iterations <ITER>
+//
+// This batch is intentionally sized to finish well under a minute on a GitHub
+// runner. The deeper, longer nightly sweep is documented in fuzz/README.md.
+
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const harness = join(HERE, 'harness.mjs');
+
+// [target, seedsSpec, iterationsPerSeed]
+const BATCH = [
+  ['capability-race', '1..24', 250],
+  ['handshake-consume', '1..24', 250],
+];
+
+const startedAt = process.hrtime.bigint();
+let failed = false;
+
+for (const [target, seeds, iterations] of BATCH) {
+  const result = spawnSync(
+    process.execPath,
+    [harness, target, '--seeds', seeds, '--iterations', String(iterations)],
+    { stdio: 'inherit' },
+  );
+  if (result.status !== 0) {
+    failed = true;
+    break;
+  }
+}
+
+const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
+process.stdout.write(`\nfuzz CI batch ${failed ? 'FAILED' : 'passed'} in ${elapsedMs.toFixed(0)} ms\n`);
+process.exit(failed ? 1 : 0);

--- a/fuzz/harness.mjs
+++ b/fuzz/harness.mjs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// EP continuous adversarial fuzzing harness (audit GAP 7).
+//
+// A seeded, deterministic, CI-runnable property fuzzer for the concurrency-
+// sensitive surfaces of the protocol. The async-guard bypass that motivated
+// this harness was a parallel-consumption race: a check-then-act window between
+// a budget/consumption read and its mutation. A fuzzer that drives many
+// concurrent reserve/commit attempts, interleaved at operation-step boundaries,
+// and asserts the safety invariants after every scenario would have flagged it.
+//
+// Design goals:
+//   1. REPRODUCIBLE. The RNG is seeded (mulberry32); the interleaving scheduler
+//      draws every scheduling decision from that same RNG. Same seed => same
+//      logical operation sequence and the same PASS/FAIL verdict. (Reservation
+//      tokens / capability ids are node crypto UUIDs and therefore differ run to
+//      run; they are opaque to every invariant, so the verdict stays stable.)
+//   2. NO wall-clock / Math.random nondeterminism in the harness itself.
+//   3. Targets import and exercise the ACTUAL shipped modules — never a reimpl.
+//
+// Usage:
+//   node fuzz/harness.mjs <target> [--seed N] [--seeds A..B] [--iterations K]
+//
+// Exit code is non-zero on the first invariant violation, and the failing seed
+// + iteration are printed so the exact scenario can be replayed with --seed.
+
+import { pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** Thrown by a target when a safety invariant is violated by real code. */
+export class InvariantViolation extends Error {
+  constructor(invariant, detail) {
+    super(`invariant violated: ${invariant} — ${detail}`);
+    this.name = 'InvariantViolation';
+    this.invariant = invariant;
+    this.detail = detail;
+  }
+}
+
+/** Assert helper that raises a typed InvariantViolation (not a bare Error). */
+export function invariant(condition, name, detail) {
+  if (!condition) throw new InvariantViolation(name, detail);
+}
+
+/**
+ * mulberry32 — a small, fast, fully deterministic 32-bit PRNG. Seeded once;
+ * produces the identical stream for the identical seed on every platform.
+ */
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function next() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** A seeded RNG facade with the small vocabulary the targets need. */
+export function createRng(seed) {
+  const next = mulberry32(seed);
+  return {
+    seed,
+    next,
+    /** integer in [min, max] inclusive */
+    int(min, max) {
+      if (max < min) return min;
+      return min + Math.floor(next() * (max - min + 1));
+    },
+    /** true with probability p */
+    bool(p = 0.5) {
+      return next() < p;
+    },
+    pick(arr) {
+      return arr[this.int(0, arr.length - 1)];
+    },
+  };
+}
+
+/**
+ * Cooperative interleaving scheduler.
+ *
+ * `ops` is an array of operations; each operation is an array of async step
+ * thunks. The scheduler repeatedly picks a still-running operation at random
+ * (from the seeded RNG) and advances it exactly one step, awaiting that step to
+ * completion before choosing the next. Interleaving therefore happens at step
+ * boundaries: modelling, for example, reserve() as one step and a later
+ * commit() as another, with other operations' steps interleaved in between —
+ * precisely the check-then-act window a parallel-consumption race exploits.
+ *
+ * Because the choice is drawn from the seeded RNG and each step is awaited
+ * fully, the whole interleaving is deterministic for a given seed.
+ */
+export async function interleave(ops, rng) {
+  const cursors = ops
+    .map((steps, id) => ({ id, steps, pos: 0 }))
+    .filter((c) => c.steps.length > 0);
+  let stepCount = 0;
+  while (cursors.length > 0) {
+    const idx = rng.int(0, cursors.length - 1);
+    const cursor = cursors[idx];
+    await cursor.steps[cursor.pos]();
+    cursor.pos += 1;
+    stepCount += 1;
+    if (cursor.pos >= cursor.steps.length) cursors.splice(idx, 1);
+  }
+  return stepCount;
+}
+
+const TARGETS = {
+  'capability-race': './targets/capability-race.mjs',
+  'handshake-consume': './targets/handshake-consume.mjs',
+};
+
+function parseArgs(argv) {
+  const args = { target: null, seed: 1, seeds: null, iterations: 200 };
+  const rest = argv.slice(2);
+  for (let i = 0; i < rest.length; i += 1) {
+    const token = rest[i];
+    if (token === '--seed') args.seed = Number(rest[(i += 1)]);
+    else if (token === '--seeds') args.seeds = rest[(i += 1)];
+    else if (token === '--iterations') args.iterations = Number(rest[(i += 1)]);
+    else if (!args.target) args.target = token;
+  }
+  return args;
+}
+
+function seedRange(spec, fallbackSeed) {
+  if (!spec) return [fallbackSeed];
+  const match = /^(-?\d+)\.\.(-?\d+)$/.exec(spec.trim());
+  if (!match) throw new Error(`--seeds must look like A..B, got ${spec}`);
+  const start = Number(match[1]);
+  const end = Number(match[2]);
+  const seeds = [];
+  for (let s = start; s <= end; s += 1) seeds.push(s);
+  return seeds;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (!args.target || !TARGETS[args.target]) {
+    process.stderr.write(
+      `usage: node fuzz/harness.mjs <${Object.keys(TARGETS).join('|')}> `
+        + '[--seed N] [--seeds A..B] [--iterations K]\n',
+    );
+    process.exit(2);
+    return;
+  }
+
+  const targetModule = await import(pathToFileURL(join(HERE, TARGETS[args.target])).href);
+  const target = targetModule.default;
+  const seeds = seedRange(args.seeds, args.seed);
+  const iterations = Number.isSafeInteger(args.iterations) && args.iterations > 0 ? args.iterations : 200;
+
+  const startedAt = process.hrtime.bigint();
+  let totalIterations = 0;
+  let totalOps = 0;
+
+  process.stdout.write(
+    `fuzz target=${target.name} seeds=${seeds[0]}..${seeds[seeds.length - 1]} `
+      + `iterations/seed=${iterations}\n`,
+  );
+  process.stdout.write(`invariants: ${target.invariants.join(', ')}\n`);
+
+  for (const seed of seeds) {
+    const rng = createRng(seed);
+    for (let iteration = 0; iteration < iterations; iteration += 1) {
+      try {
+        const result = await target.iterate({ rng, iteration, seed });
+        totalIterations += 1;
+        totalOps += result?.ops ?? 0;
+      } catch (error) {
+        if (error instanceof InvariantViolation) {
+          process.stdout.write('\n');
+          process.stdout.write('!!! FUZZ FOUND AN INVARIANT VIOLATION !!!\n');
+          process.stdout.write(`  target:     ${target.name}\n`);
+          process.stdout.write(`  seed:       ${seed}\n`);
+          process.stdout.write(`  iteration:  ${iteration}\n`);
+          process.stdout.write(`  invariant:  ${error.invariant}\n`);
+          process.stdout.write(`  detail:     ${error.detail}\n`);
+          process.stdout.write(`  replay:     node fuzz/harness.mjs ${target.name} --seed ${seed} --iterations ${iteration + 1}\n`);
+          process.exit(1);
+          return;
+        }
+        throw error;
+      }
+    }
+  }
+
+  const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
+  process.stdout.write(
+    `OK  ${totalIterations} iterations across ${seeds.length} seed(s), `
+      + `${totalOps} concurrent operations driven, all invariants held `
+      + `(${elapsedMs.toFixed(0)} ms)\n`,
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((error) => {
+    process.stderr.write(`fuzz harness crashed: ${error?.stack || error}\n`);
+    process.exit(3);
+  });
+}

--- a/fuzz/harness.mjs
+++ b/fuzz/harness.mjs
@@ -111,8 +111,28 @@ export async function interleave(ops, rng) {
   return stepCount;
 }
 
+/**
+ * TRUE-concurrency driver. Unlike interleave() (which advances one op-step at a
+ * time and awaits each, so a store method runs atomically to completion),
+ * concurrent() fires every op-sequence at once via Promise.all. If any store
+ * method has an internal check-then-act `await` (the async-guard bug class),
+ * concurrent calls interleave INSIDE that method and can violate an invariant.
+ * Against a correctly-atomic store this simply passes; its value is as a
+ * regression guard — a reintroduced non-atomic reserve/commit would be caught.
+ * fuzz/race-teeth.selftest.mjs proves this driver DOES catch a non-atomic store.
+ *
+ * `opSequences` is an array of arrays of async step thunks; each sequence runs
+ * its steps in order, all sequences run concurrently.
+ */
+export async function concurrent(opSequences) {
+  await Promise.all(opSequences.map(async (steps) => {
+    for (const step of steps) await step();
+  }));
+}
+
 const TARGETS = {
   'capability-race': './targets/capability-race.mjs',
+  'concurrent-race': './targets/concurrent-race.mjs',
   'handshake-consume': './targets/handshake-consume.mjs',
 };
 

--- a/fuzz/race-teeth.selftest.mjs
+++ b/fuzz/race-teeth.selftest.mjs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Proves the true-concurrency driver (harness.concurrent) has TEETH: it detects
+// the async-guard bug class — a check-then-act window between a budget read and
+// its mutation. Named .selftest.mjs so the vitest gate never collects it; run
+// with: node --test fuzz/race-teeth.selftest.mjs
+//
+// Two assertions:
+//   1. Against a deliberately NON-ATOMIC store (an `await` between reading the
+//      budget and mutating it), driven concurrently, the over-budget invariant
+//      MUST fire — the exact failure a reintroduced async-guard bug would cause.
+//   2. Against the SHIPPED atomic createMemoryCapabilityStore, the same driver
+//      MUST pass — confirming the guard is a clean regression signal, not noise.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { generateKeyPairSync } from 'node:crypto';
+import { concurrent, InvariantViolation, invariant } from './harness.mjs';
+import {
+  createMemoryCapabilityStore,
+  mintCapabilityReceipt,
+} from '../packages/gate/capability-receipt.js';
+
+const { privateKey } = generateKeyPairSync('ed25519');
+const CURRENCY = 'usd';
+const NOW = 1_700_000_000_000;
+const clock = () => NOW;
+const EXPIRY = new Date(NOW + 86_400_000).toISOString();
+const baseReceipt = (id) => ({ '@version': 'EP-RECEIPT-v1', payload: { receipt_id: id } });
+
+// A deliberately NON-ATOMIC budget store: reserveSpend reads the remaining
+// budget, yields to the event loop (the check-then-act window), then mutates.
+// This is exactly the async-guard bug shape. Concurrent callers both see budget
+// available and both reserve -> over-commit.
+function nonAtomicStore(budget) {
+  const state = { budget, consumed: 0, reserved: 0 };
+  const ops = new Map();
+  return {
+    getState: () => ({ ...state }),
+    async reserveSpend({ operationId, amount }) {
+      const available = state.budget - state.consumed - state.reserved; // READ
+      await Promise.resolve();                                          // await gap
+      if (available < amount) return { ok: false, reason: 'budget_exceeded' };
+      state.reserved += amount;                                        // ACT (too late)
+      const token = `tok-${operationId}`;
+      ops.set(operationId, { amount, token, status: 'reserved' });
+      return { ok: true, reservation_token: token };
+    },
+    async commitSpend({ operationId, reservationToken }) {
+      const op = ops.get(operationId);
+      if (!op || op.status !== 'reserved' || op.reservation_token === reservationToken) {
+        // (token match check intentionally loose — not what this test probes)
+      }
+      if (!op || op.status !== 'reserved') return { ok: false, reason: 'already' };
+      op.status = 'committed';
+      state.reserved -= op.amount;
+      state.consumed += op.amount;
+      return { ok: true };
+    },
+  };
+}
+
+function spendSeq(store, operationId, amount, acc) {
+  const s = { token: null };
+  return [
+    async () => { const r = await store.reserveSpend({ operationId, amount }); if (r.ok) s.token = r.reservation_token; },
+    async () => { if (!s.token) return; const c = await store.commitSpend({ operationId, reservationToken: s.token }); if (c.ok) acc.committed += amount; },
+  ];
+}
+
+test('concurrent driver DETECTS over-commit in a non-atomic store (teeth)', async () => {
+  const budget = 100;
+  const store = nonAtomicStore(budget);
+  const acc = { committed: 0 };
+  // 10 concurrent ops each bidding 40 against a budget of 100: an atomic store
+  // commits at most 2 (80); the non-atomic store lets many pass the stale read.
+  const seqs = Array.from({ length: 10 }, (_, i) => spendSeq(store, `op${i}`, 40, acc));
+  await concurrent(seqs);
+  // The check the fuzz target runs. Against this racy store it MUST fire.
+  assert.throws(
+    () => invariant(store.getState().consumed <= budget, 'total-committed<=budget',
+      `consumed=${store.getState().consumed} budget=${budget}`),
+    InvariantViolation,
+    'the concurrent driver failed to surface the non-atomic over-commit',
+  );
+  assert.ok(store.getState().consumed > budget, `expected over-commit, got consumed=${store.getState().consumed}`);
+});
+
+test('concurrent driver PASSES against the shipped atomic store (clean signal)', async () => {
+  const budget = 100;
+  const capabilityId = 'cap-teeth';
+  const { capabilityReceipt } = mintCapabilityReceipt(baseReceipt('r-teeth'), {
+    issuerPrivateKey: privateKey, budget: { amount: budget, currency: CURRENCY }, expiry: EXPIRY, capabilityId,
+  });
+  const store = createMemoryCapabilityStore();
+  store.registerCapability(capabilityReceipt);
+  const fingerprint = store.getState(capabilityId).capability_fingerprint;
+  const acc = { committed: 0 };
+  const seqs = Array.from({ length: 10 }, (_, i) => {
+    const s = { token: null };
+    return [
+      async () => {
+        const r = await store.reserveSpend({ capabilityId, capabilityFingerprint: fingerprint, operationId: `op${i}`, amount: 40, currency: CURRENCY, now: clock });
+        if (r.ok) s.token = r.reservation_token;
+      },
+      async () => { if (!s.token) return; const c = await store.commitSpend({ capabilityId, operationId: `op${i}`, reservationToken: s.token, now: clock }); if (c.ok) acc.committed += 40; },
+    ];
+  });
+  await concurrent(seqs);
+  const st = store.getState(capabilityId);
+  assert.ok(st.consumed_amount <= budget, `atomic store over-committed: ${st.consumed_amount}`);
+  assert.equal(st.consumed_amount, acc.committed);
+});

--- a/fuzz/targets/capability-race.mjs
+++ b/fuzz/targets/capability-race.mjs
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fuzz target: parallel-consumption race against the capability budget store.
+//
+// This is the exact class of bug the async-guard bypass belonged to: many
+// concurrent reserve/commit attempts against ONE capability, where a
+// check-then-act window between the budget read and its mutation could let the
+// total committed spend exceed the immutable budget, or let a single
+// reservation commit twice.
+//
+// The target imports and drives the ACTUAL createMemoryCapabilityStore and
+// mintCapabilityReceipt exported from packages/gate/capability-receipt.js — no
+// reimplementation. Each scenario mints a fresh capability, registers it, then
+// interleaves N randomized spend operations (each: reserve -> commit) plus a
+// seeded mix of adversarial operations (double-commit, wrong-token commit,
+// over-budget bids). After the interleaving settles, the store's own state is
+// checked against the safety invariants.
+
+import { generateKeyPairSync } from 'node:crypto';
+import {
+  createMemoryCapabilityStore,
+  mintCapabilityReceipt,
+} from '../../packages/gate/capability-receipt.js';
+import { invariant } from '../harness.mjs';
+
+// One issuer key for the whole run; irrelevant to the invariants, so reused to
+// keep each iteration cheap.
+const { privateKey } = generateKeyPairSync('ed25519');
+
+function baseReceipt(receiptId) {
+  return { '@version': 'EP-RECEIPT-v1', payload: { receipt_id: receiptId } };
+}
+
+const CURRENCY = 'usd';
+// A fixed logical clock well before the capability expiry; the store treats
+// `now` as an injectable function, so no Date.now nondeterminism enters here.
+const NOW = 1_700_000_000_000;
+const clock = () => NOW;
+const EXPIRY = new Date(NOW + 86_400_000).toISOString();
+
+export default {
+  name: 'capability-race',
+  invariants: [
+    'total-committed<=budget',
+    'no-double-commit',
+    'unique-reservation-tokens-among-commits',
+    'consumed-monotonic',
+    'consumed+reserved<=budget',
+    'consumed==sum-of-committed-amounts',
+  ],
+  async iterate({ rng, iteration }) {
+    const budget = rng.int(20, 500);
+    const opCount = rng.int(4, 40);
+    // Per-op max bid ranges from "tiny" to "can exceed budget alone", so both
+    // the fits-easily and the heavily-contended regimes get exercised.
+    const maxBid = rng.int(1, Math.max(2, Math.floor(budget / 2)));
+
+    const capabilityId = `cap-${iteration}-${rng.int(0, 1_000_000)}`;
+    const { capabilityReceipt } = mintCapabilityReceipt(baseReceipt(`r-${capabilityId}`), {
+      issuerPrivateKey: privateKey,
+      budget: { amount: budget, currency: CURRENCY },
+      expiry: EXPIRY,
+      capabilityId,
+    });
+
+    const store = createMemoryCapabilityStore();
+    invariant(store.registerCapability(capabilityReceipt), 'registration', 'capability failed to register');
+
+    // The envelope fingerprint reserveSpend requires is exactly the one the
+    // store computed at registration; read it back rather than recompute.
+    const fingerprint = store.getState(capabilityId).capability_fingerprint;
+
+    // Shared accounting the invariant check will compare against the store's
+    // own internal state.
+    const committedOps = [];
+    let expectedCommittedTotal = 0;
+    let lastConsumed = 0;
+
+    const assertConsumedMonotonic = () => {
+      const consumed = store.getState(capabilityId).consumed_amount;
+      invariant(consumed >= lastConsumed, 'consumed-monotonic', `consumed went ${lastConsumed} -> ${consumed}`);
+      lastConsumed = consumed;
+    };
+
+    const ops = [];
+    for (let i = 0; i < opCount; i += 1) {
+      const operationId = `op-${iteration}-${i}`;
+      const amount = rng.int(1, maxBid);
+      const kind = rng.pick(['normal', 'normal', 'normal', 'double-commit', 'wrong-token']);
+      const state = { reserved: false, token: null };
+
+      const reserveStep = async () => {
+        const r = await store.reserveSpend({
+          capabilityId,
+          capabilityFingerprint: fingerprint,
+          operationId,
+          amount,
+          currency: CURRENCY,
+          now: clock,
+        });
+        if (r.ok) {
+          state.reserved = true;
+          state.token = r.reservation_token;
+          invariant(typeof r.reservation_token === 'string' && r.reservation_token.length >= 16,
+            'reservation-token-shape', `token=${r.reservation_token}`);
+        } else {
+          // The only legitimate reasons to refuse a fresh, in-window,
+          // matching-currency reservation are budget exhaustion.
+          invariant(r.reason === 'budget_exceeded' || r.reason === 'operation_in_flight'
+            || r.reason === 'operation_already_committed',
+          'reserve-refusal-reason', `unexpected reserve refusal: ${r.reason}`);
+        }
+      };
+
+      const commitStep = async () => {
+        if (!state.reserved) return;
+        const c = await store.commitSpend({
+          capabilityId,
+          operationId,
+          reservationToken: state.token,
+          now: clock,
+        });
+        invariant(c.ok, 'commit-owner', `owner commit refused: ${c.reason}`);
+        committedOps.push({ operationId, token: state.token, amount });
+        expectedCommittedTotal += amount;
+        assertConsumedMonotonic();
+      };
+
+      if (kind === 'normal') {
+        ops.push([reserveStep, commitStep]);
+      } else if (kind === 'double-commit') {
+        // Second commit on the same operation MUST be refused (no double-spend).
+        const doubleStep = async () => {
+          if (!state.reserved) return;
+          const again = await store.commitSpend({
+            capabilityId,
+            operationId,
+            reservationToken: state.token,
+            now: clock,
+          });
+          invariant(!again.ok && again.reason === 'capability_operation_already_finalized',
+            'no-double-commit', `second commit of ${operationId} returned ${JSON.stringify(again)}`);
+        };
+        ops.push([reserveStep, commitStep, doubleStep]);
+      } else {
+        // Commit with a forged reservation token MUST be refused.
+        const wrongTokenStep = async () => {
+          if (!state.reserved) return;
+          const forged = await store.commitSpend({
+            capabilityId,
+            operationId,
+            reservationToken: 'forged-token-0000000000000000',
+            now: clock,
+          });
+          invariant(!forged.ok, 'reservation-owner-fencing', `forged-token commit of ${operationId} succeeded`);
+        };
+        ops.push([reserveStep, wrongTokenStep, commitStep]);
+      }
+    }
+
+    const { interleave } = await import('../harness.mjs');
+    await interleave(ops, rng);
+
+    // ── Invariants ─────────────────────────────────────────────────────────
+    // The primary safety check is on the amount WE independently observed the
+    // store confirm as committed — never only the store's self-reported field,
+    // which a racy implementation could clobber while still over-committing.
+    invariant(expectedCommittedTotal <= budget,
+      'total-committed<=budget',
+      `independently-tracked committed sum=${expectedCommittedTotal} budget=${budget}`);
+
+    const finalState = store.getState(capabilityId);
+
+    invariant(finalState.consumed_amount <= budget,
+      'total-committed<=budget',
+      `store consumed=${finalState.consumed_amount} budget=${budget}`);
+
+    invariant(finalState.consumed_amount === expectedCommittedTotal,
+      'consumed==sum-of-committed-amounts',
+      `store consumed=${finalState.consumed_amount} tracked=${expectedCommittedTotal}`);
+
+    invariant(finalState.consumed_amount + finalState.reserved_amount <= budget,
+      'consumed+reserved<=budget',
+      `consumed=${finalState.consumed_amount} reserved=${finalState.reserved_amount} budget=${budget}`);
+
+    const uniqueOps = new Set(committedOps.map((o) => o.operationId));
+    invariant(uniqueOps.size === committedOps.length,
+      'no-double-commit',
+      `${committedOps.length} commits but ${uniqueOps.size} distinct operations`);
+
+    const uniqueTokens = new Set(committedOps.map((o) => o.token));
+    invariant(uniqueTokens.size === committedOps.length,
+      'unique-reservation-tokens-among-commits',
+      `${committedOps.length} commits but ${uniqueTokens.size} distinct tokens`);
+
+    return { ops: opCount };
+  },
+};

--- a/fuzz/targets/capability-race.mjs
+++ b/fuzz/targets/capability-race.mjs
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Fuzz target: parallel-consumption race against the capability budget store.
+// Fuzz target: interleaved-consumption invariant regression test.
 //
-// This is the exact class of bug the async-guard bypass belonged to: many
-// concurrent reserve/commit attempts against ONE capability, where a
-// check-then-act window between the budget read and its mutation could let the
-// total committed spend exceed the immutable budget, or let a single
-// reservation commit twice.
+// HONEST SCOPE: this target interleaves reserve/commit calls at whole-METHOD
+// boundaries under the harness's interleave() scheduler, which awaits each step
+// to completion. Because the shipped store methods are synchronous bodies under
+// async (run-to-completion atomic in single-threaded JS), this does NOT
+// manufacture an intra-method check-then-act race — it is a deterministic
+// linearizability/accounting regression guard over the real store: many
+// interleaved spend operations plus adversarial ops (double-commit, forged
+// token, over-budget bids) must never violate the budget/consumption invariants.
+//
+// The TRUE-concurrency race detector (the async-guard bug class) is the sibling
+// target concurrent-race.mjs, whose teeth are proven in race-teeth.selftest.mjs.
 //
 // The target imports and drives the ACTUAL createMemoryCapabilityStore and
 // mintCapabilityReceipt exported from packages/gate/capability-receipt.js — no

--- a/fuzz/targets/concurrent-race.mjs
+++ b/fuzz/targets/concurrent-race.mjs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fuzz target: TRUE-concurrency race against the capability budget store.
+//
+// This is the target that actually exercises the async-guard bug CLASS — an
+// internal check-then-act window between a budget read and its mutation. Unlike
+// capability-race.mjs (which interleaves at whole-method boundaries under an
+// atomic-method assumption), this target fires every op via Promise.all so
+// that, if reserve/commit were ever non-atomic, concurrent calls would
+// interleave inside the method and over-commit.
+//
+// Against the shipped createMemoryCapabilityStore — whose reserve/commit bodies
+// are synchronous under async (run-to-completion atomic in single-threaded JS)
+// — every invariant holds. That is the point: this is a REGRESSION GUARD. A
+// change that reintroduces a non-atomic check-then-act reserve/commit would make
+// this target fail. fuzz/race-teeth.selftest.mjs proves the driver has teeth by
+// running it against a deliberately non-atomic store and showing the over-commit
+// invariant fires.
+
+import { generateKeyPairSync } from 'node:crypto';
+import {
+  createMemoryCapabilityStore,
+  mintCapabilityReceipt,
+} from '../../packages/gate/capability-receipt.js';
+import { invariant, concurrent } from '../harness.mjs';
+
+const { privateKey } = generateKeyPairSync('ed25519');
+const CURRENCY = 'usd';
+const NOW = 1_700_000_000_000;
+const clock = () => NOW;
+const EXPIRY = new Date(NOW + 86_400_000).toISOString();
+
+function baseReceipt(receiptId) {
+  return { '@version': 'EP-RECEIPT-v1', payload: { receipt_id: receiptId } };
+}
+
+// Build a capability + registered store; return the store, id, fingerprint.
+export function freshCapability(store, capabilityId, budget) {
+  const { capabilityReceipt } = mintCapabilityReceipt(baseReceipt(`r-${capabilityId}`), {
+    issuerPrivateKey: privateKey,
+    budget: { amount: budget, currency: CURRENCY },
+    expiry: EXPIRY,
+    capabilityId,
+  });
+  invariant(store.registerCapability(capabilityReceipt), 'registration', 'capability failed to register');
+  return store.getState(capabilityId).capability_fingerprint;
+}
+
+// One op sequence: reserve then (if reserved) commit, tracking the confirmed
+// committed amount on a shared accumulator.
+export function spendSequence({ store, capabilityId, fingerprint, operationId, amount, acc }) {
+  const state = { token: null };
+  return [
+    async () => {
+      const r = await store.reserveSpend({
+        capabilityId, capabilityFingerprint: fingerprint, operationId, amount, currency: CURRENCY, now: clock,
+      });
+      if (r.ok) state.token = r.reservation_token;
+    },
+    async () => {
+      if (!state.token) return;
+      const c = await store.commitSpend({ capabilityId, operationId, reservationToken: state.token, now: clock });
+      if (c.ok) { acc.committed += amount; acc.count += 1; }
+    },
+  ];
+}
+
+export function checkInvariants({ store, capabilityId, budget, acc }) {
+  const s = store.getState(capabilityId);
+  invariant(acc.committed <= budget, 'total-committed<=budget',
+    `independently-tracked committed sum=${acc.committed} budget=${budget}`);
+  invariant(s.consumed_amount <= budget, 'total-committed<=budget',
+    `store consumed=${s.consumed_amount} budget=${budget}`);
+  invariant(s.consumed_amount === acc.committed, 'consumed==sum-of-committed-amounts',
+    `store consumed=${s.consumed_amount} tracked=${acc.committed}`);
+  invariant(s.consumed_amount + s.reserved_amount <= budget, 'consumed+reserved<=budget',
+    `consumed=${s.consumed_amount} reserved=${s.reserved_amount} budget=${budget}`);
+}
+
+export default {
+  name: 'concurrent-race',
+  invariants: [
+    'total-committed<=budget', 'consumed==sum-of-committed-amounts', 'consumed+reserved<=budget',
+  ],
+  async iterate({ rng, iteration }) {
+    const budget = rng.int(20, 500);
+    const opCount = rng.int(4, 40);
+    const maxBid = rng.int(1, Math.max(2, Math.floor(budget / 2)));
+    const capabilityId = `cap-${iteration}-${rng.int(0, 1_000_000)}`;
+    const store = createMemoryCapabilityStore();
+    const fingerprint = freshCapability(store, capabilityId, budget);
+    const acc = { committed: 0, count: 0 };
+
+    const sequences = [];
+    for (let i = 0; i < opCount; i += 1) {
+      sequences.push(spendSequence({
+        store, capabilityId, fingerprint,
+        operationId: `op-${iteration}-${i}`, amount: rng.int(1, maxBid), acc,
+      }));
+    }
+    await concurrent(sequences);
+    checkInvariants({ store, capabilityId, budget, acc });
+    return { ops: opCount };
+  },
+};

--- a/fuzz/targets/handshake-consume.mjs
+++ b/fuzz/targets/handshake-consume.mjs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fuzz target: consume-once under concurrency.
+//
+// SCOPE, stated honestly. The production handshake consume-once guarantee
+// (lib/handshake/consume.js) is enforced inside PostgreSQL: the
+// `consume_handshake_atomic` RPC takes FOR UPDATE on the handshake row and a
+// UNIQUE constraint on handshake_id in handshake_consumptions makes a second
+// consume a 23505 error (migrations 074 / 085). That path is NOT runnable in a
+// CI fuzz harness — it needs a live Supabase/Postgres — so this target does not
+// pretend to drive it.
+//
+// What it DOES drive is the real, shipped, in-process consumption store that
+// enforces the identical invariant the handshake DB path mirrors: a receipt /
+// key authorizes exactly ONE action, once. `MemoryConsumptionStore` and
+// `createDurableConsumptionStore` are imported unmodified from
+// packages/gate/store.js. The durable-store scenario runs several independent
+// store instances over ONE shared backend — the fleet model (many pods, one
+// Redis/Postgres) — which is exactly where a naive check-then-act consume would
+// double-execute. The invariant is: across all concurrent consumers of a single
+// key, exactly one succeeds.
+
+import {
+  MemoryConsumptionStore,
+  createDurableConsumptionStore,
+  createMemoryBackend,
+} from '../../packages/gate/store.js';
+import { invariant, interleave } from '../harness.mjs';
+
+export default {
+  name: 'handshake-consume',
+  invariants: [
+    'consume-once (exactly one concurrent consumer succeeds)',
+    'no-consume-after-commit',
+    'reservation-ownership-fenced',
+  ],
+  async iterate({ rng, iteration }) {
+    const key = `handshake:${iteration}:${rng.int(0, 1_000_000)}`;
+    let opsDriven = 0;
+
+    // ── Scenario A: direct single-shot consume() on the gate store ─────────
+    // N consumers race consume(key). Replay defense requires exactly one true.
+    {
+      const store = new MemoryConsumptionStore();
+      const consumers = rng.int(2, 32);
+      opsDriven += consumers;
+      let successes = 0;
+      const ops = [];
+      for (let i = 0; i < consumers; i += 1) {
+        ops.push([
+          async () => {
+            const ok = await store.consume(key);
+            if (ok) successes += 1;
+          },
+        ]);
+      }
+      await interleave(ops, rng);
+      invariant(successes === 1,
+        'consume-once (exactly one concurrent consumer succeeds)',
+        `${consumers} consumers, ${successes} succeeded (expected 1)`);
+      // A post-hoc consume must also fail: the key is spent.
+      invariant((await store.consume(key)) === false,
+        'no-consume-after-commit',
+        'a later consume of an already-consumed key succeeded');
+    }
+
+    // ── Scenario B: fleet reserve/commit over ONE shared backend ───────────
+    // Independent durable-store instances model separate pods sharing a single
+    // atomic backend. Only one may reserve the key; only that owner may commit;
+    // a foreign store must not be able to commit or release another's
+    // reservation, and once committed the key must never consume again.
+    {
+      const backend = createMemoryBackend();
+      const pods = rng.int(2, 16);
+      opsDriven += pods;
+      const stores = Array.from({ length: pods }, () => createDurableConsumptionStore(backend));
+
+      const reserved = new Array(pods).fill(false);
+      let reserveWins = 0;
+      let ownerIndex = -1;
+
+      // Phase 1: every pod tries to reserve the same key, interleaved.
+      const reserveOps = stores.map((store, i) => [
+        async () => {
+          const ok = await store.reserve(key);
+          reserved[i] = ok;
+          if (ok) {
+            reserveWins += 1;
+            ownerIndex = i;
+          }
+        },
+      ]);
+      await interleave(reserveOps, rng);
+
+      invariant(reserveWins === 1,
+        'consume-once (exactly one concurrent consumer succeeds)',
+        `${pods} pods reserved the key, ${reserveWins} won (expected 1)`);
+
+      // Phase 2: a NON-owner attempting to commit must be refused (ownership
+      // fencing throws inside the store); the owner's commit must succeed.
+      for (let i = 0; i < pods; i += 1) {
+        if (i === ownerIndex) continue;
+        let refused = false;
+        try {
+          await stores[i].commit(key);
+        } catch {
+          refused = true;
+        }
+        invariant(refused,
+          'reservation-ownership-fenced',
+          `pod ${i} committed a reservation owned by pod ${ownerIndex}`);
+      }
+      await stores[ownerIndex].commit(key);
+
+      // Phase 3: the key is now committed; no store may consume it again.
+      const late = createDurableConsumptionStore(backend);
+      invariant((await late.consume(key)) === false,
+        'no-consume-after-commit',
+        'consume succeeded on an already-committed key');
+
+      return { ops: opsDriven };
+    }
+  },
+};


### PR DESCRIPTION
## What (audit GAP 7)

A seeded, deterministic, CI-runnable fuzz harness for the concurrency-sensitive surfaces (new `fuzz/` dir + one CI job, no product code touched — disjoint from PR #292).

## Adversarial review caught an overclaim, and I fixed it for real

The first cut claimed `capability-race` would have caught the async-guard bypass. It wouldn't: it interleaves at whole-**method** boundaries under a scheduler that awaits each step, so store methods run atomically and no intra-method check-then-act race is reachable. I did **not** just relabel — I made the teeth real:

- **`concurrent-race`** — a true `Promise.all` concurrency driver against the real store. Passes (the store is atomic) → a **regression guard**: a reintroduced non-atomic reserve/commit fails CI.
- **`race-teeth.selftest.mjs`** — proves the driver has teeth: run against a deliberately non-atomic store (an `await` between the budget read and mutation) the over-budget invariant **fires**; against the real store it stays clean. 2/2 node:test pass.
- **`capability-race` / `handshake-consume`** relabeled honestly as interleaving accounting/linearizability regression tests (double-commit, forged-token, over-budget refusals), not race detectors.

## Real output
```
concurrent-race  2400 iters / 52876 concurrent ops, all invariants held
capability-race  6000 iters / 132657 ops, all held
handshake-consume 6000 iters / 154599 ops, all held
teeth self-test: 2/2 (DETECTS non-atomic over-commit; PASSES atomic store)
fuzz CI batch passed in ~1.7s
```

Honest scope: production handshake consume-once is a Postgres unique constraint not runnable in CI without a live DB; the target fuzzes the identical invariant on the shipped in-process store, stated in the header/README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)