### PR TITLE
Add Gate attempt-pair fixture for AAE x PSEA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         # app/api/v1/guarded both enforce. Keep it wired in.
         run: node --test packages/verify/test.js packages/verify/*.test.js packages/issue/test.js packages/attest/test.js packages/require-receipt/*.test.js
       - name: Verify AAE x PSEA x Gate attempt pair (node:test)
-        run: node --test interop/aae-psea-gate/verify.test.mjs
+        run: node --test interop/aae-psea-gate/verify.test.mjs interop/aae-psea-gate/reperform.test.mjs
       - name: Verify every remaining package suite (discovered, not listed)
         # The step above still enumerates packages. That is the bug pattern that
         # dropped 8 of 11 verify suites until 2026-07-02 and left eight whole

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
         # missing_receipt_id contract that packages/gate redteam HI-5 and
         # app/api/v1/guarded both enforce. Keep it wired in.
         run: node --test packages/verify/test.js packages/verify/*.test.js packages/issue/test.js packages/attest/test.js packages/require-receipt/*.test.js
+      - name: Verify AAE x PSEA x Gate attempt pair (node:test)
+        run: node --test interop/aae-psea-gate/verify.test.mjs
       - name: Verify every remaining package suite (discovered, not listed)
         # The step above still enumerates packages. That is the bug pattern that
         # dropped 8 of 11 verify suites until 2026-07-02 and left eight whole

--- a/interop/aae-psea-gate/README.md
+++ b/interop/aae-psea-gate/README.md
@@ -35,7 +35,17 @@ The verifier enforces four cross-run constraints:
 
 ```sh
 node --test interop/aae-psea-gate/verify.test.mjs
+node interop/aae-psea-gate/reperform.mjs
 ```
+
+`reperform.mjs` is the independent return package. It fetches every source
+artifact from the immutable upstream commit, verifies the exact byte pins,
+authenticates the Ed25519 AAE JWS under the fixture's pinned trust decision,
+re-performs the applicable AAE Section 5 checks through step 7, checks that the
+action payload is exact RFC 8785 output, compares the recomputed 32 octets to
+the authenticated `action_binding`, and only then joins the result to the Gate
+attempt pair. Its JSON output is checked in as
+`independent-return.v1.json`.
 
 The vector deliberately does **not** establish named-human WHO confirmation,
 PSEA conformance, execution order or a provider effect. Those remain external

--- a/interop/aae-psea-gate/README.md
+++ b/interop/aae-psea-gate/README.md
@@ -1,0 +1,42 @@
+# AAE x PSEA x EMILIA Gate attempt pair
+
+This directory carries EMILIA's side of the seven-field AAE/PSEA cross-run. It
+closes the admission-custody case that cannot be represented as one row: the
+same single-use authority can remain `AUTHORIZED` on a second presentation
+while Gate withholds admission as `NONE / already_consumed`.
+
+The committed vector pins the current AAE proof-exchange fixture at
+`MoltyCel/aae-conformance-vectors` PR 6, commit
+`e8c00e5014c52a4cb4ff51d24c360db5c82d599e`. That upstream fixture still marks
+the WHO axis `PROPOSED`; this directory does not promote it to confirmed and
+does not claim PSEA conformance. The vector also carries the exact upstream JWS
+and action-payload SHA-256 commitments published by that fixture's manifest.
+
+## Attempt pair
+
+1. The first attempt is natively accepted, linked, evidence-satisfied and
+   authorized. Gate consumes admission. Its provider effect remains
+   `INDETERMINATE / provider_outcome_unresolved`.
+2. The second attempt presents the same authority, action, evidence and
+   decision. Gate records a separate attempt with admission
+   `NONE / already_consumed` and outcome `NONE`.
+
+The verifier enforces four cross-run constraints:
+
+- every non-`NONE` outcome must have a same-or-prior admission in
+  `CONSUMED`, `DISPATCH_PENDING` or `INVOKED`;
+- every `INDETERMINATE` outcome must carry a reason;
+- an already-consumed replay preserves the authorization decision but receives
+  no second admission; and
+- the two records preserve their native result, linkage, evidence, decision,
+  reservation and top-level authority/action/evidence commitments.
+
+## Verify
+
+```sh
+node --test interop/aae-psea-gate/verify.test.mjs
+```
+
+The vector deliberately does **not** establish named-human WHO confirmation,
+PSEA conformance, execution order or a provider effect. Those remain external
+facts requiring their own evidence.

--- a/interop/aae-psea-gate/gate-attempt-pair.v1.json
+++ b/interop/aae-psea-gate/gate-attempt-pair.v1.json
@@ -1,0 +1,67 @@
+{
+  "@version": "EMILIA-AAE-PSEA-GATE-ATTEMPT-PAIR-v1",
+  "profile": "aae-psea-seven-field-crosswalk",
+  "source_fixture": {
+    "repository": "https://github.com/MoltyCel/aae-conformance-vectors",
+    "pull_request": 6,
+    "commit": "e8c00e5014c52a4cb4ff51d24c360db5c82d599e",
+    "source_vector_commit": "48450505c05c7182962c166781354e88412581e7",
+    "path": "fixtures/aae-psea-proof-exchange-v1/",
+    "jws_digest": "sha256:c2db119de3f04a775a7c11afd1b78a6d6e03780ad84fc09f76ccb2ccac7c2b9b",
+    "action_payload_digest": "sha256:d6583cbc62c1278311ad311a586da207189693a98143f773a8fc960ae59ac606",
+    "who_axis_status": "PROPOSED"
+  },
+  "exchange_id": "urn:emilia:interop:aae-psea-gate:exchange:001",
+  "authority_id": "urn:emilia:authority:single-use:001",
+  "authority_digest": "sha256:6edf79aa66eaf0b59535addf28914e7e302c25738476b1375b5a1ed6449fa6fc",
+  "action_digest": "sha256:36fb9de709cfd015ab544f9534ff4be369c1f02eef76ed0c31baa2a6b9c00d84",
+  "evidence_digest": "sha256:cb741babcbc387c88177deea80f6735c3dd192e2613a4d806af25f90dbd6072e",
+  "attempts": [
+    {
+      "attempt": 1,
+      "rows": {
+        "aae_native": { "value": "ACCEPT" },
+        "action_linkage": { "value": "EQUIVALENT" },
+        "principal_linkage": { "value": "SAME", "status": "PROPOSED" },
+        "evidence_satisfaction": { "value": "SATISFIED" },
+        "decision": { "value": "AUTHORIZED" },
+        "admission": { "value": "CONSUMED" },
+        "outcome": { "value": "INDETERMINATE", "reason": "provider_outcome_unresolved" }
+      },
+      "gate_custody": {
+        "reservation_id": "urn:emilia:gate:reservation:001",
+        "execution_right": "CONSUMED",
+        "prior_admission": null
+      }
+    },
+    {
+      "attempt": 2,
+      "rows": {
+        "aae_native": { "value": "ACCEPT" },
+        "action_linkage": { "value": "EQUIVALENT" },
+        "principal_linkage": { "value": "SAME", "status": "PROPOSED" },
+        "evidence_satisfaction": { "value": "SATISFIED" },
+        "decision": { "value": "AUTHORIZED" },
+        "admission": { "value": "NONE", "reason": "already_consumed" },
+        "outcome": { "value": "NONE" }
+      },
+      "gate_custody": {
+        "reservation_id": "urn:emilia:gate:reservation:001",
+        "execution_right": "CONSUMED",
+        "prior_admission": "CONSUMED"
+      }
+    }
+  ],
+  "constraints": [
+    "non_none_outcome_requires_qualifying_admission",
+    "indeterminate_outcome_requires_reason",
+    "already_consumed_preserves_authorized_decision",
+    "attempt_pair_preserves_authority_action_and_evidence"
+  ],
+  "nonclaims": {
+    "psea_conformance": "NOT_ESTABLISHED",
+    "who_axis_confirmation": "NOT_ESTABLISHED",
+    "execution_order": "NOT_ESTABLISHED",
+    "provider_effect": "INDETERMINATE"
+  }
+}

--- a/interop/aae-psea-gate/independent-return.v1.json
+++ b/interop/aae-psea-gate/independent-return.v1.json
@@ -1,0 +1,34 @@
+{
+  "@version": "EMILIA-AAE-PSEA-INDEPENDENT-RETURN-v1",
+  "source": {
+    "repository": "https://github.com/MoltyCel/aae-conformance-vectors",
+    "commit": "e8c00e5014c52a4cb4ff51d24c360db5c82d599e",
+    "fixture_path": "fixtures/aae-psea-proof-exchange-v1/",
+    "source_vector_commit": "48450505c05c7182962c166781354e88412581e7",
+    "files": {
+      "fixtures/aae-psea-proof-exchange-v1/aae-envelope.jws": "sha256:c2db119de3f04a775a7c11afd1b78a6d6e03780ad84fc09f76ccb2ccac7c2b9b",
+      "fixtures/aae-psea-proof-exchange-v1/action-payload.json": "sha256:d6583cbc62c1278311ad311a586da207189693a98143f773a8fc960ae59ac606",
+      "fixtures/aae-psea-proof-exchange-v1/issuer-trust.json": "sha256:8ee59a17b9ff4b36dfe9f4dbfd49e12aafbe0443cc8477e243adec87aad4a2a9",
+      "fixtures/aae-psea-proof-exchange-v1/expected.json": "sha256:51e6ac125835573c44f63aeb0a0645f47cb4eef17756b4394c6f5a9c3544bb70",
+      "fixtures/aae-psea-proof-exchange-v1/manifest.json": "sha256:11cd5c6ff281c5253f28248b230d90dbb198a3435bf78d7a7e1a7c8c2fe14af2",
+      "fixtures/aae-psea-proof-exchange-v1/README.md": "sha256:fcf699e7dffa2570c7b7f1868d670bb1e5a75aedaa969a582002092b447149eb",
+      "interop/psea/vectors/xp-1-aligned-principal.json": "sha256:5405eff68026f02e8380d09075b07fbe6104448e2d1ec7c9be7d8c9085cc1d06"
+    }
+  },
+  "verification": {
+    "exact_source_bytes": "VERIFIED",
+    "aae_signature": "VALID",
+    "aae_native": "ACCEPT@7",
+    "action_payload_jcs": "EXACT",
+    "authenticated_action_binding": "MATCH",
+    "action_digest": "sha256:d6583cbc62c1278311ad311a586da207189693a98143f773a8fc960ae59ac606",
+    "gate_attempt_pair": "VALID",
+    "second_admission": "NONE/already_consumed"
+  },
+  "accepted_result": {
+    "action_linkage": "EQUIVALENT",
+    "principal_linkage": "PROPOSED",
+    "psea_conformance": "NOT_ESTABLISHED",
+    "provider_effect": "INDETERMINATE"
+  }
+}

--- a/interop/aae-psea-gate/reperform.mjs
+++ b/interop/aae-psea-gate/reperform.mjs
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  createHash,
+  createPublicKey,
+  verify as verifySignature,
+} from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { verifyGateAttemptPair } from './verify.mjs';
+
+export const SOURCE_REPOSITORY = 'https://github.com/MoltyCel/aae-conformance-vectors';
+export const SOURCE_COMMIT = 'e8c00e5014c52a4cb4ff51d24c360db5c82d599e';
+export const SOURCE_VECTOR_COMMIT = '48450505c05c7182962c166781354e88412581e7';
+export const FIXTURE_PATH = 'fixtures/aae-psea-proof-exchange-v1';
+
+const SOURCE_PINS = Object.freeze({
+  [`${FIXTURE_PATH}/aae-envelope.jws`]:
+    'c2db119de3f04a775a7c11afd1b78a6d6e03780ad84fc09f76ccb2ccac7c2b9b',
+  [`${FIXTURE_PATH}/action-payload.json`]:
+    'd6583cbc62c1278311ad311a586da207189693a98143f773a8fc960ae59ac606',
+  [`${FIXTURE_PATH}/issuer-trust.json`]:
+    '8ee59a17b9ff4b36dfe9f4dbfd49e12aafbe0443cc8477e243adec87aad4a2a9',
+  [`${FIXTURE_PATH}/expected.json`]:
+    '51e6ac125835573c44f63aeb0a0645f47cb4eef17756b4394c6f5a9c3544bb70',
+  [`${FIXTURE_PATH}/manifest.json`]:
+    '11cd5c6ff281c5253f28248b230d90dbb198a3435bf78d7a7e1a7c8c2fe14af2',
+  [`${FIXTURE_PATH}/README.md`]:
+    'fcf699e7dffa2570c7b7f1868d670bb1e5a75aedaa969a582002092b447149eb',
+  'interop/psea/vectors/xp-1-aligned-principal.json':
+    '5405eff68026f02e8380d09075b07fbe6104448e2d1ec7c9be7d8c9085cc1d06',
+});
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function json(bytes, path) {
+  try {
+    return JSON.parse(bytes.toString('utf8'));
+  } catch {
+    fail(`${path} is not valid JSON`);
+  }
+}
+
+function exact(value, expected, path) {
+  if (value !== expected) fail(`${path}: expected ${expected}, got ${value}`);
+}
+
+function validUnicodeScalarString(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return false;
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** RFC 8785 canonicalization for the I-JSON subset used by the exchange. */
+export function canonicalize(value, seen = new WeakSet()) {
+  if (value === null) return 'null';
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'string') {
+    if (!validUnicodeScalarString(value)) fail('invalid Unicode scalar');
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || !Number.isSafeInteger(value)) fail('non-I-JSON number');
+    return JSON.stringify(Object.is(value, -0) ? 0 : value);
+  }
+  if (!value || typeof value !== 'object') fail('non-JSON value');
+  if (seen.has(value)) fail('cyclic JSON');
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return `[${value.map((entry) => canonicalize(entry, seen)).join(',')}]`;
+    }
+    const keys = Object.keys(value).sort();
+    for (const key of keys) {
+      if (!validUnicodeScalarString(key) || value[key] === undefined) {
+        fail('non-I-JSON member');
+      }
+    }
+    return `{${keys
+      .map((key) => `${JSON.stringify(key)}:${canonicalize(value[key], seen)}`)
+      .join(',')}}`;
+  } finally {
+    seen.delete(value);
+  }
+}
+
+function resolveAssertionKey(header, trust) {
+  exact(header.alg, 'EdDSA', 'JWS protected header alg');
+  exact(header.cty, 'aae+json', 'JWS protected header cty');
+  const kid = header.kid;
+  if (typeof kid !== 'string' || !kid.includes('#')) fail('JWS kid is not a DID URL');
+  exact(kid, trust.trust_decision.resolves_kid, 'JWS kid');
+  const signingDid = kid.split('#', 1)[0];
+  if (!trust.trust_decision.trusted_issuers.includes(signingDid)) {
+    fail('JWS signing DID is not in the pinned trust decision');
+  }
+  const document = trust.did_documents.find((item) => item.id === signingDid);
+  if (!document || !document.assertionMethod.includes(kid)) {
+    fail('JWS kid is not authorized for assertionMethod');
+  }
+  const method = document.verificationMethod.find((item) => item.id === kid);
+  const jwk = method?.publicKeyJwk;
+  if (jwk?.kty !== 'OKP' || jwk?.crv !== 'Ed25519') {
+    fail('JWS verification method is not Ed25519');
+  }
+  return { key: createPublicKey({ key: jwk, format: 'jwk' }), signingDid };
+}
+
+function verifyAaeFixture(jwsBytes, trust, sourceVector) {
+  const compact = jwsBytes.toString('ascii');
+  const parts = compact.split('.');
+  if (parts.length !== 3) fail('AAE fixture is not a compact JWS');
+  const [protectedB64u, payloadB64u, signatureB64u] = parts;
+  const header = json(Buffer.from(protectedB64u, 'base64url'), 'JWS protected header');
+  const payload = json(Buffer.from(payloadB64u, 'base64url'), 'JWS payload');
+  const { key, signingDid } = resolveAssertionKey(header, trust);
+  if (!verifySignature(
+    null,
+    Buffer.from(`${protectedB64u}.${payloadB64u}`, 'ascii'),
+    key,
+    Buffer.from(signatureB64u, 'base64url'),
+  )) {
+    fail('AAE Ed25519 signature is invalid');
+  }
+
+  exact(payload.issuer, signingDid, 'AAE issuer/signing authority');
+  const aae = payload.credentialSubject?.aae;
+  if (!aae?.mandate || !aae.constraints || !aae.validity) fail('AAE blocks are incomplete');
+
+  const context = sourceVector.input?.context;
+  if (!context?.subject_binding?.challenge_response_valid) fail('subject binding input is not satisfied');
+  const now = Date.parse(context.current_time);
+  const notBefore = Date.parse(aae.validity.not_before);
+  const notAfter = Date.parse(aae.validity.not_after);
+  if (!(now >= notBefore && now <= notAfter)) fail('AAE is outside the pinned validity window');
+  if (aae.validity.single_use && sourceVector.input?.consumed_ids?.includes(payload.id)) {
+    fail('AAE single-use identifier was already consumed');
+  }
+  if (!aae.mandate.actions.includes(context.requested_action)) {
+    fail('requested action is outside the AAE mandate');
+  }
+  const transaction = aae.constraints.max_transaction_value;
+  if (
+    !transaction
+    || context.action_context.currency !== transaction.currency
+    || context.action_context.amount > transaction.value
+  ) {
+    fail('AAE max_transaction_value constraint is not satisfied');
+  }
+  if (aae.validity.revocation_check || aae.mandate.delegation) {
+    fail('fixture unexpectedly requires conditional AAE steps 8 or 9');
+  }
+  return { header, payload, result: 'ACCEPT', verification_step: 7 };
+}
+
+export function verifyActionBinding(payloadBytes, aaePayload) {
+  const parsed = json(payloadBytes, 'action payload');
+  const canonical = Buffer.from(canonicalize(parsed), 'utf8');
+  if (!canonical.equals(payloadBytes)) fail('action payload bytes are not exact RFC 8785 output');
+  const digestBytes = createHash('sha256').update(payloadBytes).digest();
+  const binding = aaePayload.credentialSubject?.aae?.mandate?.action_binding;
+  if (!binding) fail('authenticated action_binding is missing');
+  exact(binding.alg, 'sha-256', 'action_binding alg');
+  exact(binding.canonicalization, 'JCS (RFC 8785)', 'action_binding canonicalization');
+  exact(binding.payload_digest, `sha-256:${digestBytes.toString('base64url')}`, 'action_binding digest');
+  return { hex: digestBytes.toString('hex'), b64u: digestBytes.toString('base64url') };
+}
+
+export async function fetchPinnedSource(fetchImpl = globalThis.fetch) {
+  if (typeof fetchImpl !== 'function') fail('fetch implementation is unavailable');
+  const files = {};
+  for (const [path, expectedDigest] of Object.entries(SOURCE_PINS)) {
+    const url = `https://raw.githubusercontent.com/MoltyCel/aae-conformance-vectors/${SOURCE_COMMIT}/${path}`;
+    const response = await fetchImpl(url);
+    if (!response.ok) fail(`source fetch failed for ${path}: HTTP ${response.status}`);
+    const bytes = Buffer.from(await response.arrayBuffer());
+    exact(sha256(bytes), expectedDigest, `${path} sha256`);
+    files[path] = bytes;
+  }
+  return files;
+}
+
+export function verifyPinnedSource(files, gateRecord) {
+  for (const [path, expectedDigest] of Object.entries(SOURCE_PINS)) {
+    if (!Buffer.isBuffer(files[path])) fail(`source file is missing: ${path}`);
+    exact(sha256(files[path]), expectedDigest, `${path} sha256`);
+  }
+
+  const manifest = json(files[`${FIXTURE_PATH}/manifest.json`], 'source manifest');
+  const expected = json(files[`${FIXTURE_PATH}/expected.json`], 'source expected result');
+  const trust = json(files[`${FIXTURE_PATH}/issuer-trust.json`], 'issuer trust');
+  const sourceVector = json(
+    files['interop/psea/vectors/xp-1-aligned-principal.json'],
+    'source vector',
+  );
+  exact(manifest.head_commit, SOURCE_VECTOR_COMMIT, 'source manifest head_commit');
+  exact(manifest.source_vector, 'interop/psea/vectors/xp-1-aligned-principal.json', 'source vector path');
+  exact(manifest.jws_sha256, SOURCE_PINS[`${FIXTURE_PATH}/aae-envelope.jws`], 'manifest JWS digest');
+  exact(
+    manifest.action_payload_sha256,
+    SOURCE_PINS[`${FIXTURE_PATH}/action-payload.json`],
+    'manifest action payload digest',
+  );
+
+  const aae = verifyAaeFixture(files[`${FIXTURE_PATH}/aae-envelope.jws`], trust, sourceVector);
+  exact(aae.result, expected.aae_native.result, 'AAE native result');
+  exact(aae.verification_step, expected.aae_native.verification_step, 'AAE verification step');
+  const action = verifyActionBinding(
+    files[`${FIXTURE_PATH}/action-payload.json`],
+    aae.payload,
+  );
+  exact(action.hex, manifest.action_payload_sha256, 'recomputed action digest');
+  exact(
+    action.hex,
+    Buffer.from(sourceVector.input.join_what.secondary_digest.value, 'base64').toString('hex'),
+    'source-vector secondary action digest',
+  );
+
+  exact(gateRecord.source_fixture.commit, SOURCE_COMMIT, 'Gate source commit');
+  exact(
+    gateRecord.source_fixture.jws_digest,
+    `sha256:${manifest.jws_sha256}`,
+    'Gate JWS digest',
+  );
+  exact(
+    gateRecord.source_fixture.action_payload_digest,
+    `sha256:${action.hex}`,
+    'Gate action payload digest',
+  );
+  const gate = verifyGateAttemptPair(gateRecord);
+
+  return {
+    '@version': 'EMILIA-AAE-PSEA-INDEPENDENT-RETURN-v1',
+    source: {
+      repository: SOURCE_REPOSITORY,
+      commit: SOURCE_COMMIT,
+      fixture_path: `${FIXTURE_PATH}/`,
+      source_vector_commit: SOURCE_VECTOR_COMMIT,
+      files: Object.fromEntries(
+        Object.entries(SOURCE_PINS).map(([path, digest]) => [path, `sha256:${digest}`]),
+      ),
+    },
+    verification: {
+      exact_source_bytes: 'VERIFIED',
+      aae_signature: 'VALID',
+      aae_native: `ACCEPT@${aae.verification_step}`,
+      action_payload_jcs: 'EXACT',
+      authenticated_action_binding: 'MATCH',
+      action_digest: `sha256:${action.hex}`,
+      gate_attempt_pair: gate.valid ? 'VALID' : 'INVALID',
+      second_admission: `${gate.second_admission}/${gate.second_reason}`,
+    },
+    accepted_result: {
+      action_linkage: 'EQUIVALENT',
+      principal_linkage: 'PROPOSED',
+      psea_conformance: 'NOT_ESTABLISHED',
+      provider_effect: 'INDETERMINATE',
+    },
+  };
+}
+
+export async function performIndependentReturn(fetchImpl = globalThis.fetch) {
+  const files = await fetchPinnedSource(fetchImpl);
+  const gatePath = fileURLToPath(new URL('./gate-attempt-pair.v1.json', import.meta.url));
+  const gateRecord = JSON.parse(await readFile(gatePath, 'utf8'));
+  return verifyPinnedSource(files, gateRecord);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const result = await performIndependentReturn();
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}

