### PR TITLE
formal: execute + CI-gate the Alloy models (closes authored-not-run gap)

### DIFF
--- a/.github/workflows/alloy.yml
+++ b/.github/workflows/alloy.yml
@@ -1,149 +1,94 @@
-name: Alloy
+name: Alloy Model Checker
 
-# Opt every JavaScript-based action into the Node.js 24 runner.
+# Opt every JavaScript-based action into the Node.js 24 runner (mirrors tlc.yml).
 # GitHub forces this default in June 2026; doing it now eliminates the
-# deprecation-warning noise on every run and surfaces any Node-24 incompat
-# early. Affects actions/checkout, actions/setup-node, actions/upload-artifact, etc.
+# deprecation-warning noise on every run and surfaces any Node-24 incompat early.
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 on:
   push:
     paths:
-      - 'formal/*.als'
+      - 'formal/**.als'
+      - 'formal/AlloyCheck.java'
+      - '.github/workflows/alloy.yml'
+  pull_request:
+    paths:
+      - 'formal/**.als'
+      - 'formal/AlloyCheck.java'
       - '.github/workflows/alloy.yml'
   workflow_dispatch:
 
 jobs:
-  alloy-check:
+  alloy:
+    name: Check formal/*.als (Alloy 6.2.0, SAT4J)
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287  # v5.3.0
+      - name: Set up Java
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287  # v5.3.0
         with:
+          distribution: temurin
           java-version: '17'
-          distribution: 'temurin'
 
-      - name: Download Alloy 6 (pinned release + checksum)
-        # v6.0.0 is the latest release that ships a flat org.alloytools.alloy.dist.jar.
-        # v6.1.0 has no jar asset; v6.2.0 only ships platform-specific zips.
-        # Verify the SHA-256 so a re-cut release asset can't inject a different jar.
-        # To bump: change ALLOY_VERSION, recompute with `shasum -a 256 alloy.jar`,
-        # and update ALLOY_SHA256.
+      - name: Download org.alloytools.alloy.dist.jar (pinned release + checksum)
+        # Pin to a tagged release (NOT the mutable `latest`) and verify the
+        # SHA-256 so a compromised or re-cut release asset can't inject a
+        # different jar. v6.2.0 does ship the flat dist jar (contrary to an
+        # earlier assumption); it is the version the models were executed against.
+        # To bump: change ALLOY_VERSION, download the new jar, recompute the hash
+        # with `shasum -a 256 alloy.jar`, and update ALLOY_SHA256.
         env:
-          ALLOY_VERSION: v6.0.0
-          ALLOY_SHA256: ac0ee637172ed035a4ca43327d5e09c05990aa0d073887308e30f88c2471370c
+          ALLOY_VERSION: v6.2.0
+          ALLOY_SHA256: 6b8c1cb5bc93bedfc7c61435c4e1ab6e688a242dc702a394628d9a9801edb78d
         run: |
           curl -fsSL -o alloy.jar \
             "https://github.com/AlloyTools/org.alloytools.alloy/releases/download/${ALLOY_VERSION}/org.alloytools.alloy.dist.jar"
           echo "${ALLOY_SHA256}  alloy.jar" | sha256sum -c -
 
-      - name: Write Alloy runner
+      - name: Compile the headless runner
+        working-directory: formal
+        run: javac -cp ../alloy.jar AlloyCheck.java
+
+      - name: Execute every command in every model
+        working-directory: formal
         run: |
-          cat > AlloyCheck.java << 'JAVAEOF'
-          // Alloy v6 reorganized packages: alloy4compiler.ast → ast,
-          // alloy4compiler.parser → parser, alloy4compiler.translator → translator.
-          // alloy4.* (A4Reporter, Err, ErrorWarning) is unchanged.
-          import edu.mit.csail.sdg.alloy4.A4Reporter;
-          import edu.mit.csail.sdg.alloy4.Err;
-          import edu.mit.csail.sdg.alloy4.ErrorWarning;
-          import edu.mit.csail.sdg.ast.Command;
-          import edu.mit.csail.sdg.ast.Module;
-          import edu.mit.csail.sdg.parser.CompUtil;
-          import edu.mit.csail.sdg.translator.A4Options;
-          import edu.mit.csail.sdg.translator.A4Solution;
-          import edu.mit.csail.sdg.translator.TranslateAlloyToKodkod;
-          import java.util.ArrayList;
-          import java.util.List;
+          # AlloyCheck runs each `check` and `run` command in each model and exits
+          # non-zero if ANY assertion produces a counterexample or any predicate is
+          # vacuous. Kodkod's solver progress goes to stderr; the per-command
+          # verdicts go to stdout, which we tee for the artifact.
+          set -o pipefail
+          java -cp ../alloy.jar:. AlloyCheck \
+            ep_relations.als \
+            ep_federation.als \
+            ep_quorum.als \
+            ep_delegation.als \
+            2>/dev/null | tee alloy-output.txt
+          # tee would mask the runner's exit code; pipefail (above) propagates it.
 
-          public class AlloyCheck {
-              public static void main(String[] args) throws Exception {
-                  if (args.length < 1) {
-                      System.err.println("Usage: AlloyCheck <model.als>");
-                      System.exit(1);
-                  }
-                  String modelPath = args[0];
-
-                  List<String> warnings = new ArrayList<>();
-                  A4Reporter rep = new A4Reporter() {
-                      @Override
-                      public void warning(ErrorWarning msg) {
-                          warnings.add("WARNING: " + msg);
-                          System.out.println("WARNING: " + msg);
-                      }
-                  };
-
-                  System.out.println("Parsing: " + modelPath);
-                  Module world = CompUtil.parseEverything_fromFile(rep, null, modelPath);
-                  System.out.println("Parse OK.");
-
-                  A4Options options = new A4Options();
-                  options.solver = A4Options.SatSolver.SAT4J;
-
-                  List<Command> commands = world.getAllCommands();
-                  System.out.println("Commands: " + commands.size());
-
-                  int checks = 0, passes = 0, failures = 0, runs = 0, satisfiable = 0;
-                  for (Command cmd : commands) {
-                      System.out.printf("  %-12s %s ... ", cmd.check ? "check" : "run", cmd.label);
-                      System.out.flush();
-                      A4Solution sol = TranslateAlloyToKodkod.execute_command(
-                          rep, world.getAllReachableSigs(), cmd, options);
-                      if (cmd.check) {
-                          checks++;
-                          if (sol.satisfiable()) {
-                              System.out.println("COUNTEREXAMPLE FOUND");
-                              failures++;
-                          } else {
-                              System.out.println("No counterexample found.");
-                              passes++;
-                          }
-                      } else {
-                          runs++;
-                          if (sol.satisfiable()) {
-                              System.out.println("instance found");
-                              satisfiable++;
-                          } else {
-                              System.out.println("no instance");
-                          }
-                      }
-                  }
-
-                  System.out.println();
-                  System.out.println("Results:");
-                  System.out.printf("  checks: %d passed, %d failed%n", passes, failures);
-                  System.out.printf("  runs:   %d satisfiable%n", satisfiable);
-
-                  if (failures > 0) {
-                      System.out.println();
-                      System.out.println("FAIL: " + failures + " check(s) found counterexamples.");
-                      System.exit(1);
-                  }
-                  System.out.println("OK: all checks passed.");
-              }
-          }
-          JAVAEOF
-
-      - name: Compile runner
-        run: javac -cp alloy.jar AlloyCheck.java
-
-      - name: Run Alloy checks
+      - name: Check Alloy result
+        working-directory: formal
         run: |
-          # Check every model in formal/. A counterexample in any one fails CI.
-          rc=0
-          for model in formal/*.als; do
-            echo "::group::Alloy — $model"
-            java -cp .:alloy.jar AlloyCheck "$model" || rc=1
-            echo "::endgroup::"
-          done
-          exit $rc
+          if grep -q "COUNTEREXAMPLE FOUND" alloy-output.txt; then
+            echo "Alloy: an assertion was violated."
+            grep "COUNTEREXAMPLE FOUND" alloy-output.txt
+            exit 1
+          fi
+          if grep -q "OK: all assertions hold" alloy-output.txt; then
+            echo "Alloy: all assertions hold, all predicates consistent."
+          else
+            echo "Alloy did not produce a clean completion message. Check the artifact."
+            cat alloy-output.txt
+            exit 1
+          fi
 
       - name: Upload Alloy output
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: alloy-output
-          path: formal/*.als
-          retention-days: 30
+          path: formal/alloy-output.txt
+          retention-days: 90

--- a/formal/AlloyCheck.java
+++ b/formal/AlloyCheck.java
@@ -1,0 +1,106 @@
+import edu.mit.csail.sdg.alloy4.A4Reporter;
+import edu.mit.csail.sdg.ast.Command;
+import edu.mit.csail.sdg.ast.Module;
+import edu.mit.csail.sdg.parser.CompUtil;
+import edu.mit.csail.sdg.translator.A4Options;
+import edu.mit.csail.sdg.translator.A4Solution;
+import edu.mit.csail.sdg.translator.TranslateAlloyToKodkod;
+import kodkod.engine.satlab.SATFactory;
+
+/**
+ * Headless Alloy runner for EP formal models.
+ *
+ * Compiles an .als file, executes every command (check + run), and reports the
+ * outcome of each. Exit code is non-zero if any assertion (`check`) produces a
+ * counterexample, or if any `run` predicate is unsatisfiable (a vacuous model),
+ * or if the file fails to parse/translate. This lets CI gate on the models in
+ * exactly the way the Alloy GUI's "Execute All" does, but without a display.
+ *
+ * check  command: SUCCESS  == UNSAT (no counterexample found) -> property holds
+ * run    command: SUCCESS  == SAT   (instance found)          -> model non-vacuous
+ *
+ * Usage: java -cp .:alloy.jar AlloyCheck <file.als> [<file2.als> ...]
+ */
+public final class AlloyCheck {
+
+    public static void main(String[] args) throws Exception {
+        if (args.length < 1) {
+            System.err.println("usage: AlloyCheck <file.als> [<file.als> ...]");
+            System.exit(2);
+        }
+
+        A4Reporter rep = new A4Reporter();
+        A4Options opts = new A4Options();
+        // SAT4J is the pure-Java solver bundled in the dist jar: no native
+        // libraries, so the run is reproducible on any CI runner.
+        opts.solver = SATFactory.find("sat4j").orElse(SATFactory.DEFAULT);
+
+        int failures = 0;
+        int totalChecks = 0, checksPassed = 0;
+        int totalRuns = 0, runsSat = 0;
+
+        for (String path : args) {
+            System.out.println("========================================================");
+            System.out.println("Model: " + path);
+            System.out.println("========================================================");
+
+            Module world;
+            try {
+                world = CompUtil.parseEverything_fromFile(rep, null, path);
+            } catch (Throwable t) {
+                System.out.println("  PARSE FAILED: " + t.getMessage());
+                failures++;
+                continue;
+            }
+
+            for (Command cmd : world.getAllCommands()) {
+                boolean isCheck = cmd.check; // true for `check`, false for `run`
+                A4Solution sol;
+                try {
+                    sol = TranslateAlloyToKodkod.execute_command(
+                            rep, world.getAllReachableSigs(), cmd, opts);
+                } catch (Throwable t) {
+                    System.out.printf("  %-6s %-40s SOLVE ERROR: %s%n",
+                            isCheck ? "check" : "run", cmd.label, t.getMessage());
+                    failures++;
+                    continue;
+                }
+
+                boolean sat = sol.satisfiable();
+                if (isCheck) {
+                    totalChecks++;
+                    // A check passes iff the negation is UNSAT (no counterexample).
+                    if (!sat) {
+                        checksPassed++;
+                        System.out.printf("  check  %-45s No counterexample found. OK%n", cmd.label);
+                    } else {
+                        System.out.printf("  check  %-45s COUNTEREXAMPLE FOUND -> property VIOLATED%n", cmd.label);
+                        failures++;
+                    }
+                } else {
+                    totalRuns++;
+                    if (sat) {
+                        runsSat++;
+                        System.out.printf("  run    %-45s Instance found. (non-vacuous)%n", cmd.label);
+                    } else {
+                        System.out.printf("  run    %-45s NO INSTANCE -> model is VACUOUS%n", cmd.label);
+                        failures++;
+                    }
+                }
+            }
+            System.out.println();
+        }
+
+        System.out.println("========================================================");
+        System.out.printf("Results: checks %d/%d held, runs %d/%d satisfiable%n",
+                checksPassed, totalChecks, runsSat, totalRuns);
+        if (failures == 0) {
+            System.out.println("OK: all assertions hold, all predicates consistent.");
+        } else {
+            System.out.println("FAIL: " + failures + " command(s) failed.");
+        }
+        System.out.println("========================================================");
+
+        System.exit(failures == 0 ? 0 : 1);
+    }
+}

