### PR TITLE
fix(release): replay provenance on migrated TypeScript

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,15 @@ name: Release Provenance
 # early. Affects actions/checkout, actions/setup-node, actions/upload-artifact, etc.
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  RELEASE_REF: ${{ inputs.release_ref || github.ref_name }}
 
 on:
+  workflow_dispatch:
+    inputs:
+      release_ref:
+        description: Exact immutable release tag to replay, for example gate-v0.14.0
+        required: true
+        type: string
   release:
     types: [published]
   push:
@@ -24,10 +31,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: ${{ env.RELEASE_REF }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Require an exact immutable release tag
+        run: |
+          case "$RELEASE_REF" in
+            *-v*) ;;
+            *) echo "::error::Release provenance requires an exact *-v* tag."; exit 2 ;;
+          esac
+          TAG_COMMIT=$(git rev-parse "refs/tags/$RELEASE_REF^{commit}")
+          HEAD_COMMIT=$(git rev-parse HEAD)
+          test "$TAG_COMMIT" = "$HEAD_COMMIT"
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
-          node-version: 20
+          # The security-case loader resolves migrated .ts sources and needs
+          # Node's built-in TypeScript stripping (Node >=22.6).
+          node-version: 24
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
@@ -93,7 +116,7 @@ jobs:
       - name: Upload release evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: release-evidence-${{ github.ref_name }}
+          name: release-evidence-${{ env.RELEASE_REF }}
           path: |
             release-artifacts/${{ steps.pack-verify.outputs.tarball }}
             release-artifacts/${{ steps.pack-verify.outputs.tarball }}.sha256


### PR DESCRIPTION
## Summary
- run generic release provenance on Node 24 so the governed TypeScript loader can execute
- add an exact immutable-tag replay input for repairing provenance without moving release tags
- bind uploaded evidence names to the inspected release tag

## Verification
- workflow YAML parsed with the repository YAML dependency
- `npm run check:release-chain`
- `git diff --check`

The dedicated Verify 3.13.0 and Gate 0.14.0 publication workflows already completed successfully and verified registry bytes. This repairs the older generic tag-provenance workflow that failed on Node 20.