### PR TITLE
feat(gate): brand-typed protocol-state — illegal transitions are compile errors (GAP-4)

### DIFF
--- a/packages/gate/protocol-state.js
+++ b/packages/gate/protocol-state.js
@@ -1,0 +1,186 @@
+/**
+ * EP Protocol-State — brand-typed handshake lifecycle (GAP-4).
+ *
+ * Purpose: make an ILLEGAL protocol-state transition a COMPILE error, not a
+ * runtime failure. Each lifecycle state is a distinct nominal (branded) type,
+ * and every transition is a function whose parameter type admits ONLY its legal
+ * predecessor state(s) and whose return type is exactly its legal successor.
+ * Passing the wrong state to a transition (e.g. `consume(initiated)` — consuming
+ * before verification) is rejected by `tsc` before the code ever runs.
+ *
+ * ── Source of truth ─────────────────────────────────────────────────────────
+ * The state graph mirrors the formally-verified model, not a toy:
+ *   formal/ep_handshake.tla   — abstract lifecycle + transition guards
+ *   lib/handshake/invariants.js (HANDSHAKE_STATUSES) — the 6 persisted statuses
+ *   lib/handshake/create.js    — status:'initiated'          (T1 Initiate)
+ *   lib/handshake/present.js   — initiated → pending_verification (T2 Present)
+ *   lib/handshake/verify.js    — outcome accepted/rejected/expired (T3/T4/T7)
+ *   lib/handshake/consume.js   — verified → consumed            (T5 Consume)
+ *   lib/handshake/finalize.js  — → revoked                       (T6 Revoke)
+ *
+ * ── States (TLA `state` domain) ─────────────────────────────────────────────
+ *   none | initiated | pending_verification | verified
+ *   | rejected | expired | revoked | consumed
+ *
+ * Two of these are ABSTRACT lifecycle states, not DB status values:
+ *   - `none`     : pre-initiation. There is no persisted row yet.
+ *   - `consumed` : a verified handshake that has an entry in the
+ *                  `handshake_consumptions` table. Consumption does NOT rewrite
+ *                  `handshakes.status` (it stays 'verified'); it is recorded
+ *                  atomically in a side table by `consume_handshake_atomic`.
+ *                  The TLA model abstracts (status='verified' ∧ h∈consumptions)
+ *                  as the distinct terminal state `consumed`. This module keeps
+ *                  that abstraction so "consume-once" and "no-verify-after-consume"
+ *                  are expressible in the type system.
+ *
+ * The other six are exactly `HANDSHAKE_STATUSES` from invariants.js and carry a
+ * `dbStatus` field equal to the persisted `handshakes.status` value.
+ *
+ * ── Legal transition graph (the ONLY edges; everything else is a type error) ─
+ *   genesis()                                        -> None
+ *   initiate(None)                                   -> Initiated
+ *   present(Initiated)                               -> PendingVerification
+ *   verifyAccept(PendingVerification)                -> Verified
+ *   verifyReject(PendingVerification)                -> Rejected      (terminal)
+ *   consume(Verified)                                -> Consumed      (terminal)
+ *   revoke(Initiated|PendingVerification|Verified)   -> Revoked       (terminal)
+ *   expire(Initiated|PendingVerification|Verified)   -> Expired       (terminal)
+ *
+ * Terminal states (Rejected, Expired, Revoked, Consumed) are accepted by NO
+ * transition function, so any move out of a terminal state is a compile error.
+ *
+ * Branding note: each state is nominally distinguished by a private, readonly
+ * string-literal `tag`. Distinct tags make each state a distinct type, so no
+ * legal predecessor of one transition is accidentally assignable to another.
+ * The runtime value literally is `{ tag, dbStatus }`; there is no phantom-only
+ * field, so no casts are needed and the runtime and the types cannot drift.
+ *
+ * This module is intentionally free of I/O. It is the compile-time spine that
+ * the runtime state machine (verify.js / consume.js / finalize.js) is expected
+ * to obey; it does not replace those code paths' own DB-level guards.
+ *
+ * @license Apache-2.0
+ */
+
+/**
+ * The six persisted `handshakes.status` values (single source: invariants.js
+ * HANDSHAKE_STATUSES). `none` and `consumed` are abstract and have no row status.
+ * @typedef {'initiated'|'pending_verification'|'verified'|'rejected'|'expired'|'revoked'} DbHandshakeStatus
+ */
+
+/**
+ * Pre-initiation. No persisted handshake exists yet.
+ * @typedef {{ readonly tag: 'none', readonly dbStatus: null }} None
+ */
+/**
+ * A handshake row was created (T1). DB status 'initiated'.
+ * @typedef {{ readonly tag: 'initiated', readonly dbStatus: 'initiated' }} Initiated
+ */
+/**
+ * A presentation was added and verification is pending (T2). DB 'pending_verification'.
+ * @typedef {{ readonly tag: 'pending_verification', readonly dbStatus: 'pending_verification' }} PendingVerification
+ */
+/**
+ * Verification accepted (T3). DB 'verified'. Only state from which consume is legal.
+ * @typedef {{ readonly tag: 'verified', readonly dbStatus: 'verified' }} Verified
+ */
+/**
+ * Verification rejected (T4). Terminal. DB 'rejected'.
+ * @typedef {{ readonly tag: 'rejected', readonly dbStatus: 'rejected' }} Rejected
+ */
+/**
+ * Binding expired (T7). Terminal. DB 'expired'.
+ * @typedef {{ readonly tag: 'expired', readonly dbStatus: 'expired' }} Expired
+ */
+/**
+ * Revoked by a party (T6). Terminal. DB 'revoked'.
+ * @typedef {{ readonly tag: 'revoked', readonly dbStatus: 'revoked' }} Revoked
+ */
+/**
+ * Consumed exactly once (T5). Terminal abstract state; the row keeps DB status
+ * 'verified' and gains a `handshake_consumptions` record.
+ * @typedef {{ readonly tag: 'consumed', readonly dbStatus: 'verified' }} Consumed
+ */
+
+/**
+ * Any state in the lifecycle.
+ * @typedef {None|Initiated|PendingVerification|Verified|Rejected|Expired|Revoked|Consumed} ProtocolState
+ */
+/**
+ * States a still-active handshake can be revoked or expired from (T6/T7 domain).
+ * @typedef {Initiated|PendingVerification|Verified} Active
+ */
+
+/**
+ * T0: genesis — the empty pre-initiation state.
+ * @returns {None}
+ */
+export function genesis() {
+  return { tag: 'none', dbStatus: null };
+}
+
+/**
+ * T1 Initiate: none -> initiated. Maps to create.js status:'initiated'.
+ * @param {None} _s
+ * @returns {Initiated}
+ */
+export function initiate(_s) {
+  return { tag: 'initiated', dbStatus: 'initiated' };
+}
+
+/**
+ * T2 Present: initiated -> pending_verification. Maps to present.js.
+ * @param {Initiated} _s
+ * @returns {PendingVerification}
+ */
+export function present(_s) {
+  return { tag: 'pending_verification', dbStatus: 'pending_verification' };
+}
+
+/**
+ * T3 VerifyAccept: pending_verification -> verified. verify.js outcome='accepted'.
+ * @param {PendingVerification} _s
+ * @returns {Verified}
+ */
+export function verifyAccept(_s) {
+  return { tag: 'verified', dbStatus: 'verified' };
+}
+
+/**
+ * T4 VerifyReject: pending_verification -> rejected (terminal). verify.js outcome='rejected'.
+ * @param {PendingVerification} _s
+ * @returns {Rejected}
+ */
+export function verifyReject(_s) {
+  return { tag: 'rejected', dbStatus: 'rejected' };
+}
+
+/**
+ * T5 Consume: verified -> consumed (terminal). consume.js requires 'verified' state
+ * and enforces consume-once at the DB level.
+ * @param {Verified} _s
+ * @returns {Consumed}
+ */
+export function consume(_s) {
+  return { tag: 'consumed', dbStatus: 'verified' };
+}
+
+/**
+ * T6 Revoke: {initiated|pending_verification|verified} -> revoked (terminal).
+ * finalize.js. Legal only from an active (pre-terminal) state.
+ * @param {Active} _s
+ * @returns {Revoked}
+ */
+export function revoke(_s) {
+  return { tag: 'revoked', dbStatus: 'revoked' };
+}
+
+/**
+ * T7 Expire: {initiated|pending_verification|verified} -> expired (terminal).
+ * verify.js outcome='expired'. Legal only from an active (pre-terminal) state.
+ * @param {Active} _s
+ * @returns {Expired}
+ */
+export function expire(_s) {
+  return { tag: 'expired', dbStatus: 'expired' };
+}