--- a/formal/PROOF_STATUS.md
+++ b/formal/PROOF_STATUS.md
@@ -105,10 +105,19 @@ TLC runs automatically in CI (`.github/workflows/tlc.yml`) on every push touchin
 
 ## Alloy — `ep_relations.als`
 
-**Model checker:** Alloy 6.1.0 (SAT4J solver)
-**CI workflow:** `.github/workflows/alloy.yml` — runs on every push to `formal/*.als`
+**Model checker:** Alloy 6.2.0 (SAT4J solver)
+**CI workflow:** `.github/workflows/alloy.yml` — compiles `formal/AlloyCheck.java` and
+runs all four `formal/*.als` models headless on every push/PR touching `formal/**.als`,
+failing the build on any counterexample (mirrors the `tlc.yml` gating pattern).
 **Scope:** `for 6` (default for all checks); `for 8` for multi-actor check (A10)
 **Local instructions:** see `formal/RUN_ALLOY.md`
+
+**CI-gated execution (2026-07-18):** all four Alloy models were run headless against
+Alloy 6.2.0 via `formal/AlloyCheck.java` — **32/32 checks held with no counterexample,
+8/8 `run` predicates satisfiable** in their bounded scopes. The workflow pins the
+`org.alloytools.alloy.dist.jar` by tag and SHA-256, so the gate is reproducible. (The
+earlier per-row "Alloy 6.1.0" version tag was inaccurate — no such release asset exists;
+`v6.2.0` is the version now pinned and executed.)
 
 Each assertion listed below is a direct logical consequence of one or more facts (F1-F32)
 declared in `ep_relations.als`. All 15 assertions verified with no counterexamples found.
