### PR TITLE
types: enable noImplicitAny across all four tiers (migration foundation)

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowJs": true, "checkJs": true, "noEmit": true, "strict": false, "strictNullChecks": true,
     "target": "es2022", "module": "esnext", "moduleResolution": "bundler",
-    "jsx": "preserve", "skipLibCheck": true, "noImplicitAny": false,
+    "jsx": "preserve", "skipLibCheck": true, "noImplicitAny": true,
     "baseUrl": ".", "paths": { "@/*": ["./*"] }, "types": ["react", "node"]
   },
   "include": [

--- a/tsconfig.core.json
+++ b/tsconfig.core.json
@@ -8,7 +8,7 @@
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "skipLibCheck": true,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "resolveJsonModule": true
   },
   "include": [

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowJs": true, "checkJs": true, "noEmit": true, "strict": false, "strictNullChecks": true,
     "target": "es2022", "module": "esnext", "moduleResolution": "bundler",
-    "skipLibCheck": true, "noImplicitAny": false, "baseUrl": ".",
+    "skipLibCheck": true, "noImplicitAny": true, "baseUrl": ".",
     "paths": { "@/*": ["./*"] }
   },
   "include": ["lib/**/*.js", "lib/**/*.mjs"],

--- a/tsconfig.rest.json
+++ b/tsconfig.rest.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowJs": true, "checkJs": true, "noEmit": true, "strict": false, "strictNullChecks": true,
     "target": "es2022", "module": "esnext", "moduleResolution": "bundler",
-    "skipLibCheck": true, "noImplicitAny": false, "baseUrl": ".",
+    "skipLibCheck": true, "noImplicitAny": true, "baseUrl": ".",
     "paths": {
       "@/*": ["./*"],
       "@emilia-protocol/fire-drill": ["./packages/fire-drill/index.js"],


### PR DESCRIPTION
Locks in the JSDoc type-annotation coverage the type fleets built. **All four production tiers (core, lib, rest, app) type-check at 0 errors with `noImplicitAny` on** — verified locally with `tsc -p <config> --noEmit` on each.

This is phase 1 of the TypeScript migration (JSDoc-based type coverage on `.js` files). It does not change runtime behavior — the files stay `.js`; this only makes the already-present JSDoc types enforced by the compiler. Phase 2 (the actual `.ts`/`.tsx` rename) follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)