### PR TITLE
fix(release): pin published Verify 3.16.0 bytes

### DIFF
--- a/release/release-packages.v1.json
+++ b/release/release-packages.v1.json
@@ -16,7 +16,7 @@
       "registry_dependency_tarballs": [
         {
           "spec": "@emilia-protocol/verify@3.16.0",
-          "sha256": "d4d682281fefe95dec0a895c8ec9561c8f6675819d9426c22d390be80f09e3ea"
+          "sha256": "50caa243b057708a30d459839b0ca02292aa297c1f7523ee77f3559492e08fea"
         }
       ]
     },
@@ -32,7 +32,7 @@
       "registry_dependency_tarballs": [
         {
           "spec": "@emilia-protocol/verify@3.16.0",
-          "sha256": "d4d682281fefe95dec0a895c8ec9561c8f6675819d9426c22d390be80f09e3ea"
+          "sha256": "50caa243b057708a30d459839b0ca02292aa297c1f7523ee77f3559492e08fea"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- pin Gate and ep-qualify to the exact published Verify 3.16.0 registry tarball
- preserve the release guard that rejected the stale dependency hash

## Verification
- downloaded npm registry tarball SHA-256: `50caa243b057708a30d459839b0ca02292aa297c1f7523ee77f3559492e08fea`
- `npm run check:release-chain`
- dependency verification for `packages/gate` and `packages/qualify`

The already-published Verify tag is unchanged. Gate and ep-qualify remain unpublished pending this pin repair.