--- a/packages/gate/protocol-state.typecheck.js
+++ b/packages/gate/protocol-state.typecheck.js
@@ -1,0 +1,94 @@
+/**
+ * EP Protocol-State — TYPE-LEVEL conformance test (GAP-4).
+ *
+ * This file is checked by `tsc` under tsconfig.core.json, not run as a unit
+ * test. It asserts, at compile time, that the ONLY legal transitions of the
+ * handshake lifecycle are the ones the formal model permits:
+ *
+ *   - The "legal sequences" section MUST type-check with no errors.
+ *   - Every `// @ts-expect-error` line guards a transition that MUST be illegal.
+ *     If any such transition ever becomes legal (a regression in the brand
+ *     types), tsc reports the `@ts-expect-error` as UNUSED and the type-gate
+ *     fails. This is the tripwire.
+ *
+ * These are type-only assertions; the functions are pure and the file is safe
+ * to load, but nothing here is intended to run.
+ *
+ * @license Apache-2.0
+ */
+
+import {
+  genesis, initiate, present, verifyAccept, verifyReject, consume, revoke, expire,
+} from './protocol-state.js';
+
+/* eslint-disable no-unused-vars */
+
+// ── LEGAL SEQUENCES (must compile) ──────────────────────────────────────────
+
+// Full happy path: none → initiated → pending_verification → verified → consumed
+const _consumed = consume(verifyAccept(present(initiate(genesis()))));
+
+// Reject branch: … → pending_verification → rejected
+const _rejected = verifyReject(present(initiate(genesis())));
+
+// Revoke is legal from every active (pre-terminal) state:
+const _revokedFromInitiated = revoke(initiate(genesis()));
+const _revokedFromPending = revoke(present(initiate(genesis())));
+const _revokedFromVerified = revoke(verifyAccept(present(initiate(genesis()))));
+
+// Expire is legal from every active (pre-terminal) state:
+const _expiredFromInitiated = expire(initiate(genesis()));
+const _expiredFromPending = expire(present(initiate(genesis())));
+const _expiredFromVerified = expire(verifyAccept(present(initiate(genesis()))));
+
+// Convenience handles to well-typed states for the illegal section below.
+const none = genesis();
+const initiated = initiate(none);
+const pending = present(initiated);
+const verified = verifyAccept(pending);
+const consumedState = consume(verified);
+const revokedState = revoke(initiated);
+const rejectedState = verifyReject(pending);
+const expiredState = expire(initiated);
+
+// ── ILLEGAL TRANSITIONS (each MUST be a type error) ─────────────────────────
+
+// Consume before verification — the canonical GAP-4 violation.
+// @ts-expect-error consume requires Verified, not None
+consume(none);
+// @ts-expect-error consume requires Verified, not Initiated
+consume(initiated);
+// @ts-expect-error consume requires Verified, not PendingVerification
+consume(pending);
+
+// Skipping the presentation step (initiated → verified directly).
+// @ts-expect-error verifyAccept requires PendingVerification, not Initiated
+verifyAccept(initiated);
+// @ts-expect-error verifyReject requires PendingVerification, not Initiated
+verifyReject(initiated);
+
+// Presenting after the handshake already left the initiated state.
+// @ts-expect-error present requires Initiated, not PendingVerification
+present(pending);
+// @ts-expect-error present requires Initiated, not Verified
+present(verified);
+
+// Re-initiating something that already exists.
+// @ts-expect-error initiate requires None, not Verified
+initiate(verified);
+
+// No transition may leave a TERMINAL state (consumed/revoked/rejected/expired).
+// @ts-expect-error cannot consume a Consumed handshake (consume-once)
+consume(consumedState);
+// @ts-expect-error cannot revoke a Consumed handshake
+revoke(consumedState);
+// @ts-expect-error cannot expire a Consumed handshake
+expire(consumedState);
+// @ts-expect-error cannot verify a Revoked handshake
+verifyAccept(revokedState);
+// @ts-expect-error cannot revoke an already-Revoked handshake
+revoke(revokedState);
+// @ts-expect-error cannot consume a Rejected handshake
+consume(rejectedState);
+// @ts-expect-error cannot revoke an Expired handshake
+revoke(expiredState);

