### PR TITLE
fix(schema): reconcile private namespace objects

### DIFF
--- a/.github/workflows/schema-security.yml
+++ b/.github/workflows/schema-security.yml
@@ -13,8 +13,9 @@ name: schema-security
 #
 # Required repo secret (Settings → Secrets → Actions):
 #   SCHEMA_GATE_DB_URL — least-privilege pooler connection string for the
-#   read-only `schema_gate` Postgres role (EXECUTE on gov_schema_contract_introspect
-#   only; cannot read any table rows). The god-mode service-role key is NOT in CI.
+#   read-only `schema_gate` Postgres role (EXECUTE on the two metadata-only
+#   schema introspection functions; cannot read any table rows). The god-mode
+#   service-role key is NOT in CI.
 #
 # To make this a true deploy gate: add "schema-security / schema-contract" as a
 # required status check in branch protection for main, and enable Vercel's

--- a/scripts/_schema-introspect.mjs
+++ b/scripts/_schema-introspect.mjs
@@ -6,8 +6,8 @@
 // migration-reconcile.mjs).
 //
 // Least-privilege by default: when SCHEMA_GATE_DB_URL is set (CI), connect as the
-// dedicated `schema_gate` Postgres role — which can EXECUTE only
-// gov_schema_contract_introspect() and read NO table rows — over the Supabase
+// dedicated `schema_gate` Postgres role — which can EXECUTE only the two
+// metadata introspection functions and read NO table rows — over the Supabase
 // pooler. The god-mode service-role key never enters CI.
 //
 // Local fallback: if SCHEMA_GATE_DB_URL is absent, use supabase-js with the
