### PR TITLE
docs: narrow public verification claims

### DIFF
--- a/public/directory-promo/PROMPTS.txt
+++ b/public/directory-promo/PROMPTS.txt
@@ -3,9 +3,9 @@ EMILIA Protocol — MCP Directory promotional screenshots + paired prompts
 01-desktop-verify-receipt.png  (Claude Desktop, live connector output)
 Prompt: "Verify this EMILIA receipt and explain whether the signed action was
 altered."
-Shows: ep_verify_receipt — offline verification of the signed action and anchor,
-without exposing trust-profile or policy-evaluation internals over the public
-MCP connector.
+Shows: ep_verify_receipt — offline verification of the signed action and anchor.
+The no-auth public connector exposes exactly this tool and ep_verify_signoff;
+trust-profile and policy-evaluation APIs require authenticated API access.
 
 02-connector-read-only-tools.png  (claude.ai connector settings)
 Shows: the EMILIA Guard connector installed on claude.ai — verification tools
@@ -21,5 +21,7 @@ altered?" → valid: true; change the amount → valid: false.
 04-signoff-approved-class-a.png  (the artifact ep_verify_signoff verifies)
 Shows: "Signed and approved — key class A": a device-held passkey signed the
 exact action; the receipt now verifies offline, no EP server required.
-Pair with ep_verify_signoff: "Did a named human approve this exact action on
-their own device?" → six checks pass.
+Pair with ep_verify_signoff: "Verify the WebAuthn ceremony and exact-action
+binding in this signoff." → six cryptographic checks pass. The result does not
+by itself establish legal identity, authority, perception, or relying-party
+acceptance.

--- a/public/directory-promo/index.html
+++ b/public/directory-promo/index.html
@@ -28,7 +28,7 @@
   Paired prompts: <a href="/directory-promo/PROMPTS.txt">PROMPTS.txt</a> · Verify a receipt yourself: <a href="/verify">/verify</a></p>
 
   <figure>
-    <img src="/directory-promo/01-desktop-trust-evaluate.png" alt="Claude Desktop verifying an EMILIA receipt without exposing trust profile internals">
+    <img src="/directory-promo/01-desktop-trust-evaluate.png" alt="Claude Desktop verifying an EMILIA receipt with the public read-only connector">
     <figcaption><b>01 — Receipt verification in Claude Desktop.</b>
       <div class="prompt">Prompt: “Verify this EMILIA receipt and explain whether the signed action was altered.”</div>
     </figcaption>
@@ -48,8 +48,8 @@
 
   <figure>
     <img src="/directory-promo/04-signoff-approved-class-a.png" alt="Signed and approved — key class A; receipt verifies offline">
-    <figcaption><b>04 — The artifact ep_verify_signoff verifies.</b> Device-held passkey signed the exact action; verifies offline.
-      <div class="prompt">Pair: “Did a named human approve this exact action on their own device? Verify this signoff.”</div>
+    <figcaption><b>04 — The artifact ep_verify_signoff verifies.</b> A WebAuthn assertion records user presence and verification and is bound to the exact action.
+      <div class="prompt">Pair: “Verify the WebAuthn ceremony and exact-action binding in this signoff.” The result does not by itself establish legal identity, authority, perception, or relying-party acceptance.</div>
     </figcaption>
   </figure>
 </main>

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,7 +4,7 @@ Skills that guide Claude to use the EMILIA Protocol MCP connector well.
 
 | Skill | Description |
 |---|---|
