### PR TITLE
fix(conformance): refresh clean-room runner pin

### DIFF
--- a/conformance/clean-room/reference-port.manifest.json
+++ b/conformance/clean-room/reference-port.manifest.json
@@ -16,7 +16,7 @@
   "runner": {
     "protocol": "EP-CONFORMANCE-FILE-RUNNER-v1",
     "artifact_argument_index": 0,
-    "artifact_sha256": "0fa8a9f59789b79e14f7e2838df9cafa2d624af702bc4bae36770a2af8da1152",
+    "artifact_sha256": "e1b8d96e3992a3e18a3df02f49e292e38a606a95b3030a840421767879504ae7",
     "fixed_arguments": [
       "conformance/runners/run-js.mjs"
     ]


### PR DESCRIPTION
## Summary
- refresh the clean-room reference manifest after the JavaScript runner changed
- restore the strict external-acceptance contract so it reaches and proves same-team refusal

## Verification
- `npx --yes node@20 scripts/test-clean-room-intake.mjs`
- `npm run security-case:emit`
- `npm run conformance:hostility`
- `npm run conformance:manifest:clean-room:check`
- `git diff --check`

No draft source, submission schedule, or private packet content is included.