### PR TITLE
release: verify 3.18.0

### DIFF
--- a/apps/secure-app/package-lock.json
+++ b/apps/secure-app/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@noble/curves": "1.9.7",
         "@noble/hashes": "1.8.0",
-        "expo": "^56.0.0",
+        "expo": "~56.0.18",
         "expo-asset": "~56.0.21",
         "expo-local-authentication": "~56.0.5",
         "expo-screen-capture": "~56.0.4",
@@ -1272,12 +1272,12 @@
       }
     },
     "node_modules/@expo/inline-modules": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@expo/inline-modules/-/inline-modules-0.0.14.tgz",
-      "integrity": "sha512-jHrqsgpb5QnnwGfxD6NrUAMW9JcS1+j/e8GiLSy+12Md7aRnEWqi347xZ8Q57tkow1iXdeVLXPeyn1VmmCB8fA==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@expo/inline-modules/-/inline-modules-0.0.15.tgz",
+      "integrity": "sha512-EtGaKjzsNF0Jp3Alcn6aKX/QOPEdf1P6i5qTm91mJBmJ4lcWbQkyPrCVNEZHjp989w7c4exd8myA6c0whHcghg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~56.0.13"
+        "@expo/config-plugins": "~56.0.14"
       }
     },
     "node_modules/@expo/json-file": {
@@ -1291,12 +1291,12 @@
       }
     },
     "node_modules/@expo/local-build-cache-provider": {
-      "version": "56.0.10",
-      "resolved": "https://registry.npmjs.org/@expo/local-build-cache-provider/-/local-build-cache-provider-56.0.10.tgz",
-      "integrity": "sha512-ki4bnpcWaZRfOdcN1TYLuN02k+R8UaUJ9rQuSOKlj471ZnDcrAn/muugA8xHiIbZ/hS5HGNIy5z5A/unTPjVUw==",
+      "version": "56.0.11",
+      "resolved": "https://registry.npmjs.org/@expo/local-build-cache-provider/-/local-build-cache-provider-56.0.11.tgz",
+      "integrity": "sha512-2SfYrb5vBs0Ra3bZfpvtJXJbS1oTSwo9DmG4bpZUW/sKUT0+kXHkPI9uGiUa687SIOEQuFBinylD3C9Z2lma3Q==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~56.0.12",
+        "@expo/config": "~56.0.13",
         "chalk": "^4.1.2"
       }
     },
@@ -1381,15 +1381,6 @@
         "@xmldom/xmldom": "^0.8.8",
         "base64-js": "^1.5.1",
         "xmlbuilder": "^15.1.1"