@@ -28,8 +28,17 @@ export async function fetchSchemaSnapshot() {
         const client = new pg.Client({ connectionString: dbUrl, ssl: { ca, rejectUnauthorized: true } });
         await client.connect();
         try {
-            const { rows } = await client.query('select public.gov_schema_contract_introspect() as snap');
-            return rows[0].snap;
+            const { rows } = await client.query(`
+        select
+          public.gov_schema_contract_introspect() as snap,
+          public.gov_schema_reconcile_introspect() as reconcile
+      `);
+            const row = rows[0];
+            return {
+                ...row.snap,
+                reconcile_tables: row.reconcile.tables,
+                reconcile_functions: row.reconcile.functions,
+            };
         }
         finally {
             await client.end();
@@ -42,8 +51,19 @@ export async function fetchSchemaSnapshot() {
         throw new Error('Set SCHEMA_GATE_DB_URL (preferred) or NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY');
     }
     const sb = createClient(URL, KEY, { auth: { persistSession: false } });
-    const { data, error } = await sb.rpc('gov_schema_contract_introspect');
-    if (error)
-        throw new Error(`introspection RPC failed (migration 115 applied?): ${error.message}`);
-    return data;
+    const [contractResult, reconcileResult] = await Promise.all([
+        sb.rpc('gov_schema_contract_introspect'),
+        sb.rpc('gov_schema_reconcile_introspect'),
+    ]);
+    if (contractResult.error) {
+        throw new Error(`contract introspection RPC failed (migration 115 applied?): ${contractResult.error.message}`);
+    }
+    if (reconcileResult.error) {
+        throw new Error(`reconciliation introspection RPC failed (migration 20260722050000 applied?): ${reconcileResult.error.message}`);
+    }
+    return {
+        ...contractResult.data,
+        reconcile_tables: reconcileResult.data.tables,
+        reconcile_functions: reconcileResult.data.functions,
+    };
 }

--- a/scripts/_schema-introspect.mts
+++ b/scripts/_schema-introspect.mts
@@ -4,8 +4,8 @@
 // migration-reconcile.mjs).
 //
 // Least-privilege by default: when SCHEMA_GATE_DB_URL is set (CI), connect as the
-// dedicated `schema_gate` Postgres role — which can EXECUTE only
-// gov_schema_contract_introspect() and read NO table rows — over the Supabase
+// dedicated `schema_gate` Postgres role — which can EXECUTE only the two
+// metadata introspection functions and read NO table rows — over the Supabase
 // pooler. The god-mode service-role key never enters CI.
 //
 // Local fallback: if SCHEMA_GATE_DB_URL is absent, use supabase-js with the
@@ -27,8 +27,17 @@ export async function fetchSchemaSnapshot(): Promise<Record<string, any>> {
     const client = new (pg as any).Client({ connectionString: dbUrl, ssl: { ca, rejectUnauthorized: true } });
     await client.connect();
     try {
-      const { rows } = await client.query('select public.gov_schema_contract_introspect() as snap');
-      return (rows[0 as any] as any).snap as Record<string, any>;
+      const { rows } = await client.query(`
+        select
+          public.gov_schema_contract_introspect() as snap,
+          public.gov_schema_reconcile_introspect() as reconcile
+      `);
+      const row = rows[0 as any] as any;
+      return {
+        ...(row.snap as Record<string, any>),
+        reconcile_tables: row.reconcile.tables,
+        reconcile_functions: row.reconcile.functions,
+      };
     } finally {
       await client.end();
     }
@@ -40,7 +49,19 @@ export async function fetchSchemaSnapshot(): Promise<Record<string, any>> {
     throw new Error('Set SCHEMA_GATE_DB_URL (preferred) or NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY');
   }
   const sb = (createClient as any)(URL, KEY, { auth: { persistSession: false } });
-  const { data, error } = await sb.rpc('gov_schema_contract_introspect');
-  if (error) throw new Error(`introspection RPC failed (migration 115 applied?): ${error.message}`);
-  return data as Record<string, any>;
+  const [contractResult, reconcileResult] = await Promise.all([
+    sb.rpc('gov_schema_contract_introspect'),
+    sb.rpc('gov_schema_reconcile_introspect'),
+  ]);
+  if (contractResult.error) {
+    throw new Error(`contract introspection RPC failed (migration 115 applied?): ${contractResult.error.message}`);
+  }
+  if (reconcileResult.error) {
+    throw new Error(`reconciliation introspection RPC failed (migration 20260722050000 applied?): ${reconcileResult.error.message}`);
+  }
+  return {
+    ...(contractResult.data as Record<string, any>),
+    reconcile_tables: reconcileResult.data.tables,
+    reconcile_functions: reconcileResult.data.functions,
+  };
 }

--- a/scripts/db-contract.manifest.mjs
+++ b/scripts/db-contract.manifest.mjs
@@ -263,13 +263,14 @@ export const contract = {
         'bind_guard_receipt_event_scope',
         'reject_guard_receipt_binding_mutation',
         'gov_schema_contract_introspect',
+        'gov_schema_reconcile_introspect',
         'complete_webauthn_registration_atomic',
         'consume_trust_desk_bootstrap_atomic',
         ...RELEASE_LOCK_SERVICE_RPCS,
     ],
     // Functions that MUST exist (existence only). Includes the append-only
     // immutability triggers — their absence means tamper-evidence is unenforced.
-    requiredRpcs: ['gov_schema_contract_introspect', 'load_verify_context',
+    requiredRpcs: ['gov_schema_contract_introspect', 'gov_schema_reconcile_introspect', 'load_verify_context',
         'prevent_protocol_event_mutation', 'prevent_handshake_event_mutation',
         'prevent_consumption_reversal'],
 };

--- a/scripts/db-contract.manifest.mts
+++ b/scripts/db-contract.manifest.mts
@@ -292,6 +292,7 @@ export const contract: DbContract = {
     'bind_guard_receipt_event_scope',
     'reject_guard_receipt_binding_mutation',
     'gov_schema_contract_introspect',
+    'gov_schema_reconcile_introspect',
     'complete_webauthn_registration_atomic',
     'consume_trust_desk_bootstrap_atomic',
     ...RELEASE_LOCK_SERVICE_RPCS,
@@ -299,7 +300,7 @@ export const contract: DbContract = {
 
   // Functions that MUST exist (existence only). Includes the append-only
   // immutability triggers — their absence means tamper-evidence is unenforced.
-  requiredRpcs: ['gov_schema_contract_introspect', 'load_verify_context',
+  requiredRpcs: ['gov_schema_contract_introspect', 'gov_schema_reconcile_introspect', 'load_verify_context',
     'prevent_protocol_event_mutation', 'prevent_handshake_event_mutation',
     'prevent_consumption_reversal'],
 };

--- a/scripts/migration-reconcile.mjs
+++ b/scripts/migration-reconcile.mjs
@@ -84,8 +84,12 @@ catch (e) {
     console.error('FATAL: introspection failed:', e.message);
     process.exit(2);
 }
-const prodTables = new Set(snap.tables);
-const prodFns = new Set(snap.functions.map((f) => f.name));
+if (!Array.isArray(snap.reconcile_tables) || !Array.isArray(snap.reconcile_functions)) {
+    console.error('FATAL: reconciliation snapshot is missing qualified private-schema object names');
+    process.exit(2);
+}
+const prodTables = new Set(snap.reconcile_tables);
+const prodFns = new Set(snap.reconcile_functions);
 const missingTables = declaredTables.filter((t) => !prodTables.has(t));
 const missingFns = declaredFns.filter((f) => !prodFns.has(f));
 console.log(`\nMigration journal vs reality — ${new Date().toISOString()}`);

--- a/scripts/migration-reconcile.mts
+++ b/scripts/migration-reconcile.mts
@@ -88,8 +88,13 @@ let snap: any;
 try { snap = await fetchSchemaSnapshot(); }
 catch (e) { console.error('FATAL: introspection failed:', (e as any).message); process.exit(2); }
 
-const prodTables: Set<string> = new Set(snap.tables);
-const prodFns: Set<string> = new Set(snap.functions.map((f: any) => f.name));
+if (!Array.isArray(snap.reconcile_tables) || !Array.isArray(snap.reconcile_functions)) {
+  console.error('FATAL: reconciliation snapshot is missing qualified private-schema object names');
+  process.exit(2);
+}
+
+const prodTables: Set<string> = new Set(snap.reconcile_tables);
+const prodFns: Set<string> = new Set(snap.reconcile_functions);
 
 const missingTables: string[] = declaredTables.filter((t) => !prodTables.has(t));
 const missingFns: string[] = declaredFns.filter((f) => !prodFns.has(f));

--- a/supabase/migrations/20260722050000_schema_reconcile_private_namespaces.sql
+++ b/supabase/migrations/20260722050000_schema_reconcile_private_namespaces.sql
@@ -1,0 +1,51 @@
+-- Forward-only repair for the migration journal reconciliation gate.
+--
+-- gov_schema_contract_introspect() deliberately exposes the public API schema
+-- used by the executable DB contract.  Trust Program and Remedy Program state
+-- live in private schemas, so comparing every migration-declared object only
+-- against that public snapshot creates a false "journal lied" result after a
+-- successful deployment.  This metadata-only companion returns qualified
+-- names for every non-system table/function without reading application rows.
+
+CREATE OR REPLACE FUNCTION public.gov_schema_reconcile_introspect()
+RETURNS JSONB
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public'
+AS $$
+  SELECT jsonb_build_object(
+    'tables', (
+      SELECT coalesce(jsonb_agg(object_name ORDER BY object_name), '[]'::jsonb)
+      FROM (
+        SELECT CASE
+          WHEN n.nspname = 'public' THEN c.relname
+          ELSE n.nspname || '.' || c.relname
+        END AS object_name
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relkind IN ('r', 'p')
+          AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+          AND n.nspname !~ '^pg_(toast|temp)'
+      ) qualified_tables
+    ),
+    'functions', (
+      SELECT coalesce(jsonb_agg(object_name ORDER BY object_name), '[]'::jsonb)
+      FROM (
+        SELECT DISTINCT CASE
+          WHEN n.nspname = 'public' THEN p.proname
+          ELSE n.nspname || '.' || p.proname
+        END AS object_name
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+          AND n.nspname !~ '^pg_(toast|temp)'
+      ) qualified_functions
+    )
+  );
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.gov_schema_reconcile_introspect()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.gov_schema_reconcile_introspect()
+  TO service_role, schema_gate;


### PR DESCRIPTION
## Why

The main-only reconciliation gate compared every migration-declared object against the intentionally public-only contract snapshot. Private Trust Program and Remedy Program objects were deployed, but the gate could not name them and falsely reported journal drift.

## Fix

- add a metadata-only SECURITY DEFINER reconciliation snapshot with qualified non-system object names
- keep anon and authenticated execution revoked
- grant only service_role and the row-blind schema_gate role
- require the new RPC in the executable DB contract
- fail closed when the qualified snapshot is missing

## Verification

- live schema contract: 531 assertions passed
- live migration reconciliation: 166 files, 118 declared tables, 121 declared functions, zero missing objects
- private snapshot: 7 Trust Program tables / 7 functions and 6 Remedy Program tables / 6 functions
- lint, typecheck:rest, generated runtime parity, and diff checks pass
- the forward migration is applied and journaled as 20260722050000

This restores the main deployment gate without weakening private-schema isolation.