### PR TITLE
docs(site): reflect reliance risk plane

### DIFF
--- a/app/gate/page.tsx
+++ b/app/gate/page.tsx
@@ -40,6 +40,29 @@ const TIERS = [
   { tier: 'quorum', body: 'm-of-n distinct humans — the cryptographic two-person rule.' },
 ];
 
+const RISK_PLANE = [
+  {
+    title: 'RP policy · loss schedule',
+    body: 'The relying party pins a separately signed loss-allocation schedule to the exact Reliance Program as an admissibility-profile policy input. The schedule never authorizes execution.',
+  },
+  {
+    title: 'Open Exposure Ledger',
+    body: 'Before provider invocation, the durable ledger atomically reserves declared exposure against configured ceilings. INVOKING and INDETERMINATE stay open until independent reconciliation.',
+  },
+  {
+    title: 'Exact-action refusal',
+    body: 'A signed statement binds the technical refusal to the exact action, failed requirements, challenge, nonce, custody, and time. It is not a legal or adverse-benefit denial.',
+  },
+  {
+    title: 'Coverage attestation',
+    body: 'A bounded-period attestation signs the supplied system-of-record and receipt roots, counts, joins, exceptions, and uncertainty. It does not prove that either population is complete.',
+  },
+  {
+    title: 'Receipt census + loss feed',
+    body: 'Governed aggregate receipt buckets use coarse primary suppression. Signed loss-experience records preserve external provenance and correction lineage without becoming adjudicated losses.',
+  },
+];
+
 const DEMO = [
   ['read_status', 'passes through'],
   ['release_payment, no receipt', '428 Receipt Required'],
@@ -197,6 +220,48 @@ export default function GatePage() {
               Gate may require; it cannot reserve resources, call a provider, or establish that an
               action is wise, legal, or safe.
             </p>
+          </div>
+        </section>
+
+        {/* Reliance Risk Plane */}
+        <section id="reliance-risk-plane" style={styles.section}>
+          <div style={styles.container}>
+            <div style={{ ...styles.eyebrow, color: color.gold }}>RELIANCE RISK PLANE · GATE 0.20.0</div>
+            <h2 style={{ ...styles.h2, marginTop: 12, maxWidth: 860 }}>
+              Bound unresolved exposure without turning risk evidence into authorization.
+            </h2>
+            <p style={{ ...styles.lead, maxWidth: 820, marginTop: 18 }}>
+              Gate now carries customer-owned responsibility terms, declared open exposure, exact
+              technical refusals, and bounded loss evidence alongside the existing authorization
+              lifecycle. Each artifact stays a separate evidence leg under the relying party&rsquo;s
+              pinned program and authorities.
+            </p>
+            <div style={{ marginTop: 32, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: 16 }}>
+              {RISK_PLANE.map(({ title, body }) => (
+                <div key={title} style={{ ...styles.card, padding: 24, borderTop: `3px solid ${color.gold}` }}>
+                  <div style={{ ...styles.h3, fontSize: 17 }}>{title}</div>
+                  <p style={{ ...styles.body, fontSize: 14, color: color.t2, marginTop: 10 }}>{body}</p>
+                </div>
+              ))}
+            </div>
+            <p style={{ ...styles.body, maxWidth: 840, marginTop: 24, fontSize: 14, color: color.t2 }}>
+              <strong style={{ color: color.t1 }}>The boundary:</strong> EMILIA does not insure,
+              bear or allocate loss, adjudicate disputes or losses, establish legal enforceability,
+              prove coverage, causation, solvency, or population completeness, or move money.
+            </p>
+            <div style={{ display: 'flex', gap: 16, marginTop: 22, flexWrap: 'wrap' }}>
+              <a href="/proof#reliance-risk-plane" style={{ fontFamily: font.mono, fontSize: 12, color: color.gold }}>
+                Inspect the executable claim &rarr;
+              </a>
+              <a
+                href="https://github.com/emiliaprotocol/emilia-protocol/blob/main/docs/architecture/RELIANCE-RISK-PLANE.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ fontFamily: font.mono, fontSize: 12, color: color.t2 }}
+              >
+                Read the architecture contract &rarr;
+              </a>
+            </div>
           </div>
         </section>
 

--- a/app/insurance/layout.tsx
+++ b/app/insurance/layout.tsx
@@ -1,36 +1,30 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Proof a Human Authorized the Transfer — EMILIA for Insurers',
+  title: 'Reliance Risk Evidence for Insurers — EMILIA Gate',
   description:
-    'Cyber and crime policies require dual authorization and out-of-band '
-    + 'verification of wires and payment changes — but the proof is ad hoc and '
-    + 'deepfakes now defeat the callback. EMILIA turns that control into a '
-    + 'cryptographic, offline-verifiable authorization receipt: a named human '
-    + 'signs the exact action; a two-person rule a cloned voice cannot defeat.',
+    'Gate 0.20 adds customer-owned loss terms, open-exposure custody, exact-action '
+    + 'refusals, bounded population reconciliation, receipt census, and external '
+    + 'loss-feed evidence without making insurance or coverage decisions.',
   alternates: { canonical: '/insurance' },
   openGraph: {
-    title: 'EMILIA for insurers — verifiable proof a human authorized the transfer',
+    title: 'EMILIA Reliance Risk Plane — technical evidence for insurers',
     description:
-      'The dual-authorization control you already require, finally machine-checkable '
-      + 'and deepfake-resistant. An offline-verifiable authorization receipt for '
-      + 'funds-transfer-fraud, social engineering, and agentic-AI risk.',
+      'Re-perform customer-owned responsibility terms, open exposure, technical '
+      + 'refusals, population reconciliation, receipt census, and loss provenance. '
+      + 'EMILIA does not insure, adjudicate, prove coverage, or move money.',
     url: 'https://www.emiliaprotocol.ai/insurance',
     type: 'article',
   },
   keywords: [
-    'proof of authorization for wire transfers',
-    'funds transfer fraud control evidence',
-    'social engineering fraud insurance control',
-    'out-of-band verification proof',
-    'dual authorization receipt',
-    'deepfake wire fraud prevention',
-    'business email compromise control',
-    'agentic AI liability insurance',
-    'AI agent authorization evidence',
-    'cyber insurance coverage condition proof',
-    'verifiable human authorization',
-    'two-person rule cryptographic',
+    'reliance risk evidence',
+    'open exposure ledger',
+    'loss allocation schedule',
+    'exact action refusal statement',
+    'receipt census',
+    'loss experience provenance',
+    'insurance control evidence',
+    'AI agent consequence control',
   ],
 };
 

--- a/app/insurance/page.tsx
+++ b/app/insurance/page.tsx
@@ -1,54 +1,66 @@
 // SPDX-License-Identifier: Apache-2.0
-// EP for insurers - verifiable proof a human authorized the transfer.
-// Funds-transfer-fraud / social-engineering / agentic-AI risk landing page.
+// Shipped reliance-risk evidence for insurers and assurance teams.
 
 import SiteNav from '@/components/SiteNav';
 import SiteFooter from '@/components/SiteFooter';
 import { styles, cta, color, font } from '@/lib/tokens';
 
-const BROKE = [
+const ARTIFACTS = [
   {
-    label: 'Deepfakes defeat the callback',
-    body: 'The out-of-band call-back was the gold-standard proof of authorization. '
-      + 'Now the "known number" can reach a voice-cloned executive (the Arup $25.6M '
-      + 'case). The control you mandate no longer proves a real human authorized anything.',
+    label: 'RP policy',
+    title: 'Loss-allocation schedule',
+    body: 'The relying party pins separately signed responsibility terms to the exact Reliance Program. Verification establishes the signed bytes, issuer, status, and program binding—not legal enforceability, coverage, solvency, or payment.',
   },
   {
-    label: 'AI agents break attribution',
-    body: 'Autonomous agents move money at machine speed. "The AI did it" is foreclosed '
-      + '(California AB 316 pins liability on the deployer) exactly when the deployer can '
-      + 'least prove who authorized the action. Underwriters cannot audit a model the way '
-      + 'they audit a firewall.',
+    label: 'Live control',
+    title: 'Open Exposure Ledger',
+    body: 'Declared exposure is reserved before provider invocation against configured ceilings. INVOKING and INDETERMINATE stay open; only the configured independent reconciliation authority can close them.',
+  },
+  {
+    label: 'Transaction evidence',
+    title: 'Exact-action refusal',
+    body: 'A signed refusal binds the action, program, failed requirements, challenge, nonce, custody, and time. It is technical exact-action evidence—not a legal denial, adverse-benefit denial, or coverage decision.',
+  },
+  {
+    label: 'Period evidence',
+    title: 'Coverage reconciliation',
+    body: 'The attestation signs supplied system-of-record and receipt roots, counts, joins, exclusions, exceptions, and uncertainty for a bounded period. Here “coverage” means declared-population reconciliation, not insurance coverage.',
+  },
+  {
+    label: 'Portfolio evidence',
+    title: 'Receipt census + loss feed',
+    body: 'The census emits governed aggregate buckets with coarse primary suppression. The signed loss feed preserves external provenance and correction lineage; its observations are not verified or adjudicated losses.',
   },
 ];
 
 const PILOT = [
-  ['For the insured',
-    'Run EMILIA in observe mode on one workflow (vendor bank-account changes over a '
-    + 'threshold). Every flagged action emits a receipt your underwriter - or the '
-    + 'insured’s auditor - verifies offline. The attestation becomes provable, '
-    + 'claims-ready evidence.'],
-  ['For the carrier',
-    'Accept EMILIA receipts as proof the dual-authorization / verification control was '
-    + 'followed - a premium credit or coverage condition that is, for the first time, '
-    + 'machine-auditable rather than reconstructed forensically, and that survives the '
-    + 'deepfake failure mode your actuaries are now pricing.'],
+  [
+    'For the protected operator',
+    'Select one fully mediated action, pin the Reliance Program and authorities, define declared exposure ceilings, and test refusals, uncertainty, reconciliation, and bounded-period evidence before production use.',
+  ],
+  [
+    'For the carrier or assurer',
+    'Re-perform the supplied artifacts under independently pinned inputs and decide what, if anything, they support for underwriting, control testing, or claims review. EMILIA supplies technical evidence; the relying party keeps the conclusion.',
+  ],
 ];
 
 const FAQ = [
-  ['How is this different from our existing dual-authorization requirement?',
-    'It is the same control, made provable. Instead of reconstructing whether a callback '
-    + 'happened from recorded calls and emails after a loss, you get a cryptographic '
-    + 'receipt: a named human signed the exact action (amount, payee, account) on their '
-    + 'own device, verifiable offline by anyone.'],
-  ['Why is it deepfake-resistant?',
-    'The approval is a hardware-held signature over the exact action, not a phone '
-    + 'conversation. A cloned voice cannot produce the signature, so EP-QUORUM (the '
-    + 'two-person rule) cannot be defeated the way a callback can.'],
-  ['Is it vendor lock-in?',
-    'No. EMILIA Protocol is an open protocol (Apache-2.0) published as IETF Internet-Drafts, '
-    + 'with reference verifiers in three languages (JS, Python, Go). Carrier and insured can verify '
-    + 'receipts with open-source code, with no account and no trust in EMILIA.'],
+  [
+    'Does EMILIA provide insurance or decide coverage?',
+    'No. EMILIA is technical enforcement and evidence infrastructure. It does not insure, decide policy coverage, allocate or bear loss, establish liability, adjudicate a claim, or move money.',
+  ],
+  [
+    'What does an exact-action refusal prove?',
+    'It proves that the signed technical statement binds the named action, program, failed requirements, challenge, nonce, custody, and time under the pinned verification inputs. It is not a legal denial, an adverse-benefit denial, or proof that a refusal was substantively correct.',
+  ],
+  [
+    'Does the coverage attestation prove the population was complete?',
+    'No. It signs the supplied inventory roots and conserving counts for a bounded period. Completeness needs separate system-of-record evidence. The receipt census also uses only coarse primary suppression, not differential privacy.',
+  ],
+  [
+    'Can a carrier verify the artifacts without an EMILIA callback?',
+    'Yes. The formats, verifier, vectors, and exact executable claim are public. The current stateful risk-plane and signed risk-artifact implementation is JavaScript; no insurer adoption or external deployment is claimed.',
+  ],
 ];
 
 const jsonLd = {
@@ -68,66 +80,71 @@ export default function InsurancePage() {
       <SiteNav activePage="Insurance" />
       <main style={styles.page}>
         <section style={{ ...styles.sectionWide, paddingTop: 80, paddingBottom: 56 }}>
-          <div style={styles.eyebrow}>CYBER · CRIME / FIDELITY · AGENTIC-AI RISK</div>
+          <div style={styles.eyebrow}>RELIANCE RISK PLANE · GATE 0.20.0</div>
           <h1 style={{ ...styles.h1Large, maxWidth: 900 }}>
-            Verifiable proof a human authorized the transfer.
+            Technical evidence for reliance decisions. Not an insurance decision.
           </h1>
           <p style={{ ...styles.body, maxWidth: 780, marginTop: 18, fontSize: 18 }}>
-            Your policies make dual authorization and out-of-band verification of wires and
-            payment-instruction changes conditions precedent to funds-transfer-fraud cover.
-            You deny claims and rescind policies when those controls were not followed - yet
-            the proof today is ad hoc, reconstructed forensically after a loss. There is no
-            machine-checkable artifact that a specific human authorized a specific transfer.
+            Gate 0.20.0 adds a bounded risk plane around the exact authorization lifecycle:
+            customer-owned responsibility terms, declared open-exposure custody, signed technical
+            refusals, period population reconciliation, aggregate receipt census, and externally
+            reported loss experience with correction lineage.
           </p>
           <p style={{ ...styles.body, maxWidth: 760, marginTop: 8 }}>
-            EMILIA turns that control into a cryptographic, offline-verifiable authorization
-            receipt - and a two-person rule a cloned voice cannot defeat.
+            An insurer, auditor, or customer can re-perform those artifacts under independently
+            pinned inputs. EMILIA does not supply the underwriting, legal, coverage, causation,
+            completeness, solvency, adjudication, or payment conclusion.
           </p>
           <div style={{ display: 'flex', gap: 12, marginTop: 30, flexWrap: 'wrap' }}>
-            <a href="/pilot?v=insurance" style={cta.primary}>Scope an observe-mode pilot</a>
-            <a href="/briefs/emilia-insurance-onepager.pdf" style={cta.secondary}>Read the one-pager (PDF)</a>
+            <a href="/proof#reliance-risk-plane" style={cta.primary}>Inspect the shipped proof</a>
+            <a href="/pilot?v=insurance" style={cta.secondary}>Scope one protected workflow</a>
           </div>
         </section>
 
         <section style={styles.sectionWide}>
-          <div style={styles.eyebrow}>TWO THINGS JUST BROKE THE OLD CONTROL</div>
+          <div style={styles.eyebrow}>WHAT SHIPPED</div>
           <h2 style={{ ...styles.h2, maxWidth: 760 }}>
-            The callback you require no longer proves authorization.
+            Five evidence surfaces. None can authorize an action by itself.
           </h2>
-          <div style={{ marginTop: 28, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 16 }}>
-            {BROKE.map((c) => (
-              <div key={c.label} style={{ ...styles.card, padding: 24, borderTop: `3px solid ${color.gold}` }}>
+          <div style={{ marginTop: 28, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: 16 }}>
+            {ARTIFACTS.map((artifact) => (
+              <div key={artifact.title} style={{ ...styles.card, padding: 24, borderTop: `3px solid ${color.gold}` }}>
                 <div style={{ fontFamily: font.mono, fontSize: 12, color: color.gold, letterSpacing: 1.5, textTransform: 'uppercase', fontWeight: 600 }}>
-                  {c.label}
+                  {artifact.label}
                 </div>
-                <div style={{ ...styles.cardBody, marginTop: 12, fontSize: 15, lineHeight: 1.7 }}>{c.body}</div>
+                <div style={{ ...styles.h3, fontSize: 19, marginTop: 10 }}>{artifact.title}</div>
+                <div style={{ ...styles.cardBody, marginTop: 10, fontSize: 14, lineHeight: 1.7 }}>{artifact.body}</div>
               </div>
             ))}
           </div>
         </section>
 
         <section style={styles.sectionWide}>
-          <div style={styles.eyebrow}>WHAT EMILIA PROVIDES</div>
-          <h2 style={{ ...styles.h2, maxWidth: 760 }}>An authorization receipt.</h2>
+          <div style={styles.eyebrow}>THE CONTROL BOUNDARY</div>
+          <h2 style={{ ...styles.h2, maxWidth: 760 }}>Terms, authority, exposure, outcome, and recourse stay separate.</h2>
           <p style={{ ...styles.body, maxWidth: 760 }}>
-            Before a transfer or instruction change executes, a named human approves the
-            exact action - amount, payee, account - on their own device (passkey / Face ID),
-            producing a signed artifact anyone can verify offline, with no account and no
-            trust in the insured&rsquo;s systems. Alter one byte and it fails. EP-QUORUM binds
-            two distinct, device-bound humans to the action - cryptographic dual control that
-            a cloned voice cannot defeat. The portable receipt is the claims-ready artifact you
-            reconstruct by hand today, verifiable years later without the insured&rsquo;s
-            cooperation.
+            The loss schedule records customer-supplied terms. Authorization still comes from the
+            existing exact-action evidence and local policy. The Open Exposure Ledger reserves a
+            declared amount before provider entry and preserves uncertainty without granting a retry.
+            Reconciliation accepts authenticated outcome evidence; it does not decide legal loss or
+            policy coverage.
           </p>
           <p style={{ ...styles.body, maxWidth: 760, marginTop: 8, fontSize: 15, color: color.t2 }}>
-            Try it in 30 seconds, offline, no account:{' '}
-            <span style={{ fontFamily: font.mono, color: color.t1 }}>npx @emilia-protocol/crash-test</span>
+            The reference artifacts are open and reproducible:{' '}
+            <a
+              href="https://github.com/emiliaprotocol/emilia-protocol/blob/main/docs/architecture/RELIANCE-RISK-PLANE.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ fontFamily: font.mono, color: color.gold }}
+            >
+              read the architecture contract
+            </a>.
           </p>
         </section>
 
         <section style={styles.sectionWide}>
           <div style={styles.eyebrow}>THE PILOT</div>
-          <h2 style={{ ...styles.h2, maxWidth: 760 }}>Observe one workflow. Prove the control.</h2>
+          <h2 style={{ ...styles.h2, maxWidth: 760 }}>Start with one exact action and one declared exposure boundary.</h2>
           <div style={{ marginTop: 28, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 16 }}>
             {PILOT.map(([label, body]) => (
               <div key={label} style={{ ...styles.card, padding: 24 }}>
@@ -153,10 +170,11 @@ export default function InsurancePage() {
 
         <section style={styles.section}>
           <p style={{ fontSize: 13, color: color.t3, maxWidth: 760, lineHeight: 1.6 }}>
-            EMILIA proves a named human (or quorum) authorized this exact action before it
-            executed. It does not prove the decision was correct, nor establish real-world
-            identity beyond the enrollment layer. Open protocol (Apache-2.0), IETF
-            Internet-Drafts; no production deployment claim implied.
+            EMILIA does not insure, bear or allocate loss, adjudicate disputes or losses,
+            establish legal enforceability, prove insurance coverage, causation, solvency, or
+            source-population completeness, or move money. Refusal statements are exact technical
+            evidence, not legal or adverse-benefit denials. No external deployment or insurer
+            adoption is claimed.
           </p>
         </section>
       </main>

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -8,11 +8,11 @@ import { cta, color, font, radius } from '@/lib/tokens';
 export const metadata: Metadata = {
   title: 'EMILIA Gate Pricing',
   description:
-    'Use the open EMILIA Protocol for free, diagnose one legacy workflow with Amelia I, carry accepted evaluation evidence into Gate when required, and scope one customer-specific deployment.',
+    'Use the open EMILIA Protocol for free, diagnose one legacy workflow, and scope customer-specific Gate enforcement with optional qualification and reliance-risk controls.',
   alternates: { canonical: '/pricing' },
   openGraph: {
     title: 'EMILIA Gate Pricing',
-    description: 'Open proof infrastructure, a read-only Amelia I diagnostic, an optional qualification entry path, a prospective Gate implementation, and deployment-specific operated controls.',
+    description: 'Open proof infrastructure, a read-only diagnostic, customer-specific Gate implementation, and deployment-scoped enforcement, exposure, reconciliation, and evidence operations.',
     url: 'https://www.emiliaprotocol.ai/pricing',
     type: 'website',
   },
@@ -82,7 +82,7 @@ const TIERS: Array<{
     price: GATE_IMPLEMENTATION.priceLabel,
     priceNote: GATE_IMPLEMENTATION.scopeLabel,
     priceIsLabel: true,
-    tagline: 'Turn the selected risk area into a fail-closed prospective control at the real executor boundary, with current candidate qualification when the workflow requires it.',
+    tagline: 'Turn the selected risk area into a fail-closed prospective control, with optional qualification and reliance-risk policy at the real executor boundary.',
     accent: color.blue,
     cta: { label: 'Design the Gate', href: '/pilot' },
     ctaStyle: 'secondary' as const,
@@ -93,8 +93,9 @@ const TIERS: Array<{
       'Receipt Required challenge and approval acquisition',
       'Exact-action verification and one-time consumption',
       `Optional qualification for ${GATE_QUALIFICATION.scopeLabel}`,
-      'Indeterminate outcome and no-blind-replay handling',
-      'Authenticated reconciliation and remedy workflow',
+      'Customer-owned Reliance Program and separately signed loss-schedule policy',
+      'Open-exposure ceilings, no-blind-replay handling, and independent reconciliation',
+      'Technical-refusal, population-reconciliation, receipt-census, and loss-feed artifacts',
       'Customer acceptance vectors and production runbook',
     ],
   },
@@ -113,7 +114,7 @@ const TIERS: Array<{
       'Everything accepted in the Gate implementation',
       'Private cloud, VPC, or self-hosted deployment options',
       'SAML/OIDC identity and SCIM provisioning integration',
-      'Durable consumption, reconciliation, dispute, and remedy operations',
+      'Durable consumption, open-exposure, reconciliation, dispute, and remedy operations',
       'Evidence retention, export, observability, and SIEM integration',
       'Negotiated support, service level, and deployment warranty',
     ],
@@ -230,6 +231,13 @@ export default function PricingPage(): React.ReactElement {
             <strong style={{ color: color.t1 }}>{GATE_QUALIFICATION.name} is an open entry path, not a pricing or certification tier.</strong>{' '}
             It carries {GATE_QUALIFICATION.outcomeLabel} into a Gate implementation when the protected
             workflow requires evaluated-candidate evidence. {GATE_QUALIFICATION.disclaimer}
+          </p>
+          <p style={{ fontSize: 14, color: color.t2, lineHeight: 1.65, maxWidth: 820, marginTop: 14 }}>
+            <strong style={{ color: color.t1 }}>Reliance Risk Plane scope is also deployment-specific.</strong>{' '}
+            EMILIA can verify customer-supplied loss terms, reserve declared open exposure, and emit
+            bounded risk evidence. EMILIA does not insure, bear or allocate loss, adjudicate disputes
+            or losses, prove coverage, causation, solvency, or population completeness, or move money.{' '}
+            <Link href="/gate#reliance-risk-plane" style={{ color: color.gold }}>See the shipped boundary &rarr;</Link>
           </p>
         </C>
       </section>

--- a/app/proof/page.tsx
+++ b/app/proof/page.tsx
@@ -182,6 +182,7 @@ const PROOF_LAYERS = [
 const LIMITS = [
   'The formal models do not prove that an AI model behaves well or that an approved action is wise, legal, or safe.',
   GATE_QUALIFICATION.disclaimer,
+  'The Reliance Risk Plane does not insure, bear or allocate loss, adjudicate disputes or losses, prove coverage, causation, solvency, or population completeness, or move money.',
   'Selected model/runtime scenarios are same-team conformance evidence under hand-authored mappings. They are not a mechanized proof that every implementation execution refines every formal behavior.',
   'The negative controls pair formal counterexamples with safe-runtime refusals; they do not inject those defects into the runtime implementation.',
   'Deterministic or in-memory scenario adapters are not production-deployment, storage-durability, provider-truth, sensor-truth, or physical-execution evidence.',
@@ -355,6 +356,55 @@ export default async function ProofPage() {
               Inspect the profile source.
             </a>
           </p>
+        </section>
+
+        <section
+          id="reliance-risk-plane"
+          style={{
+            borderTop: `1px solid ${color.border}`,
+            borderBottom: `1px solid ${color.border}`,
+            background: '#1C1917',
+            color: '#FAFAF9',
+          }}
+        >
+          <div style={{ ...styles.sectionWide, paddingTop: 76, paddingBottom: 76 }}>
+            <div style={{ ...styles.eyebrow, color: color.gold }}>SHIPPED CLAIM · GATE 0.20.0</div>
+            <h2 style={{ ...styles.h2, color: '#FAFAF9', fontSize: 'clamp(26px, 3vw, 38px)', maxWidth: 820 }}>
+              The Reliance Risk Plane has an executable claim, not an insurance claim.
+            </h2>
+            <p style={{ fontSize: 16, lineHeight: 1.72, color: 'rgba(250,250,249,0.72)', maxWidth: 820, marginTop: 18 }}>
+              The generated security case traces the loss-schedule verifier, durable exposure
+              custody, exact-action refusal, coverage reconciliation, receipt census, and
+              loss-experience feed to implementation paths, positive and negative vectors, tests,
+              assumptions, exclusions, and evidence hashes.
+            </p>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 240px), 1fr))', gap: 16, marginTop: 32 }}>
+              {[
+                ['Preventive path', 'Declared exposure is reserved before provider invocation, remains open through uncertain outcomes, and closes only through the configured independent reconciliation authority.'],
+                ['Non-authorizing artifacts', 'A loss schedule, refusal statement, coverage attestation, receipt census, or loss feed cannot create authority for an action.'],
+                ['Current implementation scope', 'The stateful risk plane and signed risk artifacts are implemented in JavaScript. No Python or Go implementation, external deployment, insurer adoption, or loss-data network is claimed.'],
+              ].map(([label, detail]) => (
+                <div key={label} style={{ borderTop: `2px solid ${color.gold}`, padding: '18px 4px 0 0' }}>
+                  <h3 style={{ ...styles.h3, fontSize: 17, color: '#FAFAF9', margin: 0 }}>{label}</h3>
+                  <p style={{ fontSize: 14, lineHeight: 1.65, color: 'rgba(250,250,249,0.68)', margin: '9px 0 0' }}>{detail}</p>
+                </div>
+              ))}
+            </div>
+            <p style={{ fontFamily: font.mono, fontSize: 11, lineHeight: 1.65, color: 'rgba(250,250,249,0.58)', maxWidth: 900, margin: '26px 0 0' }}>
+              Coverage reconciliation proves only the supplied roots and conserving counts. Receipt
+              census suppression is not differential privacy. Loss records are externally reported
+              observations, not verified or adjudicated losses. A refusal is exact technical-action
+              evidence, not a legal or adverse-benefit denial.
+            </p>
+            <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', marginTop: 22 }}>
+              <a href={`${SOURCE_BLOB}/security/claims.v1.json`} style={{ fontFamily: font.mono, fontSize: 11, color: color.gold }}>
+                Open the exact claim manifest &rarr;
+              </a>
+              <a href={`${SOURCE_BLOB}/docs/architecture/RELIANCE-RISK-PLANE.md`} style={{ fontFamily: font.mono, fontSize: 11, color: 'rgba(250,250,249,0.72)' }}>
+                Read the bounded architecture &rarr;
+              </a>
+            </div>
+          </div>
         </section>
 
         <section style={{ ...styles.sectionWide, paddingTop: 88, paddingBottom: 80 }}>


### PR DESCRIPTION
## Outcome

Updates the Gate, Proof, Pricing, and Insurance surfaces to describe the shipped Gate 0.20 Reliance Risk Plane.

## Truth boundaries

- loss-allocation schedules are relying-party policy inputs, not EMILIA insurance or adjudication
- open exposure is declared/custodied; it is not proof of legal loss
- refusal statements are technical exact-action evidence, not legal or adverse-benefit denials
- coverage attestations bind supplied populations and explicitly do not prove completeness
- census/loss feeds preserve aggregate/provenance evidence without establishing coverage, causation, solvency, or payment

## Verification

- `npm run typecheck:app`
- focused public-site/proof tests: 37/37
- production Next build
- desktop and 390px mobile inspection of `/gate`, `/proof`, `/pricing`, `/insurance`
- no horizontal overflow or console errors