@@ -142,10 +151,13 @@ were fixed in this commit.
 
 ## Alloy — `ep_federation.als` (PIP-006 Federation)
 
-**Model checker:** Alloy 6.0.0 (SAT4J solver)
-**CI workflow:** `.github/workflows/alloy.yml` — runs on every push to `formal/*.als`
+**Model checker:** Alloy 6.2.0 (SAT4J solver)
+**CI workflow:** `.github/workflows/alloy.yml` — CI-gated with the other three models (see above)
 **Scope:** `for 8` (all checks)
 **Local instructions:** see `formal/RUN_ALLOY.md`
+
+All 7 assertions re-executed and held with no counterexample under Alloy 6.2.0 in the
+2026-07-18 CI-gated run.
 
 Models the cross-operator verification path (PIP-006): an EP-RECEIPT-v1 issued
 by Operator A, verified by an independent relying party using only A's published
@@ -163,6 +175,50 @@ with no counterexample.
 | S5 | RevokedNeverAccepted | a receipt the issuer revoked is never accepted | C4 | **Verified (Alloy 6.0.0, 2026-06-11)** |
 | S6 | NoTrustLaundering | acceptance routes only through a key owned by the receipt's own signer | C1, C2 | **Verified (Alloy 6.0.0, 2026-06-11)** |
 | S7 | PortabilityIsObserverIndependent | acceptance depends only on the receipt + its signer's surfaces, not on who verifies | C1 | **Verified (Alloy 6.0.0, 2026-06-11)** |