-      }
-    },
-    "node_modules/@expo/plist/node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@expo/prebuild-config": {
@@ -1820,12 +1811,12 @@
       "license": "ISC"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
-        "node": ">=14.6"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -2702,19 +2693,19 @@
       }
     },
     "node_modules/expo": {
-      "version": "56.0.17",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-56.0.17.tgz",
-      "integrity": "sha512-CuknE6i0BOcMPzJezNDLLorHyIdV9dOo6d2FZcTnPIDHrlv0/Xg0XnNUWreQISfde5J3rtYnBgatwnrQI+AsIA==",
+      "version": "56.0.18",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-56.0.18.tgz",
+      "integrity": "sha512-xEYiFlkeOzEKEEJlE6qFYtSo+HOwcIDcwZodRqLQRlhPOHU8bYzutyednlcKbytrS6NMEFpwsBwt5LiN1ZLEjA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "^56.1.21",
+        "@expo/cli": "^56.1.22",
         "@expo/config": "~56.0.13",
         "@expo/config-plugins": "~56.0.14",
         "@expo/devtools": "~56.0.2",
         "@expo/dom-webview": "~56.0.6",
         "@expo/fingerprint": "^0.19.9",
-        "@expo/local-build-cache-provider": "^56.0.10",
+        "@expo/local-build-cache-provider": "^56.0.11",
         "@expo/log-box": "^56.0.14",
         "@expo/metro": "~56.0.0",
         "@expo/metro-config": "~56.0.18",
@@ -2901,9 +2892,9 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {
-      "version": "56.1.21",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-56.1.21.tgz",
-      "integrity": "sha512-5Z8lqBsQsxz0HCkrjxD8ogJZmOqlBbigMqvi6oZkJd/lIS/+VA+/33qfL9ljorJGXpxWMtB3+bdvyPbimsEa9Q==",
+      "version": "56.1.22",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-56.1.22.tgz",
+      "integrity": "sha512-G9IOhKU62TexMJGeZkDmyAYLsvbYT40RvIG7AR4y2ha8OEmhbbHNLNQ0mI0xK4QVf4MXiC0CPHLhMMh/ak8XQA==",
       "license": "MIT",
       "dependencies": {
         "@expo/code-signing-certificates": "^0.0.6",
@@ -2912,7 +2903,7 @@
         "@expo/devcert": "^1.2.1",
         "@expo/env": "~2.3.1",
         "@expo/image-utils": "^0.10.4",
-        "@expo/inline-modules": "^0.0.14",
+        "@expo/inline-modules": "^0.0.15",
         "@expo/json-file": "^10.2.0",
         "@expo/log-box": "^56.0.14",
         "@expo/metro": "~56.0.0",
@@ -3957,6 +3948,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3976,6 +3970,9 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -3997,6 +3994,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4016,6 +4016,9 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -4933,6 +4936,15 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/plist/node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/pngjs": {

--- a/apps/secure-app/package.json
+++ b/apps/secure-app/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@noble/curves": "1.9.7",
     "@noble/hashes": "1.8.0",
-    "expo": "^56.0.0",
+    "expo": "~56.0.18",
     "expo-asset": "~56.0.21",
     "expo-local-authentication": "~56.0.5",
     "expo-screen-capture": "~56.0.4",

--- a/formal/results/formal-runtime-scenario-conformance.v2.json
+++ b/formal/results/formal-runtime-scenario-conformance.v2.json
@@ -467,7 +467,7 @@
     },
     {
       "path": "package-lock.json",
-      "sha256": "8457b7445a7637e832bb82b723936c2c77b2ba3da7a93aa40a4efa1a8bd0008d"
+      "sha256": "6c45cebfd4ee0a764e53cf387e311ae1b0676fc09f736a90ccc6cf68060c1ba5"
     },
     {
       "path": "package.json",

--- a/lib/proof-stats.json
+++ b/lib/proof-stats.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-29T20:03:09.867Z",
+  "generatedAt": "2026-07-29T23:25:08.003Z",
   "tests": {
     "total": 7985,
     "files": 456,
@@ -21,7 +21,7 @@
     "coveredModelActions": 28,
     "actionCompleteModels": 1,
     "formalMutationOperators": 51,
-    "evidenceSha256": "db287b89a75addb9434a0431ca42089eddda299db5ea45c5db29d84450ea129e",
+    "evidenceSha256": "78626eabc9e7bb2cb405909aefff9acd45ac9ba9d12c132b766a05a7ddc9e2ce",
     "boundary": "selected model/runtime scenarios under explicit projection relations; not a mechanized implementation refinement proof"
   },
   "formalEvidenceCoverage": {
@@ -105,7 +105,7 @@
     "status": "passed",
     "claims": 35,
     "evidenceFiles": 252,
-    "evidenceBundleSha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+    "evidenceBundleSha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
   },
   "conformance": {
     "suites": 21,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14622,6 +14622,18 @@
         "ep-assure": "ep-assure.mjs"
       }
     },
+    "packages/gate/node_modules/@emilia-protocol/verify": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@emilia-protocol/verify/-/verify-3.17.1.tgz",
+      "integrity": "sha512-MVZ7O3rC1rVW//zeRiit6isH8kFftSmOJ8iw93HnKqC5HfIDXfuIXu8XLYB1GN+E0mcSHc1ACJmNmAwoPc6zNg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "emilia-verify": "cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "packages/require-receipt": {
       "name": "@emilia-protocol/require-receipt",
       "version": "0.7.0",
@@ -14635,7 +14647,7 @@
     },
     "packages/verify": {
       "name": "@emilia-protocol/verify",
-      "version": "3.17.1",
+      "version": "3.18.0",
       "license": "Apache-2.0",
       "bin": {
         "emilia-verify": "cli.js"

--- a/packages/verify/CHANGELOG.md
+++ b/packages/verify/CHANGELOG.md
@@ -5,6 +5,29 @@ This package follows [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## 3.18.0 (2026-07-29)
+
+### Added
+
+- Independent industrial-effect evidence and effect-predicate evaluation for
+  outcome binding, preserving executor claims, mediator evidence, and
+  independently observed system-of-record evidence as separate inputs.
+- A relying-party-pinned PSEA-02 verifier and AEB adapter with exact CAID
+  matching, current-status checks, explicit source-semantic loss handling,
+  and closed `VERIFIED`, `ACCEPTED`, `SATISFIED`, and `AUTHORIZED` states.
+- PEDIGREE composition vectors that keep native PEDIGREE verification
+  authoritative while testing the separate CAID and AEB decision legs.
+
+### Security
+
+- PSEA and PEDIGREE evidence cannot authorize an action by themselves. AEB
+  still requires the relying party's pinned trust configuration, exact-action
+  match, evidence requirements, current status, and local authorization.
+- Missing or materially lossy source semantics, stale or revoked evidence,
+  indeterminate native status, and effect evidence supplied only by the
+  executor fail closed instead of being upgraded into authority or outcome
+  truth.
+
 ## 3.17.1 (2026-07-29)
 
 ### Security

--- a/packages/verify/package.json
+++ b/packages/verify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emilia-protocol/verify",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "Zero-dependency offline verification for EP authorization receipts: Ed25519 receipts, Merkle anchors, commitment proofs, Class-A WebAuthn device signoffs, multi-party quorum (M-of-N / ordered, two-person rule), portable revocation, trusted-time attestation, provenance chains, long-term evidence records, federated cross-operator receipts (PIP-006), and the opt-in transparency knobs (witness cosignatures, RFC 3161 timestamp proofs, currency evaluation, consumption proofs, initiator-software attestation). Node uses built-in crypto; the /web build runs in any browser, edge, or Deno via Web Crypto. No EP infrastructure required.",
   "license": "Apache-2.0",
   "type": "module",

--- a/security/security-case.json
+++ b/security/security-case.json
@@ -1,7 +1,7 @@
 {
   "@version": "EP-SECURITY-CASE-RESOLVED-v2",
   "source": "security/claims.v1.json",
-  "evidence_bundle_sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790",
+  "evidence_bundle_sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75",
   "claim_count": 35,
   "evidence_file_count": 252,
   "execution": {
@@ -1071,15 +1071,15 @@
     "security-evidence": {
       "kind": "content-addressed-evidence-bundle",
       "filename": "security-case-evidence.v1",
-      "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790",
+      "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75",
       "file_count": 252
     },
     "verify-sdk": {
       "kind": "npm-tarball",
       "package": "@emilia-protocol/verify",
-      "version": "3.17.1",
-      "filename": "emilia-protocol-verify-3.17.1.tgz",
-      "sha256": "4dc941288d953257e4e43890bb92fd9ec675fc68e9cdd1f75ff633c740fd06e3",
+      "version": "3.18.0",
+      "filename": "emilia-protocol-verify-3.18.0.tgz",
+      "sha256": "e10cecbcde39d61379f804eef3397720d66ccb5e3799b0f1fac6b8b771af0314",
       "file_count": 273
     }
   },
@@ -1231,11 +1231,11 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "verify-sdk",
-          "sha256": "4dc941288d953257e4e43890bb92fd9ec675fc68e9cdd1f75ff633c740fd06e3"
+          "sha256": "e10cecbcde39d61379f804eef3397720d66ccb5e3799b0f1fac6b8b771af0314"
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -1494,11 +1494,11 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "verify-sdk",
-          "sha256": "4dc941288d953257e4e43890bb92fd9ec675fc68e9cdd1f75ff633c740fd06e3"
+          "sha256": "e10cecbcde39d61379f804eef3397720d66ccb5e3799b0f1fac6b8b771af0314"
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -1603,11 +1603,11 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "verify-sdk",
-          "sha256": "4dc941288d953257e4e43890bb92fd9ec675fc68e9cdd1f75ff633c740fd06e3"
+          "sha256": "e10cecbcde39d61379f804eef3397720d66ccb5e3799b0f1fac6b8b771af0314"
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -1769,11 +1769,11 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "verify-sdk",
-          "sha256": "4dc941288d953257e4e43890bb92fd9ec675fc68e9cdd1f75ff633c740fd06e3"
+          "sha256": "e10cecbcde39d61379f804eef3397720d66ccb5e3799b0f1fac6b8b771af0314"
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -1893,11 +1893,11 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "verify-sdk",
-          "sha256": "4dc941288d953257e4e43890bb92fd9ec675fc68e9cdd1f75ff633c740fd06e3"
+          "sha256": "e10cecbcde39d61379f804eef3397720d66ccb5e3799b0f1fac6b8b771af0314"
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -2092,7 +2092,7 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -2359,7 +2359,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -2556,11 +2556,11 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "verify-sdk",
-          "sha256": "4dc941288d953257e4e43890bb92fd9ec675fc68e9cdd1f75ff633c740fd06e3"
+          "sha256": "e10cecbcde39d61379f804eef3397720d66ccb5e3799b0f1fac6b8b771af0314"
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -2739,11 +2739,11 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "verify-sdk",
-          "sha256": "4dc941288d953257e4e43890bb92fd9ec675fc68e9cdd1f75ff633c740fd06e3"
+          "sha256": "e10cecbcde39d61379f804eef3397720d66ccb5e3799b0f1fac6b8b771af0314"
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -2959,11 +2959,11 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "verify-sdk",
-          "sha256": "4dc941288d953257e4e43890bb92fd9ec675fc68e9cdd1f75ff633c740fd06e3"
+          "sha256": "e10cecbcde39d61379f804eef3397720d66ccb5e3799b0f1fac6b8b771af0314"
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -3193,11 +3193,11 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "verify-sdk",
-          "sha256": "4dc941288d953257e4e43890bb92fd9ec675fc68e9cdd1f75ff633c740fd06e3"
+          "sha256": "e10cecbcde39d61379f804eef3397720d66ccb5e3799b0f1fac6b8b771af0314"
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -3422,7 +3422,7 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -3527,11 +3527,11 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "verify-sdk",
-          "sha256": "4dc941288d953257e4e43890bb92fd9ec675fc68e9cdd1f75ff633c740fd06e3"
+          "sha256": "e10cecbcde39d61379f804eef3397720d66ccb5e3799b0f1fac6b8b771af0314"
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -3745,7 +3745,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -3887,7 +3887,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -4304,7 +4304,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -4465,7 +4465,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -4712,7 +4712,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -4846,7 +4846,7 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -4965,11 +4965,11 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "verify-sdk",
-          "sha256": "4dc941288d953257e4e43890bb92fd9ec675fc68e9cdd1f75ff633c740fd06e3"
+          "sha256": "e10cecbcde39d61379f804eef3397720d66ccb5e3799b0f1fac6b8b771af0314"
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -5103,7 +5103,7 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -5320,7 +5320,7 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -5530,7 +5530,7 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -5746,7 +5746,7 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -6050,7 +6050,7 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -6258,11 +6258,11 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "verify-sdk",
-          "sha256": "4dc941288d953257e4e43890bb92fd9ec675fc68e9cdd1f75ff633c740fd06e3"
+          "sha256": "e10cecbcde39d61379f804eef3397720d66ccb5e3799b0f1fac6b8b771af0314"
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -6424,11 +6424,11 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "verify-sdk",
-          "sha256": "4dc941288d953257e4e43890bb92fd9ec675fc68e9cdd1f75ff633c740fd06e3"
+          "sha256": "e10cecbcde39d61379f804eef3397720d66ccb5e3799b0f1fac6b8b771af0314"
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -6603,11 +6603,11 @@
         },
         {
           "artifact_id": "verify-sdk",
-          "sha256": "4dc941288d953257e4e43890bb92fd9ec675fc68e9cdd1f75ff633c740fd06e3"
+          "sha256": "e10cecbcde39d61379f804eef3397720d66ccb5e3799b0f1fac6b8b771af0314"
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -6782,7 +6782,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -6928,11 +6928,11 @@
         },
         {
           "artifact_id": "verify-sdk",
-          "sha256": "4dc941288d953257e4e43890bb92fd9ec675fc68e9cdd1f75ff633c740fd06e3"
+          "sha256": "e10cecbcde39d61379f804eef3397720d66ccb5e3799b0f1fac6b8b771af0314"
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -7073,7 +7073,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -7272,7 +7272,7 @@
       "release_artifact_hashes": [
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -7686,7 +7686,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -8067,7 +8067,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     },
@@ -8270,7 +8270,7 @@
         },
         {
           "artifact_id": "security-evidence",
-          "sha256": "6a6e1a8c9766b7541fb613e72f7f5ce7339cc9c48b80224254dc8e7b7fa09790"
+          "sha256": "c194e2b5f6868d887072788902fa620a5d57990bd44f8a28234324b1bb57da75"
         }
       ]
     }
@@ -8610,7 +8610,7 @@
     },
     {
       "path": "formal/results/formal-runtime-scenario-conformance.v2.json",
-      "sha256": "db287b89a75addb9434a0431ca42089eddda299db5ea45c5db29d84450ea129e"
+      "sha256": "78626eabc9e7bb2cb405909aefff9acd45ac9ba9d12c132b766a05a7ddc9e2ce"
     },
     {
       "path": "formal/results/outcome-authority-join.summary.txt",


### PR DESCRIPTION
## What changed

- releases `@emilia-protocol/verify` 3.18.0 from the current merged source
- documents Outcome Binding, PEDIGREE composition, and the PSEA-02 AEB adapter
- keeps Gate on the already-published Verify 3.17.1 until the ordered downstream release

## Validation

- `npm test --prefix packages/verify` — 650 passed
- focused release contracts — 44 passed
- package dry run — `@emilia-protocol/verify@3.18.0`, 273 files