-| [emilia-trust-verification](emilia-trust-verification/SKILL.md) | Verify AI-agent authorization receipts and human device signoffs, and read EMILIA trust profiles. Triggers when a user shares a receipt/signoff and asks whether it is genuine, tampered, or who approved an action. Pairs with the EMILIA MCP connector (https://www.emiliaprotocol.ai/api/mcp/mcp). |
+| [emilia-trust-verification](emilia-trust-verification/SKILL.md) | Verify AI-agent authorization receipts and WebAuthn device signoffs through the two read-only public tools. Rich trust profiles and policy evaluation remain authenticated API surfaces. Pairs with the EMILIA MCP connector (https://www.emiliaprotocol.ai/api/mcp/mcp). |
 
 Each skill is a directory containing a `SKILL.md` with YAML frontmatter
 (`name`, `description`) and instructions. Apache-2.0.

--- a/skills/emilia-trust-verification/SKILL.md
+++ b/skills/emilia-trust-verification/SKILL.md
@@ -1,23 +1,22 @@
 ---
 name: EMILIA Trust Verification
 description: >-
-  Verify the authenticity of AI-agent authorization receipts and human device
-  signoffs, and read EMILIA Protocol trust profiles. Use this whenever a user
+  Verify the authenticity of AI-agent authorization receipts and human-device
+  signoffs. Use this whenever a user
   shares a "trust receipt", an "authorization receipt", a "signoff", or
   WebAuthn/passkey approval evidence and asks whether it is valid, genuine,
-  tampered with, or who approved an action — or asks to evaluate an entity's
-  trustworthiness against a policy. Pairs with the EMILIA Protocol MCP connector
-  (tools prefixed ep_). All verification is pure public-key math; nothing is
-  uploaded and no account is required.
+  or tampered with. Pairs with the public EMILIA Protocol MCP connector (tools
+  prefixed ep_). Verification is read-only public-key math; no account is
+  required.
 license: Apache-2.0
 ---
 
 # EMILIA Trust Verification
 
-EMILIA Protocol makes a high-risk AI-agent action carry a **named human's
-signed "yes"** plus a **receipt anyone can verify offline**. This skill guides
-you to verify those artifacts and read trust data using the EMILIA MCP
-connector. It requires the connector to be enabled (server URL
+EMILIA Protocol makes a high-risk AI-agent action carry a device-key signoff
+plus a **receipt anyone can verify offline**. This skill guides you to verify
+those artifacts using the public EMILIA MCP connector. It requires the
+connector to be enabled (server URL
 `https://www.emiliaprotocol.ai/api/mcp/mcp`, read-only, no auth).
 
 ## When to use this skill
@@ -27,22 +26,17 @@ Engage when the user:
 - Pastes a JSON object with `"@version": "EP-RECEIPT-v1"` (a **trust receipt**),
   or asks "is this receipt real / altered / valid?"
 - Pastes an object with a `context` + `webauthn` block (a **device signoff**),
-  or asks "did a human actually approve this?", "who signed off?", "was this
-  Face ID / passkey approval genuine?"
-- Asks to check an entity's trustworthiness, score, or whether it passes a
-  policy.
+  or asks whether the WebAuthn/passkey ceremony and exact-action binding verify.
 
 If the user mentions a receipt or signoff but hasn't pasted it, ask them for the
 JSON (they can copy a real example from <https://www.emiliaprotocol.ai/verify>).
 
-## The four tools
+## The two public tools
 
 | Tool | Use it to |
 |---|---|
 | `ep_verify_receipt` | Verify an EP-RECEIPT-v1 receipt — Ed25519 signature over canonical JSON + optional Merkle anchor. |
 | `ep_verify_signoff` | Verify a Class-A device signoff — a WebAuthn (ECDSA P-256) assertion bound to the exact action. |
-| `ep_trust_profile` | Read an entity's public trust profile (score, behavioral rates, history). |
-| `ep_trust_evaluate` | Evaluate an entity against a named policy (`standard`, `strict`, `permissive`, `discovery`) → allow / review / deny. |
 
 Each verify tool accepts the JSON object directly; the public key can be passed
 explicitly or, for self-contained evidence packets, is read from an embedded
@@ -70,16 +64,12 @@ explicitly or, for self-contained evidence packets, is read from an embedded
 - `client_data_type` / `rp_id_hash` → a genuine assertion scoped to the right
   relying party.
 
-When a signoff verifies, the meaningful statement is: *a named human approved
-this exact action on their own device — neither a compromised agent nor the
-operator could have produced this signature.* When it fails, name the specific
-check and what it implies.
-
-**Trust evaluate** — surface the `decision` (allow/review/deny), the `reasons`
-/ `failures`, the `confidence`, and the `appeal_path`. A `deny` with reason
-`no_data` means the entity simply has no receipt-backed history yet (not that it
-did something wrong); the `discovery` policy is designed for zero-history
-entities.
+When a signoff verifies, the precise statement is: *the supplied WebAuthn
+assertion verifies under the caller-supplied public key, RP ID, and allowed
+origins; it records user presence and user verification and binds the signed
+challenge to the supplied exact action.* It does **not** by itself establish
+legal identity, authority, what the user perceived, or relying-party acceptance.
+When it fails, name the specific check and what it implies.
 
 ## Demonstrate tamper-evidence
 
@@ -97,6 +87,8 @@ action. Only do this on example data the user provided.
 - These tools are **read-only**. Creating receipts, opening signoffs, or gating
   agent actions happens through EMILIA's authenticated APIs / the EMILIA Guard
   Claude Code plugin — not this connector.
+- Rich trust profiles and policy evaluation are authenticated API surfaces and
+  are deliberately not exposed by this no-auth public connector.
 - The same verifier is open source (Apache-2.0): `npm i @emilia-protocol/verify`
   (Node + browser), with JavaScript, Python, and Go implementations proven
   interoperable. Nothing here requires trusting EMILIA's servers.


### PR DESCRIPTION
Correct the no-auth MCP and skill copy to the two public read-only verification tools. State WebAuthn evidence precisely and stop implying that cryptographic verification alone establishes legal identity, authority, perception, or relying-party acceptance. Documentation-only; no runtime behavior changes.