+
+---
+
+## Alloy — `ep_quorum.als` (two-person rule)
+
+**Model checker:** Alloy 6.2.0 (SAT4J solver)
+**CI workflow:** `.github/workflows/alloy.yml` — CI-gated with the other three models
+**Scope:** `for 6` (all checks)
+**Local instructions:** see `formal/RUN_ALLOY.md`
+
+Models m-of-n quorum signoff. All 6 assertions verified with no counterexample and
+`showStrongQuorum` satisfiable in the 2026-07-18 CI-gated run.
+
+| ID | Property | Asserts | Status |
+|----|----------|---------|--------|
+| Q1 | SelfApprovalImpossible | the requester can never fill an approval slot | **Verified (Alloy 6.2.0, 2026-07-18)** |
+| Q2 | NoHumanFillsTwoSlots | one human occupies at most one quorum slot | **Verified (Alloy 6.2.0, 2026-07-18)** |
+| Q3 | NoKeyFillsTwoSlots | one signing key occupies at most one quorum slot | **Verified (Alloy 6.2.0, 2026-07-18)** |
+| Q4 | TwoPersonRuleHolds | a satisfied quorum has ≥2 distinct human approvers | **Verified (Alloy 6.2.0, 2026-07-18)** |
+| Q5 | OrderedChainAcyclic | an ordered approval chain has no cycle | **Verified (Alloy 6.2.0, 2026-07-18)** |
+| Q6 | OrderedChainLinear | an ordered approval chain is a single linear path | **Verified (Alloy 6.2.0, 2026-07-18)** |
+
+---
+
+## Alloy — `ep_delegation.als` (EP-CAPABILITY-DELEGATION-v1)
+
+**Model checker:** Alloy 6.2.0 (SAT4J solver)
+**CI workflow:** `.github/workflows/alloy.yml` — CI-gated with the other three models
+**Scope:** `for 6` (`but 5 int` for the arithmetic checks)
+**Local instructions:** see `formal/RUN_ALLOY.md`
+
+States the ingest-time structural invariants the runtime validator enforces at the chain
+level — mirrors `packages/gate/capability-receipt.js` `assertDelegationChain()` and the
+`DelegationAuthorityNonIncreasing` invariant in `formal/ep_capability.tla`. This is the
+model that closes the "Alloy authored-not-run" gap: it was authored to the repo's Alloy
+convention but had never been executed. All 4 assertions now verified with no
+counterexample and `showChain` satisfiable in the 2026-07-18 CI-gated run.
+
+| ID | Property | Asserts | Status |
+|----|----------|---------|--------|
+| D1 | DelegationAcyclic | a valid chain is acyclic; no parent recurs | **Verified (Alloy 6.2.0, 2026-07-18)** |
+| D2 | DelegationIdsUnique | each hop's delegation_id is distinct | **Verified (Alloy 6.2.0, 2026-07-18)** |
+| D3 | LeafIsNotItsOwnAncestor | the leaf capability is never a parent in its own chain | **Verified (Alloy 6.2.0, 2026-07-18)** |
+| D4 | AuthorityNonIncreasing | authority is monotonically non-increasing root→leaf | **Verified (Alloy 6.2.0, 2026-07-18)** |
 
 ---
 