--- a/packages/gate/tsconfig.protocol-state.json
+++ b/packages/gate/tsconfig.protocol-state.json
@@ -1,0 +1,19 @@
+{
+  "//": "Focused type-gate for the brand-typed protocol-state module (GAP-4). Identical compilerOptions to tsconfig.core.json; scoped to this module + its type-level test so the branding proof is not drowned by unrelated pre-existing errors in the wider core. The module and its typecheck are ALSO in tsconfig.core.json's include (packages/gate/**/*.js).",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": false,
+    "target": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "skipLibCheck": true,
+    "noImplicitAny": false,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "protocol-state.js",
+    "protocol-state.typecheck.js"
+  ]
+}

--- a/tsconfig.core.json
+++ b/tsconfig.core.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": false,
+    "target": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "skipLibCheck": true,
+    "noImplicitAny": false,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "packages/verify/**/*.js",
+    "lib/handshake/**/*.js",
+    "packages/gate/**/*.js"
+  ],
+  "exclude": [
+    "**/*.test.js",
+    "**/node_modules/**"
+  ]
+}


### PR DESCRIPTION
## GAP-4 centerpiece: make an illegal protocol-state transition a **compile** error, not a runtime failure.

Adds a brand-typed module for the EP handshake lifecycle. Each state is a distinct nominal type; each transition function accepts **only** its legal predecessor state(s) and returns **exactly** its legal successor. Passing the wrong state (e.g. `consume()` before `verifyAccept()`) is rejected by `tsc` before the code runs.

