### PR TITLE
fix(consequence): bind recovery to evidence context

### DIFF
--- a/apps/consequence-control-service/src/runtime.js
+++ b/apps/consequence-control-service/src/runtime.js
@@ -470,35 +470,40 @@ export function createConsequenceControlRuntime(config) {
             return refused(403, 'profile_not_authorized');
         }
         try {
-            const recovered = await config.recoverAttempt({
-                principal,
-                proposal: clone(proposal),
-                attempt: clone(body.attempt),
-            });
-            if (!isPlainObject(recovered)
-                || recovered.tenant_id !== body.attempt.tenant_id
-                || recovered.attempt_id !== body.attempt.attempt_id
-                || typeof recovered.owner !== 'string'
-                || recovered.owner.length < 16
-                || recovered.owner.length > 1024) {
-                return refused(409, 'attempt_recovery_refused');
-            }
-            const recoveryAuthorization = await config.aebRecoveryAuthorization({
-                principal,
-                proposal: clone(proposal),
-                attempt: clone(body.attempt),
-            });
             const result = await config.withEvidenceContext({
                 principal,
                 proposal: clone(proposal),
                 evidence: clone(body.evidence),
-            }, () => config.controller.reconcile({
-                proposal,
-                evaluation: clone(body.evaluation),
-                attempt: recovered,
-                provider_evidence: clone(body.provider_evidence),
-                aeb_recovery_authorization: recoveryAuthorization,
-            }));
+            }, async () => {
+                const recovered = await config.recoverAttempt({
+                    principal,
+                    proposal: clone(proposal),
+                    attempt: clone(body.attempt),
+                });
+                if (!isPlainObject(recovered)
+                    || recovered.tenant_id !== body.attempt.tenant_id
+                    || recovered.attempt_id !== body.attempt.attempt_id
+                    || typeof recovered.owner !== 'string'
+                    || recovered.owner.length < 16
+                    || recovered.owner.length > 1024) {
+                    return { ok: false, reason: 'attempt_recovery_refused' };
+                }
+                const recoveryAuthorization = await config.aebRecoveryAuthorization({
+                    principal,
+                    proposal: clone(proposal),
+                    attempt: clone(body.attempt),
+                });
+                return config.controller.reconcile({
+                    proposal,
+                    evaluation: clone(body.evaluation),
+                    attempt: recovered,
+                    provider_evidence: clone(body.provider_evidence),
+                    aeb_recovery_authorization: recoveryAuthorization,
+                });
+            });
+            if (result?.reason === 'attempt_recovery_refused') {
+                return refused(409, 'attempt_recovery_refused');
+            }
             return response(statusForControllerResult(result), {
                 status: result?.ok === true ? 'reconciled' : 'refused',
                 result: sanitizeControllerResult(result),

--- a/apps/consequence-control-service/src/runtime.ts
+++ b/apps/consequence-control-service/src/runtime.ts
@@ -550,35 +550,40 @@ export function createConsequenceControlRuntime(config: ConsequenceControlRuntim
       return refused(403, 'profile_not_authorized');
     }
     try {
-      const recovered = await config.recoverAttempt({
-        principal,
-        proposal: clone(proposal),
-        attempt: clone(body.attempt),
-      });
-      if (!isPlainObject(recovered)
-          || recovered.tenant_id !== body.attempt.tenant_id
-          || recovered.attempt_id !== body.attempt.attempt_id
-          || typeof recovered.owner !== 'string'
-          || recovered.owner.length < 16
-          || recovered.owner.length > 1024) {
-        return refused(409, 'attempt_recovery_refused');
-      }
-      const recoveryAuthorization = await config.aebRecoveryAuthorization({
-        principal,
-        proposal: clone(proposal),
-        attempt: clone(body.attempt),
-      });
       const result = await config.withEvidenceContext({
         principal,
         proposal: clone(proposal),
         evidence: clone(body.evidence),
-      }, () => config.controller.reconcile({
-        proposal,
-        evaluation: clone(body.evaluation),
-        attempt: recovered,
-        provider_evidence: clone(body.provider_evidence),
-        aeb_recovery_authorization: recoveryAuthorization,
-      }));
+      }, async () => {
+        const recovered = await config.recoverAttempt({
+          principal,
+          proposal: clone(proposal),
+          attempt: clone(body.attempt),
+        });
+        if (!isPlainObject(recovered)
+            || recovered.tenant_id !== body.attempt.tenant_id
+            || recovered.attempt_id !== body.attempt.attempt_id
+            || typeof recovered.owner !== 'string'
+            || recovered.owner.length < 16
+            || recovered.owner.length > 1024) {
+          return { ok: false, reason: 'attempt_recovery_refused' };
+        }
+        const recoveryAuthorization = await config.aebRecoveryAuthorization({
+          principal,
+          proposal: clone(proposal),
+          attempt: clone(body.attempt),
+        });
+        return config.controller.reconcile({
+          proposal,
+          evaluation: clone(body.evaluation),
+          attempt: recovered,
+          provider_evidence: clone(body.provider_evidence),
+          aeb_recovery_authorization: recoveryAuthorization,
+        });
+      });
+      if (result?.reason === 'attempt_recovery_refused') {
+        return refused(409, 'attempt_recovery_refused');
+      }
       return response(statusForControllerResult(result), {
         status: result?.ok === true ? 'reconciled' : 'refused',
         result: sanitizeControllerResult(result) as JsonObject,

--- a/apps/consequence-control-service/test/runtime.test.js
+++ b/apps/consequence-control-service/test/runtime.test.js
@@ -439,6 +439,48 @@ test('reconcile recovers owner and AEB authorization on the server', async () =>
   assert.deepEqual(context.evidence, evidence());
 });
 
+test('reconcile authorizes durable recovery inside the request evidence context', async () => {
+  let activeContext = null;
+  const { runtime } = fixture({
+    withEvidenceContext: async (context, work) => {
+      assert.equal(activeContext, null);
+      activeContext = structuredClone(context);
+      try {
+        return await work();
+      } finally {
+        activeContext = null;
+      }
+    },
+    recoverAttempt: async ({ attempt }) => {
+      assert.deepEqual(activeContext?.evidence, evidence());
+      return {
+        tenant_id: attempt.tenant_id,
+        attempt_id: attempt.attempt_id,
+        owner: 'pto-owner:v1:context-bound-recovery-capability',
+      };
+    },
+    aebRecoveryAuthorization: async () => {
+      assert.deepEqual(activeContext?.evidence, evidence());
+      return { recovery: 'context-bound' };
+    },
+  });
+
+  const result = await runtime.reconcile({
+    principal: PRINCIPAL,
+    proposalId: 'proposal:0000000000000001',
+    body: {
+      proposal: proposal(),
+      evaluation: { verdict: 'SATISFIED' },
+      attempt: publicAttempt(),
+      provider_evidence: { outcome: 'COMMITTED' },
+      evidence: evidence(),
+    },
+  });
+
+  assert.equal(result.status, 200);
+  assert.equal(activeContext, null);
+});
+
 test('execute refuses malformed evidence before selecting an effect', async () => {
   let effectSelected = false;
   const { runtime, calls } = fixture({


### PR DESCRIPTION
## What changed

- run durable attempt recovery inside the authenticated request evidence context
- keep server-derived recovery ownership and AEB authorization in the same context boundary
- add a regression test that refuses recovery outside that boundary

## Why

The managed canary correctly committed normal executions and refused replay, but reconciliation failed closed because the PostgreSQL recovery store requires the request evidence context and the runtime previously recovered the attempt before entering it.

## Verification

- consequence-control service: 35/35
- runtime regression suite: 15/15
- tsconfig.rest.json: clean
- standalone runtimes: synchronized (453)
- repository boundary: clean
- protocol discipline: 0 critical