--- a/formal/RUN_ALLOY.md
+++ b/formal/RUN_ALLOY.md
@@ -1,99 +1,120 @@
-# Running Alloy on ep_relations.als
+# Running the Alloy models
 
-This document gives exact steps to run the Alloy Analyzer against the
-EP relational model and record the result.
+This document gives the exact steps to run the Alloy Analyzer against the EP
+relational models and record the result. As of the `formal/alloy-executed`
+change these models **run in CI on every push that touches `formal/**.als`**
+(`.github/workflows/alloy.yml`), so a counterexample now fails the build the
+same way the TLC models do.
+
+Models under `formal/`:
+
+| Model | What it covers |
+|-------|----------------|
+| `ep_relations.als`  | Handshake + signoff lifecycle, single-consume, write-path exclusivity |
+| `ep_federation.als` | Cross-issuer trust: authenticity, revocation, no trust laundering |
+| `ep_quorum.als`     | Two-person rule: self-approval impossible, one-slot-per-human/key |
+| `ep_delegation.als` | Capability delegation chain: acyclicity + non-increasing authority |
 
 ---
 
 ## Prerequisites
 
-- Java 11 or later installed (`java -version`)
-- Alloy 6.1.0 jar (the Alloy model checker, ~80 MB, no other dependencies)
+- Java 17 or later installed (`java -version`)
+- The Alloy 6.2.0 distribution jar (`org.alloytools.alloy.dist.jar`, ~21 MB,
+  bundles the pure-Java SAT4J solver, no native dependencies)
 
 ---
 
