### PR TITLE
fix(db): support managed migration roles

### DIFF
--- a/supabase/migration-history.v1.json
+++ b/supabase/migration-history.v1.json
@@ -375,6 +375,6 @@
     "20260725203000_consequence_actuator_provider_records_managed_role_fix.sql": "57689addd3a65b50e7e693c2ace4a01a5a7a7c22e7bdd3d4d735bc9bf448bc6c",
     "20260725204500_rollout_attempt_store_managed_role_fix.sql": "8a93a8ed5aaff3b0d61ef846ffb44832195323df57719afd74b2c720b1550d92",
     "20260725210000_schema_contract_identity_arguments.sql": "4b501f8fe32311c461eb287ea9cea89ae5b528d06f96832777911f4f53ffe86f",
-    "20260728210700_open_exposure_ledger.sql": "dd7fbfc7a2f21fb0a03e0108ca1a099bfdd547d3357e1005d4d41f778093dead"
+    "20260728210700_open_exposure_ledger.sql": "8ca555e9eae2adcb6853690f6cbd850606164c8872c707d68a7904fc745d7c71"
   }
 }

--- a/supabase/migrations/20260728210700_open_exposure_ledger.sql
+++ b/supabase/migrations/20260728210700_open_exposure_ledger.sql
@@ -34,18 +34,38 @@ BEGIN
 END
 $roles$;
 
-ALTER ROLE ep_open_exposure_store_owner NOLOGIN
-  NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
-ALTER ROLE ep_open_exposure_origin NOLOGIN
-  NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
-ALTER ROLE ep_open_exposure_executor NOLOGIN
-  NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
-ALTER ROLE ep_open_exposure_reconciler NOLOGIN
-  NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
-ALTER ROLE ep_open_exposure_policy_admin NOLOGIN
-  NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
-ALTER ROLE ep_open_exposure_reader NOLOGIN
-  NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+-- Managed PostgreSQL providers commonly grant CREATEROLE without true
+-- SUPERUSER. Such a migration role may create the least-privilege roles above,
+-- but PostgreSQL reserves ALTER ... NOSUPERUSER/NOREPLICATION/NOBYPASSRLS for
+-- a superuser even when those attributes are already false. Validate the
+-- complete posture instead of performing a redundant privileged ALTER. This
+-- also fails closed if a same-named role was provisioned out of band with more
+-- authority than this store permits.
+DO $least_privilege_roles$
+BEGIN
+  IF (
+    SELECT pg_catalog.count(*)
+    FROM pg_catalog.pg_roles AS role
+    WHERE role.rolname IN (
+        'ep_open_exposure_store_owner',
+        'ep_open_exposure_origin',
+        'ep_open_exposure_executor',
+        'ep_open_exposure_reconciler',
+        'ep_open_exposure_policy_admin',
+        'ep_open_exposure_reader'
+      )
+      AND NOT role.rolcanlogin
+      AND NOT role.rolsuper
+      AND NOT role.rolcreatedb
+      AND NOT role.rolcreaterole
+      AND NOT role.rolreplication
+      AND NOT role.rolbypassrls
+  ) <> 6 THEN
+    RAISE EXCEPTION 'open exposure roles must exist with least-privilege posture'
+      USING ERRCODE = '42501';
+  END IF;
+END
+$least_privilege_roles$;
 
 DO $role_separation$
 DECLARE

--- a/tests/open-exposure-ledger-migration-contract.test.ts
+++ b/tests/open-exposure-ledger-migration-contract.test.ts
@@ -24,6 +24,23 @@ describe('Open Exposure Ledger PostgreSQL contract', () => {
     expect(history.deployment_sequence).toContain('20260728210700');
     expect(history.public_files['20260728210700_open_exposure_ledger.sql'])
       .toBe(migrationHash);
+    expect(migration).toContain('DO $least_privilege_roles$');
+    expect(migration).toContain(
+      "open exposure roles must exist with least-privilege posture",
+    );
+    expect(migration).not.toMatch(
+      /ALTER ROLE ep_open_exposure_[^;]+(?:NOSUPERUSER|NOREPLICATION|NOBYPASSRLS)/s,
+    );
+    for (const attribute of [
+      'rolcanlogin',
+      'rolsuper',
+      'rolcreatedb',
+      'rolcreaterole',
+      'rolreplication',
+      'rolbypassrls',
+    ]) {
+      expect(migration).toContain(`NOT role.${attribute}`);
+    }
   });
 
   it('forces RLS and removes direct generic/runtime table authority', () => {

--- a/tests/open-exposure-ledger-postgres.integration.test.ts
+++ b/tests/open-exposure-ledger-postgres.integration.test.ts
@@ -331,6 +331,12 @@ suite('Open Exposure Ledger migration on clean PostgreSQL 17', () => {
     await database.query(`
       CREATE SCHEMA extensions;
       CREATE EXTENSION pgcrypto WITH SCHEMA extensions;
+      CREATE OR REPLACE FUNCTION public.gov_consequence_control_security_assertions()
+        RETURNS TABLE(assertion TEXT)
+        LANGUAGE sql
+        AS $predecessor$
+          SELECT NULL::TEXT WHERE FALSE
+        $predecessor$;
     `);
     await database.query(migration);
 


### PR DESCRIPTION
## Outcome

Repairs the production-only migration failure for the Open Exposure Ledger without weakening its role posture.

Supabase grants the migration principal CREATEROLE but not true SUPERUSER. PostgreSQL therefore permits creating NOSUPERUSER roles but refuses redundant ALTER ROLE ... NOSUPERUSER/NOREPLICATION/NOBYPASSRLS clauses. The migration now:

- creates all six roles with the original least-privilege attributes
- performs no managed-incompatible privileged ALTER
- fails closed through catalog validation if any same-named role is login-capable, superuser, database/role-creating, replicating, or BYPASSRLS
- keeps final live-schema role assertions unchanged
- makes the PostgreSQL integration fixture self-contained instead of inheriting a predecessor schema function

## Verification

- 25 migration/schema-contract tests passed
- fresh PostgreSQL 17 lifecycle: 2/2 passed
- migration-history hash and LLM context passed
- security case: 34 claims, 251 evidence files, unchanged signed evidence binding
- production retry has not been attempted; the failed migration was not journaled

Gate 0.20.0 is already registry-live and byte-verified. This PR changes only the unapplied production migration and its tests/hash.