### PR TITLE
test(aeg): add negative vector for node.type/artifact.typ consistency

### DIFF
--- a/tests/evidence-graph.test.js
+++ b/tests/evidence-graph.test.js
@@ -605,3 +605,61 @@ describe('policy packs', () => {
     }
   });
 });
+
+// ── node.type / artifact.typ consistency ────────────────────────────────────
+// The graph layer dispatches verifiers by node.type (presenter-supplied).
+// A verifier that validates the artifact's own typ field rejects a relabeled
+// artifact. This mirrors the AEC layer's role-non-substitution pattern
+// (tests/role-non-substitution.test.js) at the graph layer.
+
+describe('node.type / artifact.typ consistency — verifier-level defense', () => {
+  it('a verifier that checks artifact.typ rejects a relabeled artifact', () => {
+    const auth = mk('authorization_receipt', { issued_at: '2026-07-02T00:00:00Z' });
+    const authId = artifactDigest(auth);
+
+    const strictVerifiers = {
+      authorization_receipt: (a) => ({ valid: a.typ === 'authorization_receipt', action_digest: a.action }),
+      policy_permit: (a) => ({ valid: a.typ === 'policy_permit', action_digest: a.action }),
+      workload_identity: (a) => ({ valid: a.typ === 'workload_identity', action_digest: a.action }),
+    };
+
+    const doc = {
+      '@version': EVIDENCE_GRAPH_VERSION, action_digest: ACTION,
+      nodes: [
+        { id: authId, type: 'policy_permit', artifact: auth },
+        { id: artifactDigest(mk('workload_identity')), type: 'workload_identity', artifact: mk('workload_identity') },
+      ],
+      edges: [],
+    };
+
+    const r = evaluateEvidenceGraph(doc, wirePack, { verifiers: strictVerifiers, as_of: AS_OF });
+    expect(r.verdict).not.toBe('admissible');
+  });
+
+  it('a verifier that checks artifact.typ accepts a correctly typed artifact', () => {
+    const auth = mk('authorization_receipt', { issued_at: '2026-07-02T00:00:00Z' });
+    const authId = artifactDigest(auth);
+    const permit = mk('policy_permit', { authorizes_receipt: authId, issued_at: '2026-07-02T00:00:00Z' });
+    const permitId = artifactDigest(permit);
+    const wl = mk('workload_identity', { issued_at: '2026-07-02T00:00:00Z' });
+
+    const strictVerifiers = {
+      authorization_receipt: (a) => ({ valid: a.typ === 'authorization_receipt', action_digest: a.action }),
+      policy_permit: (a) => ({ valid: a.typ === 'policy_permit', action_digest: a.action }),
+      workload_identity: (a) => ({ valid: a.typ === 'workload_identity', action_digest: a.action }),
+    };
+
+    const doc = {
+      '@version': EVIDENCE_GRAPH_VERSION, action_digest: ACTION,
+      nodes: [
+        { id: authId, type: 'authorization_receipt', artifact: auth },
+        { id: permitId, type: 'policy_permit', artifact: permit },
+        { id: artifactDigest(wl), type: 'workload_identity', artifact: wl },
+      ],
+      edges: [{ from: permitId, rel: 'permits', to: authId }],
+    };
+
+    const r = evaluateEvidenceGraph(doc, wirePack, { verifiers: strictVerifiers, as_of: AS_OF });
+    expect(r.verdict).toBe('admissible');
+  });
+});


### PR DESCRIPTION
## Summary
Add 2 negative test vectors for `node.type` / `artifact.typ` consistency in EP-AEG evidence graph evaluation, mirroring the AEC layer's `role-non-substitution.test.js` pattern at the graph layer.
## Scope
`tests/evidence-graph.test.js`. No spec, protocol, or production code changed.
Closes #
## Risk and security impact
- Security impact: None. Test-only change.
- Failure/refusal behavior: No behavior change. Verifier-level defense already exists.
- Compatibility impact: None.
## Verification
| Check | Command or evidence | Result |
| --- | --- | --- |
| Narrow tests | `npx vitest run tests/evidence-graph.test.js` | 51/51 pass |
| Negative/refusal tests | New describe block "node.type / artifact.typ consistency" | 2/2 pass |
| Related tests | `npx vitest run tests/role-non-substitution.test.js tests/aec-safety-critical.test.js` | 23/23 pass |
Not run / limitations:
- Cross-language conformance: Python and Go do not yet implement `evaluateEvidenceGraph`. Type consistency vectors are JavaScript-only.
- Full CI suite: will run on PR via GitHub Actions.
## Database and migrations
- [x] No database or schema change.
## Claims and evidence
- [x] This PR makes no public or generated claim changes.
## Secrets and sensitive data
- [x] I reviewed the diff and test output for credentials, tokens, API keys, private keys, connection strings, personal data, and confidential production or partner information.
- [x] Examples, fixtures, screenshots, and logs use synthetic or properly sanitized data.
- [x] This PR does not publicly disclose an uncoordinated vulnerability.
## Contribution checklist
- [x] Every commit includes a DCO `Signed-off-by` line (`git commit -s`); I understand CI checks every commit.
- [x] The change is scoped to the stated purpose and does not hide unrelated generated or mechanical changes.
- [x] New behavior includes applicable positive and negative/refusal coverage.
- [x] I reviewed the complete diff as a reviewer would.