-## Step 1 — Download Alloy 6
+## Step 1 — Download Alloy 6.2.0
 
 ```bash
-curl -L -o alloy.jar \
-  https://github.com/AlloyTools/org.alloytools.alloy/releases/download/v6.1.0/org.alloytools.alloy.dist.jar
+curl -fsSL -o alloy.jar \
+  https://github.com/AlloyTools/org.alloytools.alloy/releases/download/v6.2.0/org.alloytools.alloy.dist.jar
+
+# Verify the pinned checksum (the same one CI enforces):
+echo "6b8c1cb5bc93bedfc7c61435c4e1ab6e688a242dc702a394628d9a9801edb78d  alloy.jar" | shasum -a 256 -c -
 ```
 
-Or download manually from:
-https://github.com/AlloyTools/org.alloytools.alloy/releases/tag/v6.1.0
-
-Verify the download:
-```bash
-java -jar alloy.jar --help 2>&1 | head -3
-```
+> Note: there is no `v6.1.0` release asset, and the account of "flat dist jar
+> only on v6.0.0" is wrong — `v6.2.0` ships `org.alloytools.alloy.dist.jar`.
+> That is the version the models were executed against and the version CI pins.
 
 ---
 
-## Step 2 — Run all assertions (GUI)
+## Step 2 — Run all commands (GUI, optional)
 
 ```bash
 java -jar alloy.jar formal/ep_relations.als
 ```
 
-In the Alloy Analyzer window:
-
-1. Select **Execute → Check All Assertions**
-2. Each of the 15 assertions should display: **"No counterexample found."**
-3. Run the predicates (`showLifecycle`, `showAdversarial`, etc.) to confirm the
-   model is non-vacuous (instances exist).
+In the Alloy Analyzer window, **Execute → Execute All**. Each `check` should
+report **"No counterexample found."** and each `run` predicate should report an
+instance (so the model is non-vacuous).
 
 ---
 
-## Step 3 — Run all assertions (headless / CI)
+## Step 3 — Run all commands headless (this is what CI does)
 
-The CI Java runner compiles and executes `AlloyCheck.java` against `alloy.jar`.
-See `.github/workflows/alloy.yml` for the full pipeline.
-
-To reproduce locally:
+The runner is a committed file, `formal/AlloyCheck.java`. It compiles each
+`.als` file, executes every `check` and `run` command against the SAT4J solver,
+and exits non-zero if any assertion produces a counterexample or any predicate
+is vacuous.
 
 ```bash
-# 1. Compile the runner (from repo root, after downloading alloy.jar)
-javac -cp alloy.jar AlloyCheck.java
-
-# 2. Run all checks
-java -cp .:alloy.jar AlloyCheck formal/ep_relations.als
+# from the repo root, with alloy.jar downloaded to the repo root:
+cd formal
+javac -cp ../alloy.jar AlloyCheck.java
+java -cp ../alloy.jar:. AlloyCheck \
+  ep_relations.als ep_federation.als ep_quorum.als ep_delegation.als 2>/dev/null
 ```
 
