### PR TITLE
ci: harden TLC downloads against transient failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,7 +386,12 @@ jobs:
           TLA_VERSION: v1.7.4
           TLA_SHA256: 936a262061c914694dfd669a543be24573c45d5aa0ff20a8b96b23d01e050e88
         run: |
-          curl -fsSL -o tla2tools.jar \
+          curl -fsSL \
+            --retry 5 \
+            --retry-delay 2 \
+            --retry-all-errors \
+            --connect-timeout 20 \
+            -o tla2tools.jar \
             "https://github.com/tlaplus/tlaplus/releases/download/${TLA_VERSION}/tla2tools.jar"
           echo "${TLA_SHA256}  tla2tools.jar" | sha256sum -c -
       - name: Execute exact claims and require the checked-in security case to be current

--- a/.github/workflows/tlc.yml
+++ b/.github/workflows/tlc.yml
@@ -11,6 +11,7 @@ env:
 
 on:
   push:
+    branches: [main]
     paths:
       - 'formal/**.tla'
       - 'formal/**.cfg'
@@ -60,6 +61,10 @@ on:
       - '.github/workflows/tlc.yml'
   workflow_dispatch:
 
+concurrency:
+  group: tlc-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tlc:
     name: Verify handshake, authority, consequence, and effect-profile models
@@ -87,13 +92,20 @@ jobs:
       - name: Download tla2tools.jar (pinned release + checksum)
         # Pin to a tagged release (NOT the mutable `latest`) and verify the
         # SHA-256 so a compromised/re-cut release can't inject a different jar.
+        # Retry transient GitHub release-edge failures; the pinned checksum
+        # remains the security boundary for every downloaded byte.
         # To bump: change TLA_VERSION, download the new jar, recompute the hash
         # with `shasum -a 256 tla2tools.jar`, and update TLA_SHA256.
         env:
           TLA_VERSION: v1.7.4
           TLA_SHA256: 936a262061c914694dfd669a543be24573c45d5aa0ff20a8b96b23d01e050e88
         run: |
-          curl -fsSL -o tla2tools.jar \
+          curl -fsSL \
+            --retry 5 \
+            --retry-delay 2 \
+            --retry-all-errors \
+            --connect-timeout 20 \
+            -o tla2tools.jar \
             "https://github.com/tlaplus/tlaplus/releases/download/${TLA_VERSION}/tla2tools.jar"
           echo "${TLA_SHA256}  tla2tools.jar" | sha256sum -c -
 


### PR DESCRIPTION
## What changed

- run the standalone TLC workflow on branch pushes only for `main`; pull requests remain fully gated
- cancel superseded TLC runs for the same ref
- retry transient GitHub release download failures in both TLC download paths
- retain the pinned SHA-256 verification after every download

## Why

The post-merge run for #384 had two infrastructure failures:

- CI lint never reached checkout because GitHub codeload returned HTTP 429 three times
- the TLC workflow used a one-shot release download and failed on HTTP 504

The checkout failure is inside GitHub's pre-job action loader and succeeded on rerun. This patch removes duplicate TLC pressure and makes the repository-controlled release downloads resilient without weakening integrity verification.

## Verification

- `actionlint .github/workflows/ci.yml .github/workflows/tlc.yml`
- `git diff --check`