--- a/interop/aae-psea-gate/reperform.test.mjs
+++ b/interop/aae-psea-gate/reperform.test.mjs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { canonicalize, verifyActionBinding, verifyPinnedSource } from './reperform.mjs';
+
+const RETURN_PATH = fileURLToPath(new URL('./independent-return.v1.json', import.meta.url));
+
+test('the checked-in return preserves the bounded accepted result', async () => {
+  const returned = JSON.parse(await readFile(RETURN_PATH, 'utf8'));
+  assert.equal(returned.verification.exact_source_bytes, 'VERIFIED');
+  assert.equal(returned.verification.authenticated_action_binding, 'MATCH');
+  assert.equal(returned.accepted_result.action_linkage, 'EQUIVALENT');
+  assert.equal(returned.accepted_result.principal_linkage, 'PROPOSED');
+  assert.equal(returned.accepted_result.psea_conformance, 'NOT_ESTABLISHED');
+  assert.equal(returned.accepted_result.provider_effect, 'INDETERMINATE');
+});
+
+test('the independent JCS implementation reproduces the pinned payload order', () => {
+  assert.equal(
+    canonicalize({
+      operation: 'transfer',
+      target: 'iban:CH9300762011623852957',
+      amount_minor: 250000,
+      currency: 'CHF',
+      sequence: 1,
+    }),
+    '{"amount_minor":250000,"currency":"CHF","operation":"transfer","sequence":1,"target":"iban:CH9300762011623852957"}',
+  );
+});
+
+test('re-performance refuses when the exact upstream bytes are absent', () => {
+  assert.throws(() => verifyPinnedSource({}, {}), /source file is missing/);
+});
+
+test('C6: a missing authenticated action binding cannot produce WHAT equivalence', () => {
+  const payload = Buffer.from('{"amount_minor":250000}', 'utf8');
+  assert.throws(
+    () => verifyActionBinding(payload, { credentialSubject: { aae: { mandate: {} } } }),
+    /authenticated action_binding is missing/,
+  );
+});
+
+test('C7: a mismatched authenticated action binding cannot produce WHAT equivalence', () => {
+  const payload = Buffer.from('{"amount_minor":250000}', 'utf8');
+  assert.throws(
+    () => verifyActionBinding(payload, {
+      credentialSubject: {
+        aae: {
+          mandate: {
+            action_binding: {
+              alg: 'sha-256',
+              canonicalization: 'JCS (RFC 8785)',
+              payload_digest: 'sha-256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+            },
+          },
+        },
+      },
+    }),
+    /action_binding digest/,
+  );
+});

--- a/interop/aae-psea-gate/verify.mjs
+++ b/interop/aae-psea-gate/verify.mjs
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: Apache-2.0
+
+const SHA256_RE = /^sha256:[0-9a-f]{64}$/;
+const URN_RE = /^urn:[A-Za-z0-9][A-Za-z0-9:._-]+$/;
+
+const VALUES = Object.freeze({
+  aae_native: ['ACCEPT', 'REJECT'],
+  action_linkage: ['EQUIVALENT', 'NOT_EQUIVALENT', 'INDETERMINATE'],
+  principal_linkage: ['SAME', 'DIVERGENT', 'UNRESOLVED'],
+  evidence_satisfaction: ['SATISFIED', 'UNSATISFIED', 'NOT_EVALUATED'],
+  decision: ['AUTHORIZED', 'REFUSED'],
+  admission: ['NONE', 'RESERVED', 'CONSUMED', 'DISPATCH_PENDING', 'INVOKED'],
+  outcome: ['EXECUTED', 'FAILED', 'INDETERMINATE', 'NONE'],
+});
+
+const ROW_NAMES = Object.freeze(Object.keys(VALUES));
+const QUALIFYING_ADMISSIONS = new Set(['CONSUMED', 'DISPATCH_PENDING', 'INVOKED']);
+const REQUIRED_CONSTRAINTS = Object.freeze([
+  'non_none_outcome_requires_qualifying_admission',
+  'indeterminate_outcome_requires_reason',
+  'already_consumed_preserves_authorized_decision',
+  'attempt_pair_preserves_authority_action_and_evidence',
+]);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function object(value, path) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    fail(`${path} must be an object`);
+  }
+  return value;
+}
+
+function exactKeys(value, expected, path) {
+  const actual = Object.keys(object(value, path)).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
+    fail(`${path} fields must be exactly: ${wanted.join(', ')}`);
+  }
+}
+
+function nonEmpty(value, path) {
+  if (typeof value !== 'string' || value.length === 0) fail(`${path} must be a non-empty string`);
+}
+
+function digest(value, path) {
+  if (typeof value !== 'string' || !SHA256_RE.test(value)) {
+    fail(`${path} must be a lowercase sha256 digest`);
+  }
+}
+
+function urn(value, path) {
+  if (typeof value !== 'string' || !URN_RE.test(value)) fail(`${path} must be a URN`);
+}
+
+function validateRow(row, name, path) {
+  const keys = Object.keys(object(row, path)).sort();
+  if (!keys.includes('value') || keys.some((key) => !['value', 'reason', 'status'].includes(key))) {
+    fail(`${path} fields must be value, optional reason, and optional status`);
+  }
+  if (!VALUES[name].includes(row.value)) {
+    fail(`${path}.value must be one of: ${VALUES[name].join(', ')}`);
+  }
+  if ('reason' in row) nonEmpty(row.reason, `${path}.reason`);
+  if ('status' in row) {
+    if (name !== 'principal_linkage' || row.status !== 'PROPOSED') {
+      fail(`${path}.status may only mark principal_linkage PROPOSED`);
+    }
+  }
+}
+
+function validateAttempt(attempt, expectedNumber) {
+  const path = `attempts[${expectedNumber - 1}]`;
+  exactKeys(attempt, ['attempt', 'rows', 'gate_custody'], path);
+  if (attempt.attempt !== expectedNumber) fail(`${path}.attempt must be ${expectedNumber}`);
+  exactKeys(attempt.rows, ROW_NAMES, `${path}.rows`);
+  for (const name of ROW_NAMES) validateRow(attempt.rows[name], name, `${path}.rows.${name}`);
+  exactKeys(
+    attempt.gate_custody,
+    ['reservation_id', 'execution_right', 'prior_admission'],
+    `${path}.gate_custody`,
+  );
+  urn(attempt.gate_custody.reservation_id, `${path}.gate_custody.reservation_id`);
+  if (!['RESERVED', 'RELEASED', 'CONSUMED'].includes(attempt.gate_custody.execution_right)) {
+    fail(`${path}.gate_custody.execution_right is invalid`);
+  }
+  if (
+    attempt.gate_custody.prior_admission !== null &&
+    !QUALIFYING_ADMISSIONS.has(attempt.gate_custody.prior_admission)
+  ) {
+    fail(`${path}.gate_custody.prior_admission must be null or a qualifying admission`);
+  }
+}
+
+function hasQualifyingAdmission(attempts, index) {
+  for (let cursor = 0; cursor <= index; cursor += 1) {
+    if (QUALIFYING_ADMISSIONS.has(attempts[cursor].rows.admission.value)) return true;
+  }
+  return false;
+}
+
+function validateAttemptSemantics(attempts) {
+  for (const [index, attempt] of attempts.entries()) {
+    const outcome = attempt.rows.outcome;
+    if (outcome.value !== 'NONE' && !hasQualifyingAdmission(attempts, index)) {
+      fail(`attempts[${index}]: non-NONE outcome requires a qualifying same-or-prior admission`);
+    }
+    if (outcome.value === 'INDETERMINATE' && !outcome.reason) {
+      fail(`attempts[${index}].rows.outcome: INDETERMINATE requires a reason`);
+    }
+  }
+
+  const [first, second] = attempts;
+  if (first.rows.admission.value !== 'CONSUMED') {
+    fail('attempts[0]: the first presentation must consume admission');
+  }
+  if (second.rows.decision.value !== 'AUTHORIZED') {
+    fail('attempts[1]: already-consumed replay must preserve AUTHORIZED decision');
+  }
+  if (
+    second.rows.admission.value !== 'NONE' ||
+    second.rows.admission.reason !== 'already_consumed'
+  ) {
+    fail('attempts[1]: already-consumed replay must withhold admission as NONE/already_consumed');
+  }
+  if (second.rows.outcome.value !== 'NONE') {
+    fail('attempts[1]: already-consumed replay must have outcome NONE');
+  }
+  if (second.gate_custody.prior_admission !== 'CONSUMED') {
+    fail('attempts[1]: already-consumed replay must reference prior CONSUMED admission');
+  }
+  if (
+    first.gate_custody.reservation_id !== second.gate_custody.reservation_id ||
+    first.rows.aae_native.value !== second.rows.aae_native.value ||
+    first.rows.action_linkage.value !== second.rows.action_linkage.value ||
+    first.rows.principal_linkage.value !== second.rows.principal_linkage.value ||
+    first.rows.evidence_satisfaction.value !== second.rows.evidence_satisfaction.value ||
+    first.rows.decision.value !== second.rows.decision.value
+  ) {
+    fail('attempt pair must preserve reservation, native result, linkage, evidence, and decision');
+  }
+}
+
+export function verifyGateAttemptPair(record) {
+  exactKeys(
+    record,
+    [
+      '@version',
+      'profile',
+      'source_fixture',
+      'exchange_id',
+      'authority_id',
+      'authority_digest',
+      'action_digest',
+      'evidence_digest',
+      'attempts',
+      'constraints',
+      'nonclaims',
+    ],
+    'record',
+  );
+  if (record['@version'] !== 'EMILIA-AAE-PSEA-GATE-ATTEMPT-PAIR-v1') {
+    fail('unexpected attempt-pair version');
+  }
+  if (record.profile !== 'aae-psea-seven-field-crosswalk') fail('unexpected profile');
+  urn(record.exchange_id, 'record.exchange_id');
+  urn(record.authority_id, 'record.authority_id');
+  digest(record.authority_digest, 'record.authority_digest');
+  digest(record.action_digest, 'record.action_digest');
+  digest(record.evidence_digest, 'record.evidence_digest');
+
+  exactKeys(
+    record.source_fixture,
+    [
+      'repository',
+      'pull_request',
+      'commit',
+      'source_vector_commit',
+      'path',
+      'jws_digest',
+      'action_payload_digest',
+      'who_axis_status',
+    ],
+    'record.source_fixture',
+  );
+  if (record.source_fixture.repository !== 'https://github.com/MoltyCel/aae-conformance-vectors') {
+    fail('source fixture repository is not the pinned AAE vector repository');
+  }
+  if (record.source_fixture.pull_request !== 6) fail('source fixture pull request must be 6');
+  if (!/^[0-9a-f]{40}$/.test(record.source_fixture.commit)) {
+    fail('source fixture commit must be a full Git commit');
+  }
+  if (!/^[0-9a-f]{40}$/.test(record.source_fixture.source_vector_commit)) {
+    fail('source vector commit must be a full Git commit');
+  }
+  nonEmpty(record.source_fixture.path, 'record.source_fixture.path');
+  digest(record.source_fixture.jws_digest, 'record.source_fixture.jws_digest');
+  digest(record.source_fixture.action_payload_digest, 'record.source_fixture.action_payload_digest');
+  if (record.source_fixture.who_axis_status !== 'PROPOSED') {
+    fail('WHO axis must remain PROPOSED until issuer confirmation');
+  }
+  for (const [index, attempt] of record.attempts.entries()) {
+    if (attempt?.rows?.principal_linkage?.status !== 'PROPOSED') {
+      fail(`attempts[${index}].rows.principal_linkage must remain marked PROPOSED`);
+    }
+  }
+
+  if (!Array.isArray(record.attempts) || record.attempts.length !== 2) {
+    fail('record.attempts must contain exactly two attempts');
+  }
+  validateAttempt(record.attempts[0], 1);
+  validateAttempt(record.attempts[1], 2);
+  validateAttemptSemantics(record.attempts);
+
+  if (!Array.isArray(record.constraints) || record.constraints.length !== REQUIRED_CONSTRAINTS.length) {
+    fail('record.constraints must contain the four required constraints');
+  }
+  for (const constraint of REQUIRED_CONSTRAINTS) {
+    if (!record.constraints.includes(constraint)) fail(`record.constraints is missing ${constraint}`);
+  }
+
+  exactKeys(
+    record.nonclaims,
+    ['psea_conformance', 'who_axis_confirmation', 'execution_order', 'provider_effect'],
+    'record.nonclaims',
+  );
+  if (record.nonclaims.psea_conformance !== 'NOT_ESTABLISHED') {
+    fail('PSEA conformance must remain NOT_ESTABLISHED');
+  }
+  if (record.nonclaims.who_axis_confirmation !== 'NOT_ESTABLISHED') {
+    fail('WHO confirmation must remain NOT_ESTABLISHED');
+  }
+  if (record.nonclaims.execution_order !== 'NOT_ESTABLISHED') {
+    fail('execution order must remain NOT_ESTABLISHED');
+  }
+  if (record.nonclaims.provider_effect !== 'INDETERMINATE') {
+    fail('provider effect must remain INDETERMINATE');
+  }
+
+  return {
+    valid: true,
+    exchange_id: record.exchange_id,
+    attempts: 2,
+    second_admission: 'NONE',
+    second_reason: 'already_consumed',
+  };
+}

