### PR TITLE
release(python): reissue verifier as 2.8.2

### DIFF
--- a/packages/python-verify/CHANGELOG.md
+++ b/packages/python-verify/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## Unreleased
 
+## 2.8.2 (2026-07-29)
+
+- Reissues the unreleased 2.8.1 verifier behavior from the exact protected-main
+  commit after its immutable tag was created before the final release merge.
+  No verifier API or acceptance behavior changes from 2.8.1.
+
 ## 2.8.1 (2026-07-29)
 
 - Trust Receipt verification treats pinned `compromised_at` as terminal and

--- a/packages/python-verify/pyproject.toml
+++ b/packages/python-verify/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "emilia-verify"
-version = "2.8.1"
+version = "2.8.2"
 description = "Zero-infrastructure verification of EMILIA Protocol trust receipts (Ed25519 + Merkle). Byte-compatible with @emilia-protocol/verify."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Outcome

Bumps `emilia-verify` to 2.8.2 because the unpublished immutable `python-verify-v2.8.1` tag was created before #424 advanced protected main. The hardened publisher correctly refuses to move or publish that stale tag.

No verifier API or acceptance behavior changes from 2.8.1.

## Verification

- Python verifier: 127/127
- release-chain contract: 26 packages PASS
- `git diff --check`: clean

After merge, release from the exact protected-main commit as `python-verify-v2.8.2`.