-Expected output:
-```
-Parsing: formal/ep_relations.als
-Parse OK.
-Commands: 20
-  check        NoDoubleConsumption ... No counterexample found.
-  check        RevokedNeverConsumed ... No counterexample found.
-  check        ConsumedWasVerified ... No counterexample found.
-  check        BindingHashIsolation ... No counterexample found.
-  check        TerminalStateIntegrity ... No counterexample found.
-  check        WritePathExclusive ... No counterexample found.
-  check        DelegationScopeRespected ... No counterexample found.
-  check        NoDelegationCycles ... No counterexample found.
-  check        PolicyHashConsistency ... No counterexample found.
-  check        MultiActorNoDoubleConsume ... No counterexample found.
-  check        EventStateExactCorrespondence ... No counterexample found.
-  check        SignoffBindingIntegrity ... No counterexample found.
-  check        SignoffConsumeOnce ... No counterexample found.
-  check        SignoffRequiresHandshake ... No counterexample found.
-  check        FullChainIntegrity ... No counterexample found.
-  run          showLifecycle ... instance found
-  run          showAdversarial ... instance found
-  run          showDelegation ... instance found
-  run          showMultiActorConsumption ... instance found
-  run          showSignoffLifecycle ... instance found
+(Kodkod's solver progress is written to stderr; `2>/dev/null` keeps the verdicts
+readable. The exit code still gates.)
 
-Results:
-  checks: 15 passed, 0 failed
-  runs:   5 satisfiable
-OK: all checks passed.
+Actual output (Alloy 6.2.0, 2026-07-18):
+
+```
+========================================================
+Model: ep_relations.als
+========================================================
+  check  NoDoubleConsumption                           No counterexample found. OK
+  check  RevokedNeverConsumed                          No counterexample found. OK
+  ... (15 checks total, all hold)
+  run    showLifecycle                                 Instance found. (non-vacuous)
+  ... (5 runs total, all satisfiable)
+
+========================================================
+Model: ep_federation.als
+========================================================
+  check  AcceptedIsAuthentic                           No counterexample found. OK
+  ... (7 checks total, all hold)
+  run    showFederation                                Instance found. (non-vacuous)
+
+========================================================
+Model: ep_quorum.als
+========================================================
+  check  SelfApprovalImpossible                        No counterexample found. OK
+  ... (6 checks total, all hold)
+  run    showStrongQuorum                              Instance found. (non-vacuous)
+
+========================================================
+Model: ep_delegation.als
+========================================================
+  check  DelegationAcyclic                             No counterexample found. OK
+  check  DelegationIdsUnique                           No counterexample found. OK
+  check  LeafIsNotItsOwnAncestor                       No counterexample found. OK
+  check  AuthorityNonIncreasing                        No counterexample found. OK
+  run    showChain                                     Instance found. (non-vacuous)
+
+========================================================
+Results: checks 32/32 held, runs 8/8 satisfiable
+OK: all assertions hold, all predicates consistent.
+========================================================
 ```
 
 ---
 
-## What Each Assertion Covers
+## What each `ep_relations.als` assertion covers
 
 | Assert | What it proves | Facts relied on |
 |--------|---------------|-----------------|
@@ -113,37 +134,35 @@ OK: all checks passed.
 | SignoffRequiresHandshake | No signoff challenge without a verified handshake | F26 |
 | FullChainIntegrity | Full signoff chain has one consistent binding | F26-F28 |
 
+`ep_delegation.als` adds the capability-chain invariants (DelegationAcyclic,
+DelegationIdsUnique, LeafIsNotItsOwnAncestor, AuthorityNonIncreasing), mirroring
+`packages/gate/capability-receipt.js` `assertDelegationChain()` and the
+`DelegationAuthorityNonIncreasing` invariant in `formal/ep_capability.tla`.
+
 ---
 
-## Updating PROOF_STATUS.md
+## If a counterexample is found
 
-After a successful run:
-
-1. Note the Alloy version (`java -jar alloy.jar --version 2>&1 | head -1`)
-2. Update `formal/PROOF_STATUS.md` A1-A15 status to `Verified (Alloy X.Y.Z, YYYY-MM-DD)`
-3. Commit alongside any fixes to `ep_relations.als`
-
-If a counterexample is found:
 1. Record the counterexample trace in `formal/alloy-counterexample-ANN.txt`
 2. Fix the assertion or the underlying model
-3. Re-run to confirm fix
+3. Re-run to confirm the fix
 4. File a critical bug referencing the counterexample
 
 ---
 
 ## CI Integration
 
-The Alloy CI workflow runs automatically on every push that touches `formal/*.als`:
+`.github/workflows/alloy.yml` runs on every push or PR that touches
+`formal/**.als`, `formal/AlloyCheck.java`, or the workflow itself. It downloads
+Alloy 6.2.0 (pinned tag + SHA-256), compiles `formal/AlloyCheck.java`, runs all
+four models, and fails the build if any assertion produces a counterexample.
+The captured verdicts are uploaded as the `alloy-output` artifact.
 
 ```yaml
-# .github/workflows/alloy.yml
 on:
   push:
     paths:
-      - 'formal/*.als'
+      - 'formal/**.als'
+      - 'formal/AlloyCheck.java'
       - '.github/workflows/alloy.yml'
-  workflow_dispatch:
 ```
-
-The workflow downloads Alloy 6.1.0, compiles the Java runner, and fails the build
-if any assertion produces a counterexample. See the workflow file for full details.

--- a/formal/ep_delegation.als
+++ b/formal/ep_delegation.als
@@ -31,10 +31,13 @@
  *                                          amount / leaf-as-parent rejections
  *   formal/ep_capability.tla             — DelegationAuthorityNonIncreasing
  *
- * STATUS: authored to the repo's Alloy convention (formal/ep_quorum.als,
- * formal/ep_relations.als). NOT executed in this environment — the Alloy 6 jar
- * (~80 MB) was not fetched here. Run per formal/RUN_ALLOY.md:
- *   java -jar alloy.jar formal/ep_delegation.als   (Execute -> Check All Assertions)
+ * STATUS: EXECUTED and gated. Run headless against Alloy 6.2.0 (SAT4J) via
+ * formal/AlloyCheck.java; all four assertions hold with no counterexample in
+ * the bounded scope and showChain is satisfiable (non-vacuous). Runs in CI on
+ * every push touching formal/**.als (.github/workflows/alloy.yml). Reproduce
+ * per formal/RUN_ALLOY.md:
+ *   cd formal && javac -cp ../alloy.jar AlloyCheck.java \
+ *     && java -cp ../alloy.jar:. AlloyCheck ep_delegation.als
  */
 
 module ep_delegation


