### PR TITLE
feat(site): launch Amelia I diagnostic offer

### DIFF
--- a/app/HomePageClient.tsx
+++ b/app/HomePageClient.tsx
@@ -250,16 +250,23 @@ export default function HomePage() {
           <motion.div {...reveal()} style={{ maxWidth: 780 }}>
             <div style={{ fontFamily: font.mono, fontSize: 10, letterSpacing: 2, textTransform: 'uppercase', color: color.gold, marginBottom: 16 }}>Where to start</div>
             <h2 style={{ fontFamily: font.sans, fontWeight: 700, fontSize: 'clamp(26px, 3vw, 40px)', letterSpacing: -1, lineHeight: 1.15, color: color.t1, margin: 0 }}>
-              One Gate. Two practical entry points.
+              Diagnose, integrate, or adopt from code.
             </h2>
             <p style={{ fontSize: 17, color: color.t2, lineHeight: 1.72, maxWidth: 660, marginTop: 20 }}>
-              Developers can protect one privileged MCP tool without changing the rest of the
-              agent stack. Regulated operators can begin with one adverse or high-consequence
-              workflow at the actual system of record, first in observe mode and then in enforcement.
+              Amelia I can find the legacy workflow that most needs control. Engineering teams can
+              protect a known boundary directly, while developers can adopt Receipt Required around
+              one privileged tool without changing the rest of the agent stack.
             </p>
           </motion.div>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 16, marginTop: 32 }}>
             {[
+              {
+                label: 'Legacy diagnostic',
+                title: 'Find where approval and effect stopped matching.',
+                body: 'Amelia I reviews one governed export, produces source-linked integrity cases, and generates the Action Control Manifest template for the selected workflow.',
+                href: '/health/program-integrity',
+                cta: 'Explore Amelia I',
+              },
               {
                 label: 'Developer adoption',
                 title: 'Return Receipt Required from a dangerous tool.',

--- a/app/api/pilot/request/route.ts
+++ b/app/api/pilot/request/route.ts
@@ -134,7 +134,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         `What happens next: I reply personally within one business day with a ` +
         `15-minute scheduling link and the one-page ${MANAGED_PILOT.durationLabel}, ` +
         `${MANAGED_PILOT.priceLabel} pilot scope (${MANAGED_PILOT.workflowLabel}; ` +
-        `observe mode first, with enforcement only after your approval).\n\n` +
+        `synthetic first, then a governed read-only export).\n\n` +
         `Meanwhile, three things you can verify without trusting us:\n` +
         `- Be the approver yourself (20 seconds): https://www.emiliaprotocol.ai/try\n` +
         `- Verify a receipt offline: https://www.emiliaprotocol.ai/verify\n` +

--- a/app/health/program-integrity/_components/ProgramIntegrityGate.tsx
+++ b/app/health/program-integrity/_components/ProgramIntegrityGate.tsx
@@ -150,50 +150,51 @@ export default function ProgramIntegrityGate(): React.ReactElement {
           <div className={styles.heroCopy}>
             <div className={styles.kicker}>
               <HeartPulse aria-hidden="true" size={15} />
-              California public-interest reference
+              Amelia I + EMILIA Gate
             </div>
-            <h1>Make the public payment prove its authorization before it moves.</h1>
+            <h1>Find the risky workflow. Then make the next payment prove its authorization.</h1>
             <p className={styles.heroLede}>
-              EMILIA Program Integrity Gate binds a provider action, authorization,
-              destination, amount, and named approval into one exact-action record—then
-              permits one bounded execution or refuses it.
+              Amelia I reconstructs the approval-to-effect chain from a governed legacy
+              export. EMILIA Gate then binds the provider action, authorization,
+              destination, amount, and named approval before the next protected effect.
             </p>
             <p className={styles.heroBoundary}>
-              Designed to sit beside existing program-integrity analytics and payment
-              systems. It does not replace DHCS, CA-MMIS, or their controls.
+              The diagnostic is read-only and does not declare fraud. The Gate is a
+              prospective control designed to sit beside existing program-integrity and
+              payment systems—not replace DHCS, CA-MMIS, or their controls.
             </p>
             <div className={styles.heroActions}>
-              <a href="#reference-lab" className={styles.primaryAction}>
-                Run the reference gate
+              <a href="/pilot?v=health" className={styles.primaryAction}>
+                Scope the Amelia I diagnostic
                 <ArrowRight aria-hidden="true" size={16} />
               </a>
-              <a href="/govguard" className={styles.secondaryAction}>
-                Explore GovGuard
+              <a href="#reference-lab" className={styles.secondaryAction}>
+                Run the prospective Gate
               </a>
             </div>
           </div>
           <div className={styles.publicValue} aria-label="Public-interest control model">
             <div className={styles.valueTop}>
-              <span>Before public funds move</span>
+              <span>One commercial path</span>
               <ShieldCheck aria-hidden="true" size={22} />
             </div>
             <div className={styles.valueStatement}>
-              <strong>One action.</strong>
-              <strong>One accountable decision.</strong>
-              <strong>One execution right.</strong>
+              <strong>Diagnose the old record.</strong>
+              <strong>Bind the next decision.</strong>
+              <strong>Reconcile the outcome.</strong>
             </div>
             <dl className={styles.valueFacts}>
               <div>
-                <dt>Wrong fields</dt>
-                <dd>Do not execute</dd>
+                <dt>Amelia I</dt>
+                <dd>Find the boundary</dd>
               </div>
               <div>
-                <dt>Unknown outcome</dt>
-                <dd>Do not replay</dd>
+                <dt>Gate</dt>
+                <dd>Protect the effect</dd>
               </div>
               <div>
-                <dt>Outside review</dt>
-                <dd>Portable evidence</dd>
+                <dt>Assurance</dt>
+                <dd>Re-perform proof</dd>
               </div>
             </dl>
           </div>
@@ -472,14 +473,15 @@ export default function ProgramIntegrityGate(): React.ReactElement {
       <section className={styles.nextSteps} aria-labelledby="program-integrity-next-step">
         <div>
           <div className={styles.eyebrow}>Practical next step</div>
-          <h2 id="program-integrity-next-step">Test one protected workflow for 60 days.</h2>
+          <h2 id="program-integrity-next-step">Start with one read-only workflow for 60 days.</h2>
           <p>
-            Start in observe mode beside the existing program-integrity and payment stack.
-            Exercise valid, missing, mismatched, replayed, revoked, and indeterminate cases,
-            then give the portable packet to a separate authorized reviewer.
+            Begin with synthetic replay and a governed export. Amelia I surfaces the
+            approval-to-effect gaps and produces an Action Control Manifest template.
+            If the workflow justifies prospective enforcement, Gate becomes the separately
+            scoped next engagement at the real system boundary.
           </p>
           <a href="/pilot?v=gov" className={styles.pilotAction}>
-            Scope an observe-mode pilot
+            Scope the Amelia I diagnostic
             <ArrowRight aria-hidden="true" size={16} />
           </a>
         </div>

--- a/app/health/program-integrity/page.tsx
+++ b/app/health/program-integrity/page.tsx
@@ -5,9 +5,9 @@ import SiteNav from '@/components/SiteNav';
 import ProgramIntegrityGate from './_components/ProgramIntegrityGate';
 
 export const metadata: Metadata = {
-  title: 'Program Integrity Gate | EMILIA',
+  title: 'Amelia I + Program Integrity Gate | EMILIA',
   description:
-    'A synthetic, PHI-free reference demo showing exact-action authorization, fail-closed payment control, no-blind-replay handling, and portable program-integrity evidence.',
+    'Diagnose risky legacy workflows with Amelia I, then see a synthetic, PHI-free Gate demonstration of exact-action authorization, no-blind-replay handling, and portable evidence.',
 };
 
 export default function ProgramIntegrityPage() {

--- a/app/pilot/layout.tsx
+++ b/app/pilot/layout.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Request a Managed Gate Pilot — One Workflow, 60 Days — EMILIA Protocol',
   description:
-    'Scope one consequential workflow for a fixed 60-day engagement: observe first, configure the evidence and approval policy, then enforce only after customer approval.',
+    'Scope one consequential workflow for a fixed 60-day Amelia I diagnostic: synthetic first, then a governed read-only export, source-linked findings, and a Gate implementation decision.',
   alternates: { canonical: '/pilot' },
 };
 

--- a/app/pilot/page.tsx
+++ b/app/pilot/page.tsx
@@ -30,9 +30,9 @@ const PRESELECT = { gov: 'benefit_account_change', fin: 'wire_release', health: 
 const TERMS = [
   [MANAGED_PILOT.durationLabel, 'time-boxed engagement'],
   [MANAGED_PILOT.shortPriceLabel, 'fixed scope and price'],
-  ['Observe mode first', 'nothing blocked until you approve enforcement'],
+  ['Read-only first', 'no production path changes in the diagnostic'],
   [MANAGED_PILOT.workflowLabel, 'the consequential action you choose'],
-  ['Decision package', 'working control, evidence, and production plan'],
+  ['Decision package', 'findings, manifest template, and implementation scope'],
 ];
 
 export default function PilotPage(): React.ReactElement {
@@ -85,13 +85,13 @@ export default function PilotPage(): React.ReactElement {
           Pilot request
         </div>
         <h1 style={{ ...styles.h1, maxWidth: 600 }}>
-          One protected workflow. {MANAGED_PILOT.durationLabel}. {MANAGED_PILOT.shortPriceLabel}.
+          Find the workflow to protect. {MANAGED_PILOT.durationLabel}. {MANAGED_PILOT.shortPriceLabel}.
         </h1>
         <p style={{ ...styles.body, maxWidth: 580 }}>
-          Pick one consequential action your systems or agents take. We first measure it in observe mode,
-          then configure the action, evidence, approval, and escalation policy. Enforcement turns on only
-          after your team approves the rollout. You leave with the working control, its evidence package,
-          and a production recommendation.
+          Pick one consequential workflow and begin with synthetic replay plus a governed read-only export.
+          Amelia I reconstructs the approval-to-effect chain, surfaces source-linked integrity cases, and
+          produces the material-field map and Action Control Manifest template. You leave with evidence,
+          a Gate implementation scope, and a clear decision about whether prospective enforcement is worth it.
         </p>
 
         {/* terms strip */}

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -2,17 +2,17 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import SiteNav from '@/components/SiteNav';
 import SiteFooter from '@/components/SiteFooter';
-import { MANAGED_PILOT, PRODUCTION_GATE } from '@/lib/commercial-offer';
+import { GATE_IMPLEMENTATION, MANAGED_PILOT, PRODUCTION_GATE } from '@/lib/commercial-offer';
 import { cta, color, font, radius } from '@/lib/tokens';
 
 export const metadata: Metadata = {
   title: 'EMILIA Gate Pricing',
   description:
-    'Use the open EMILIA Protocol for free, prove one protected workflow in a fixed-scope pilot, then price production Gate operations around the boundary you protect.',
+    'Use the open EMILIA Protocol for free, diagnose one legacy workflow with Amelia I, implement Gate at the consequence boundary, then operate it in production.',
   alternates: { canonical: '/pricing' },
   openGraph: {
     title: 'EMILIA Gate Pricing',
-    description: 'Open proof infrastructure, a fixed-scope managed pilot, and production Gate operations priced by protected workflow.',
+    description: 'Open proof infrastructure, a read-only Amelia I diagnostic, a prospective Gate implementation, and operated production controls.',
     url: 'https://www.emiliaprotocol.ai/pricing',
     type: 'website',
   },
@@ -60,7 +60,7 @@ const TIERS: Array<{
     price: MANAGED_PILOT.shortPriceLabel,
     priceNote: `fixed scope · ${MANAGED_PILOT.durationLabel}`,
     priceIsLabel: false,
-    tagline: 'Prove Gate on one consequential workflow before committing to a production rollout.',
+    tagline: 'Find where old records lose the approval-to-effect chain before changing a production path.',
     accent: color.blue,
     cta: { label: 'Scope the pilot', href: '/pilot' },
     ctaStyle: 'primary' as const,
@@ -68,12 +68,32 @@ const TIERS: Array<{
     available: true,
     features: [
       MANAGED_PILOT.workflowLabel,
-      'Observe-mode baseline and risk inventory',
-      'Action, evidence, approval, and escalation policy',
-      'Customer-approved enforcement rollout',
-      'Failure, reconciliation, and remedy-control drill',
-      'Auditor-ready evidence package and findings review',
-      'Production architecture and commercial recommendation',
+      'Synthetic replay, then one governed read-only export',
+      'Source-linked integrity cases, not automated fraud verdicts',
+      'Deterministic findings separated from heuristic leads',
+      'Material-field and action-type map',
+      'Action Control Manifest template',
+      'Decision-ready Gate implementation scope',
+    ],
+  },
+  {
+    name: GATE_IMPLEMENTATION.name,
+    price: GATE_IMPLEMENTATION.priceLabel,
+    priceNote: GATE_IMPLEMENTATION.scopeLabel,
+    priceIsLabel: true,
+    tagline: 'Turn the selected risk area into a fail-closed prospective control at the real executor boundary.',
+    accent: color.blue,
+    cta: { label: 'Design the Gate', href: '/pilot' },
+    ctaStyle: 'secondary' as const,
+    highlight: false,
+    available: true,
+    features: [
+      'System-of-record action and route binding',
+      'Receipt Required challenge and approval acquisition',
+      'Exact-action verification and one-time consumption',
+      'Indeterminate outcome and no-blind-replay handling',
+      'Authenticated reconciliation and remedy workflow',
+      'Customer acceptance vectors and production runbook',
     ],
   },
   {
@@ -81,14 +101,14 @@ const TIERS: Array<{
     price: PRODUCTION_GATE.priceLabel,
     priceNote: 'quoted by protected workflow and operating boundary',
     priceIsLabel: true,
-    tagline: 'Managed policy, approval, consumption, and evidence operations for consequential workflows in production.',
+    tagline: 'Operate policy, approval, consumption, reconciliation, and evidence for consequential production workflows.',
     accent: color.gold,
     cta: { label: 'Talk to us', href: '/partners' },
     ctaStyle: 'secondary' as const,
     highlight: false,
     available: true,
     features: [
-      'Everything proven in the managed pilot',
+      'Everything proven in the Gate implementation',
       'Private cloud, VPC, or self-hosted deployment options',
       'SAML/OIDC identity and SCIM provisioning integration',
       'Durable consumption, reconciliation, dispute, and remedy operations',
@@ -100,12 +120,11 @@ const TIERS: Array<{
 
 // Honest open-core line: what the free protocol gives you vs. what the paid plane adds.
 const OPEN_CORE = [
-  ['Verify receipts under your own pinned trust policy', true, true, true],
-  ['Use public formats, packages, and conformance vectors', true, true, true],
-  ['Managed workflow mapping and evidence policy', false, true, true],
-  ['Observe-first rollout with customer-approved enforcement', false, true, true],
-  ['Ongoing approver routing and continuous evidence', false, false, true],
-  ['Private deployment, identity integration, profiles, and SLA', false, false, true],
+  ['Verify receipts under your own pinned trust policy', true, true, true, true],
+  ['Use public formats, packages, and conformance vectors', true, true, true, true],
+  ['Retrospective workflow diagnosis and source-linked cases', false, true, true, true],
+  ['Prospective executor-bound enforcement', false, false, true, true],
+  ['Managed production evidence and service operations', false, false, false, true],
 ];
 
 const PACKS = [
@@ -135,19 +154,19 @@ export default function PricingPage(): React.ReactElement {
             Pricing
           </div>
           <h1 style={{ fontFamily: font.sans, fontWeight: 700, fontSize: 'clamp(38px, 5vw, 64px)', letterSpacing: -2.2, lineHeight: 1.0, color: color.t1, margin: '0 0 24px', maxWidth: 780 }}>
-            Start open. Prove one workflow. Scale the boundary.
+            Diagnose the past. Protect the next effect. Operate the boundary.
           </h1>
           <p style={{ fontSize: 18, color: color.t2, maxWidth: 620, lineHeight: 1.7, margin: 0 }}>
-            The protocol and self-operated runtime are free. The paid product begins when EMILIA maps, operates,
-            and stands behind a protected workflow at your real system boundary.
+            The open protocol is free. Amelia I finds the workflow that needs control. Gate then moves from a
+            scoped implementation to an operated production boundary.
           </p>
         </C>
       </section>
 
-      {/* THREE DOORS */}
+      {/* FOUR DOORS */}
       <section style={{ paddingBottom: 80 }}>
         <C>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 16, alignItems: 'stretch' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: 16, alignItems: 'stretch' }}>
             {TIERS.map((t) => (
               <div key={t.name} style={{
                 display: 'flex', flexDirection: 'column',
@@ -208,18 +227,18 @@ export default function PricingPage(): React.ReactElement {
         <C>
           <div style={{ maxWidth: 720 }}>
             <div style={{ fontFamily: font.mono, fontSize: 10, letterSpacing: 2, textTransform: 'uppercase', color: color.gold, marginBottom: 16 }}>
-              Start here &middot; observe-mode pilot
+              Start here &middot; read-only diagnostic
             </div>
             <h2 style={{ fontFamily: font.sans, fontWeight: 700, fontSize: 'clamp(26px, 3.2vw, 42px)', letterSpacing: -1.4, lineHeight: 1.08, color: '#FAFAF9', marginBottom: 18 }}>
-              Most teams start with a pilot, not a plan.
+              Find the right boundary before asking engineering to change it.
             </h2>
             <p style={{ fontSize: 16, color: 'rgba(250,250,249,0.72)', lineHeight: 1.7, marginBottom: 30, maxWidth: 620 }}>
-              One high-risk workflow over {MANAGED_PILOT.durationLabel}. We begin in observe mode, configure the
-              evidence and approval policy, and enable enforcement only after your team approves it. You finish with
-              a working control, an evidence package, and a decision-ready production plan.
+              Amelia I starts with a synthetic replay and one governed export over {MANAGED_PILOT.durationLabel}.
+              It reconstructs action groups, separates deterministic findings from heuristic leads, and produces a
+              decision-ready manifest and implementation scope. No production path is changed in this first engagement.
             </p>
             <div style={{ display: 'flex', gap: 36, flexWrap: 'wrap', marginBottom: 32 }}>
-              {[[MANAGED_PILOT.shortPriceLabel, 'fixed, scoped engagement'], [MANAGED_PILOT.durationLabel, 'observe, configure, then enforce'], [MANAGED_PILOT.workflowLabel, 'you pick the riskiest one']].map(([n, l]) => (
+              {[[MANAGED_PILOT.shortPriceLabel, 'fixed, scoped engagement'], [MANAGED_PILOT.durationLabel, 'synthetic first, governed export second'], [MANAGED_PILOT.workflowLabel, 'find the riskiest boundary']].map(([n, l]) => (
                 <div key={n}>
                   <div style={{ fontFamily: font.sans, fontWeight: 700, fontSize: 26, letterSpacing: -1, color: '#FAFAF9' }}>{n}</div>
                   <div style={{ fontFamily: font.mono, fontSize: 11, letterSpacing: 0.4, color: 'rgba(250,250,249,0.55)' }}>{l}</div>
@@ -227,8 +246,8 @@ export default function PricingPage(): React.ReactElement {
               ))}
             </div>
             <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-              <Link href="/pilot" className="ep-cta" style={{ ...cta.primary, background: color.gold, color: '#1C1917' }}>Scope the managed pilot &rarr;</Link>
-              <Link href="/pilot/sandbox" className="ep-cta-secondary" style={{ ...cta.secondary, color: 'rgba(250,250,249,0.8)', borderColor: 'rgba(255,255,255,0.15)' }}>Run the sandbox yourself</Link>
+              <Link href="/pilot" className="ep-cta" style={{ ...cta.primary, background: color.gold, color: '#1C1917' }}>Scope the Amelia I diagnostic &rarr;</Link>
+              <Link href="/health/program-integrity" className="ep-cta-secondary" style={{ ...cta.secondary, color: 'rgba(250,250,249,0.8)', borderColor: 'rgba(255,255,255,0.15)' }}>See the prospective Gate</Link>
             </div>
           </div>
         </C>
@@ -244,18 +263,19 @@ export default function PricingPage(): React.ReactElement {
             Protocol proves. Gate prevents.
           </h2>
           <div className="ep-pricing-table" style={{ background: color.card, border: `1px solid ${color.border}`, borderRadius: radius.base, overflowX: 'auto' }}>
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 120px 120px 120px', alignItems: 'center', padding: '14px 24px', borderBottom: `1px solid ${color.borderHover}`, background: 'rgba(245,244,240,0.6)' }}>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 110px 110px 110px 110px', alignItems: 'center', padding: '14px 24px', borderBottom: `1px solid ${color.borderHover}`, background: 'rgba(245,244,240,0.6)' }}>
               <span style={{ fontFamily: font.mono, fontSize: 10, letterSpacing: 1, textTransform: 'uppercase', color: color.t1, fontWeight: 700 }}>Capability</span>
-              {['Open', 'Pilot', 'Production'].map((h) => (
+              {['Open', 'Diagnose', 'Implement', 'Operate'].map((h) => (
                 <span key={h} style={{ fontFamily: font.mono, fontSize: 10, letterSpacing: 1, textTransform: 'uppercase', color: color.t1, fontWeight: 700, textAlign: 'center' }}>{h}</span>
               ))}
             </div>
             {OPEN_CORE.map((row, i) => (
-              <div key={i} style={{ display: 'grid', gridTemplateColumns: '1fr 120px 120px 120px', alignItems: 'center', padding: '16px 24px', borderBottom: i < OPEN_CORE.length - 1 ? `1px solid ${color.border}` : 'none' }}>
+              <div key={i} style={{ display: 'grid', gridTemplateColumns: '1fr 110px 110px 110px 110px', alignItems: 'center', padding: '16px 24px', borderBottom: i < OPEN_CORE.length - 1 ? `1px solid ${color.border}` : 'none' }}>
                 <span style={{ fontSize: 14, color: color.t2 }}>{row[0]}</span>
                 <span style={{ textAlign: 'center' }}><Check on={row[1]} accent={color.green} /></span>
                 <span style={{ textAlign: 'center' }}><Check on={row[2]} accent={color.blue} /></span>
                 <span style={{ textAlign: 'center' }}><Check on={row[3]} accent={color.gold} /></span>
+                <span style={{ textAlign: 'center' }}><Check on={row[4]} accent={color.gold} /></span>
               </div>
             ))}
           </div>
@@ -327,10 +347,10 @@ export default function PricingPage(): React.ReactElement {
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 32, flexWrap: 'wrap' }}>
             <div>
               <h2 style={{ fontFamily: font.sans, fontWeight: 700, fontSize: 'clamp(24px, 3vw, 38px)', letterSpacing: -1.2, lineHeight: 1.1, color: color.t1, marginBottom: 10 }}>
-                Start with one protected action.
+                Start with one consequential workflow.
               </h2>
               <p style={{ fontSize: 16, color: color.t2, lineHeight: 1.6, maxWidth: 440, margin: 0 }}>
-                Put Gate immediately before one mutating system, require the evidence that matters, and measure the result.
+                Diagnose an uncertain legacy path with Amelia I, or put Gate directly before a known high-risk mutation.
               </p>
             </div>
             <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>

--- a/lib/commercial-offer.ts
+++ b/lib/commercial-offer.ts
@@ -5,20 +5,28 @@
  * so price, duration, scope, and rollout posture cannot drift independently.
  */
 export const MANAGED_PILOT = Object.freeze({
-  name: 'Managed Gate Pilot',
+  name: 'Amelia I Diagnostic',
   priceUsd: 25_000,
   priceLabel: '$25,000',
   shortPriceLabel: '$25K',
   durationDays: 60,
   durationLabel: '60 days',
   workflowCount: 1,
-  workflowLabel: '1 protected workflow',
-  rolloutLabel: 'Observe first; enforce only after customer approval',
+  workflowLabel: '1 read-only workflow diagnostic',
+  rolloutLabel: 'Synthetic first; governed export only after approval',
+});
+
+export const GATE_IMPLEMENTATION = Object.freeze({
+  name: 'Gate Implementation',
+  priceLabel: '$150K-$250K',
+  scopeLabel: 'one prospective consequence boundary',
+  valueMetric: 'protected workflow',
+  outcomeLabel: 'production-ready Gate binding and evidence operations',
 });
 
 export const PRODUCTION_GATE = Object.freeze({
-  name: 'Production Gate',
-  priceLabel: 'Annual contract',
+  name: 'Operated Gate',
+  priceLabel: '$250K-$500K / year',
   valueMetric: 'protected workflow',
   quoteDimensions: ['protected workflows', 'deployment boundary', 'evidence retention', 'integrations', 'service level'],
 });

--- a/tests/commercial-offer-contract.test.ts
+++ b/tests/commercial-offer-contract.test.ts
@@ -6,15 +6,21 @@ import { describe, expect, it } from 'vitest';
 
 const ROOT = resolve(import.meta.dirname, '..');
 const pricing = readFileSync(resolve(ROOT, 'app/pricing/page.tsx'), 'utf8');
+const commercialOffer = readFileSync(resolve(ROOT, 'lib/commercial-offer.ts'), 'utf8');
 const pilot = readFileSync(resolve(ROOT, 'app/pilot/page.tsx'), 'utf8');
 const pilotMetadata = readFileSync(resolve(ROOT, 'app/pilot/layout.tsx'), 'utf8');
 const intake = readFileSync(resolve(ROOT, 'app/api/pilot/request/route.ts'), 'utf8');
 const navigation = readFileSync(resolve(ROOT, 'components/SiteNav.tsx'), 'utf8');
 
 describe('commercial offer contract', () => {
-  it('has one paid entry offer and no contradictory self-serve price', () => {
+  it('has one diagnostic entry offer and a coherent Gate expansion ladder', () => {
     expect(pricing).toContain('MANAGED_PILOT');
+    expect(pricing).toContain('GATE_IMPLEMENTATION');
     expect(pricing).toContain('PRODUCTION_GATE');
+    expect(pricing).toContain('Amelia I');
+    expect(commercialOffer).toContain('$150K');
+    expect(commercialOffer).toContain('$250K');
+    expect(commercialOffer).toContain('$500K');
     expect(pricing).not.toContain("price: '$499'");
     expect(pricing).not.toContain('Gate Cloud is in early access');
   });


### PR DESCRIPTION
## What changed

- introduces Amelia I as the read-only diagnostic entry offer
- makes the commercial ladder explicit: Open Protocol, Amelia I Diagnostic, Gate Implementation, Operated Gate
- updates pricing, pilot, home, and healthcare program-integrity pages
- aligns pilot intake language and commercial contract tests

## Verification

- commercial offer contract tests passed
- application typecheck passed
- production build passed
- pricing and healthcare pages were visually inspected at desktop width

The public site describes only claim-safe product positioning. The scanner implementation, scoring logic, private pricing mechanics, and investor deck remain in the private company repository.