### PR TITLE
chore(db): reconcile open exposure journal

### DIFF
--- a/supabase/migration-history.v1.json
+++ b/supabase/migration-history.v1.json
@@ -1,17 +1,13 @@
 {
   "schema_version": "EP-MIGRATION-HISTORY-v1",
   "as_of": "2026-07-28",
-  "remote_head": "20260725210000",
+  "remote_head": "20260728210700",
   "private_remote_versions": [
     "20260723192504"
   ],
   "retroactive_pending_versions": [],
-  "forward_pending_versions": [
-    "20260728210700"
-  ],
-  "deployment_sequence": [
-    "20260728210700"
-  ],
+  "forward_pending_versions": [],
+  "deployment_sequence": [],
   "requires_include_all": false,
   "remote_versions": [
     "001",
@@ -193,7 +189,8 @@
     "20260725180000",
     "20260725203000",
     "20260725204500",
-    "20260725210000"
+    "20260725210000",
+    "20260728210700"
   ],
   "public_files": {
     "001_emilia_core_schema.sql": "f5e3c6c40fdaf54fbfc7a986f1b7cb021bfa8bee21a81bac39fe2da15f654060",

--- a/tests/open-exposure-ledger-migration-contract.test.ts
+++ b/tests/open-exposure-ledger-migration-contract.test.ts
@@ -19,9 +19,11 @@ const migrationHash = crypto.createHash('sha256')
   .digest('hex');
 
 describe('Open Exposure Ledger PostgreSQL contract', () => {
-  it('is pinned as a forward-pending migration in exact deployment order', () => {
-    expect(history.forward_pending_versions).toContain('20260728210700');
-    expect(history.deployment_sequence).toContain('20260728210700');
+  it('is pinned as the applied remote head and absent from pending queues', () => {
+    expect(history.remote_head).toBe('20260728210700');
+    expect(history.remote_versions.at(-1)).toBe('20260728210700');
+    expect(history.forward_pending_versions).not.toContain('20260728210700');
+    expect(history.deployment_sequence).not.toContain('20260728210700');
     expect(history.public_files['20260728210700_open_exposure_ledger.sql'])
       .toBe(migrationHash);
     expect(migration).toContain('DO $least_privilege_roles$');


### PR DESCRIPTION
## Outcome

Reconciles the governed migration ledger to the production journal after the Open Exposure Ledger deployment.

- remote head: `20260728210700`
- 181 remote versions
- 1 private version
- 0 pending versions
- no migration bytes changed

## Verification

- `npm run check:migration-history`
- `npx vitest run tests/migration-history.test.ts` (8/8)
- production `supabase migration list --linked` shows exact local/remote parity
- post-merge live schema-security is green: https://github.com/emiliaprotocol/emilia-protocol/actions/runs/30412339592

## Exception record

PR #416 required an admin exception because the trusted candidate guard correctly refuses any rewrite of a migration already present on `main`; that repair was necessary after the unjournaled original proved incompatible with the managed migration role. No failed security or functional test was bypassed: production was applied and the live schema contract passed before merge. The private operations ledger records the split managed-role apply and exact SHA.
