### PR TITLE
docs: repin preprint conformance manifest

### DIFF
--- a/papers/preprint/main.tex
+++ b/papers/preprint/main.tex
@@ -11,7 +11,7 @@
 % Every quantitative claim is traceable to a repository artifact:
 %   - conformance 21 suites / 331 vectors -> conformance/conformance-manifest.json
 %     (totals.suites=21, totals.vectors=331)
-%     manifest_sha256=76affcc13a26bfaeb837fbe21383538355ffc9875dc872b3077946104d8d7b77
+%     manifest_sha256=d73935ee2dd0aedad7276dd69f8acfe4c3bb1fc0ee8d2fdc16c8934f5310e5b2
 %   - all Tamarin lemma output blocks -> formal/PROOF_STATUS.md (verbatim)
 %   - TLA+ 413,137 states / 45,342 distinct / 26 invariants -> formal/PROOF_STATUS.md
 %   - Alloy 15 + 7 + 6 + 4 = 32 assertions -> formal/PROOF_STATUS.md


### PR DESCRIPTION
Repin the preprint source marker to the current governed conformance manifest introduced by Verify 3.18.1. Verified locally: check:preprint passes; six drift-refusal tests pass.