--- a/interop/aae-psea-gate/verify.test.mjs
+++ b/interop/aae-psea-gate/verify.test.mjs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { verifyGateAttemptPair } from './verify.mjs';
+
+const VECTOR_PATH = fileURLToPath(new URL('./gate-attempt-pair.v1.json', import.meta.url));
+const vector = JSON.parse(readFileSync(VECTOR_PATH, 'utf8'));
+const clone = () => structuredClone(vector);
+
+test('the EMILIA Gate attempt pair verifies', () => {
+  assert.deepEqual(verifyGateAttemptPair(vector), {
+    valid: true,
+    exchange_id: 'urn:emilia:interop:aae-psea-gate:exchange:001',
+    attempts: 2,
+    second_admission: 'NONE',
+    second_reason: 'already_consumed',
+  });
+});
+
+test('a non-NONE outcome without a qualifying admission is refused', () => {
+  const mutated = clone();
+  mutated.attempts[0].rows.admission.value = 'RESERVED';
+  assert.throws(
+    () => verifyGateAttemptPair(mutated),
+    /non-NONE outcome requires a qualifying same-or-prior admission/,
+  );
+});
+
+test('an indeterminate outcome without a reason is refused', () => {
+  const mutated = clone();
+  delete mutated.attempts[0].rows.outcome.reason;
+  assert.throws(
+    () => verifyGateAttemptPair(mutated),
+    /INDETERMINATE requires a reason/,
+  );
+});
+
+test('already-consumed replay cannot rewrite the decision as REFUSED', () => {
+  const mutated = clone();
+  mutated.attempts[1].rows.decision.value = 'REFUSED';
+  assert.throws(
+    () => verifyGateAttemptPair(mutated),
+    /already-consumed replay must preserve AUTHORIZED decision/,
+  );
+});
+
+test('already-consumed replay cannot admit the action a second time', () => {
+  const mutated = clone();
+  mutated.attempts[1].rows.admission = { value: 'CONSUMED' };
+  assert.throws(
+    () => verifyGateAttemptPair(mutated),
+    /already-consumed replay must withhold admission as NONE\/already_consumed/,
+  );
+});
+
+test('already-consumed replay must name the prior consumed admission', () => {
+  const mutated = clone();
+  mutated.attempts[1].gate_custody.prior_admission = 'INVOKED';
+  assert.throws(
+    () => verifyGateAttemptPair(mutated),
+    /must reference prior CONSUMED admission/,
+  );
+});
+
+test('the pair cannot change evidence or linkage between attempts', () => {
+  const mutated = clone();
+  mutated.attempts[1].rows.evidence_satisfaction.value = 'UNSATISFIED';
+  assert.throws(
+    () => verifyGateAttemptPair(mutated),
+    /attempt pair must preserve reservation, native result, linkage, evidence, and decision/,
+  );
+});
+
+test('the fixture cannot promote the proposed WHO axis to confirmed', () => {
+  const mutated = clone();
+  mutated.source_fixture.who_axis_status = 'CONFIRMED';
+  assert.throws(
+    () => verifyGateAttemptPair(mutated),
+    /WHO axis must remain PROPOSED/,
+  );
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -106,6 +106,7 @@ export default defineConfig({
       // composition proof uses the same portable runner.
       'conformance/trusted-context-pack.test.ts',
       'interop/apertomemory-emilia/verify.test.mjs',
+      'interop/aae-psea-gate/verify.test.mjs',
       // Generated Node-20 companions of .test.ts sources (e.g. under
       // conformance/): vitest must collect the .ts source only, or every
       // converted test in a companion-glob tree runs twice.


### PR DESCRIPTION
## Summary
- add the EMILIA-side two-attempt Gate fixture for single-use replay
- require qualifying admission before any non-NONE outcome
- require a reason for INDETERMINATE outcomes
- preserve AUTHORIZED while withholding second admission as NONE/already_consumed
- pin the current AAE proof-exchange bytes while keeping WHO PROPOSED and PSEA conformance unclaimed

## Verification
- node --test interop/aae-psea-gate/verify.test.mjs (8/8)
- git diff --check