### States & transitions — mirror the formally-verified model
Source of truth: `formal/ep_handshake.tla` (abstract lifecycle + guards), `lib/handshake/invariants.js` (`HANDSHAKE_STATUSES`), and `lib/handshake/{create,present,verify,consume,finalize}.js`.

| Transition | Signature | Code |
|---|---|---|
| T1 Initiate | `None → Initiated` | create.js `status:'initiated'` |
| T2 Present | `Initiated → PendingVerification` | present.js |
| T3 VerifyAccept | `PendingVerification → Verified` | verify.js `outcome='accepted'` |
| T4 VerifyReject | `PendingVerification → Rejected` (terminal) | verify.js `outcome='rejected'` |
| T5 Consume | `Verified → Consumed` (terminal) | consume.js |
| T6 Revoke | `{Initiated\|PendingVerification\|Verified} → Revoked` (terminal) | finalize.js |
| T7 Expire | `{Initiated\|PendingVerification\|Verified} → Expired` (terminal) | verify.js `outcome='expired'` |

`none` and `consumed` are **abstract** lifecycle states (documented in-file): consumption is recorded in `handshake_consumptions` and does **not** rewrite `handshakes.status` (it stays `'verified'`); the TLA model abstracts `(status='verified' ∧ h∈consumptions)` as terminal `consumed`. The other six states equal `HANDSHAKE_STATUSES` and carry the persisted `dbStatus`.

### Type-level test = the tripwire
`packages/gate/protocol-state.typecheck.js` — legal sequences must compile; **15** illegal transitions are each guarded by `// @ts-expect-error`. If any illegal transition ever becomes legal, tsc reports the directive as unused (**TS2578**) and the type-gate fails.

### tsc proof (TypeScript 5.9.3)
- **Focused gate** (`packages/gate/tsconfig.protocol-state.json`, identical compilerOptions to `tsconfig.core.json`): `tsc` exits **0** — legal sequences compile and every `@ts-expect-error` is genuinely suppressing an error (an unused one would fail).
- **Negative control A** — delete one suppressor → real error surfaces: `error TS2345: Argument of type 'Initiated' is not assignable to parameter of type 'Verified'`.
- **Negative control B** — widen `consume` to accept `Consumed` → guard flips to `error TS2578: Unused '@ts-expect-error' directive` (the consume-once tripwire bites).
- Under the full `tsconfig.core.json`, **zero** errors are attributable to these files.

### Scope / safety
Files-only addition. No runtime behavior changed; the module is pure and imported by nothing at runtime. Gate `node --test` boundary tests pass. This is the compile-time spine the runtime paths are expected to obey; it does not replace their DB-level guards.

### Flagged for triage (not fixed here — typing task)
`lib/handshake/finalize.js:78` — the revoke guard blocks only `status ∈ {revoked, expired}`. Because consumption leaves `handshakes.status = 'verified'` (consume.js writes no `status='consumed'`), an already-consumed handshake passes this guard, so **revoke-after-consume succeeds at runtime**, whereas the TLA `Revoke` precondition requires `h ∉ consumptions`. `rejected` is likewise not blocked. Suspected audit-integrity divergence (a consumed authorization's row can flip to `revoked` after the action executed). Not confirmed against a possible DB-level trigger; recommend the lead verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)