### PR DESCRIPTION
## What

Closes the **Alloy authored-not-run** gap. The `formal/*.als` models were written to the repo convention but never actually executed, and `ep_delegation.als` (capability chain acyclicity + non-increasing authority) had no run evidence at all. The pre-existing `alloy.yml` pinned a **nonexistent Alloy 6.1.0 tag** / v6.0.0 API through an inline heredoc runner that referenced a `formal/AlloyCheck.java` which did not exist in the tree.

## Changes

- **`formal/AlloyCheck.java`** (new, committed): headless runner over the Alloy API. Executes every `check` + `run` command per model; exits non-zero on any counterexample or vacuous predicate. Hostile-verified: a deliberately false assertion exits `1`.
- **`.github/workflows/alloy.yml`**: rewritten to compile the committed runner and run all four models against the real `org.alloytools.alloy.dist.jar` from **v6.2.0**, pinned by tag + SHA-256 (`6b8c1cb5…`), mirroring the `tlc.yml` gating pattern. Fails on any counterexample; uploads verdicts as the `alloy-output` artifact. (v6.2.0 **does** ship the flat dist jar — the earlier "v6.0.0 only" comment was wrong.)
- **`formal/RUN_ALLOY.md`**, **`ep_delegation.als`** header, **`formal/PROOF_STATUS.md`**: corrected to the real version/URL and CI-gated status; added the missing `ep_quorum` + `ep_delegation` proof sections.

## Real execution output (Alloy 6.2.0, SAT4J, exit 0)

```
Model: ep_delegation.als
  check  DelegationAcyclic            No counterexample found. OK
  check  DelegationIdsUnique          No counterexample found. OK
  check  LeafIsNotItsOwnAncestor      No counterexample found. OK
  check  AuthorityNonIncreasing       No counterexample found. OK
  run    showChain                    Instance found. (non-vacuous)

Results: checks 32/32 held, runs 8/8 satisfiable
OK: all assertions hold, all predicates consistent.
```

`ep_delegation`'s acyclicity + non-increasing-authority assertions both hold with no counterexample in scope `for 6` (`but 5 int` on the arithmetic checks). Full four-model output (ep_relations 15+5, ep_federation 7+1, ep_quorum 6+1, ep_delegation 4+1) is in the commit.

## Scope / deconflict

Touches only `formal/**` + `.github/workflows/alloy.yml`. Does **not** touch `ci.yml`, `tlc.yml`, or the `feat/gate-capability-enforcement` lane (PR #292).

## Known residual (out of lane)

`scripts/generate-proof-stats.mjs` hardcodes `alloy.version: '6.0.0 (CI)'` and counts Alloy assertions only from `ep_relations.als` + `ep_federation.als`. My change does not move that count, so `check:proof-stats` stays consistent without regeneration — but the version string is now stale (CI runs 6.2.0). Left for a follow-up since fixing it cleanly requires a full `sync:proof-stats` (vitest) regen outside this lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)