### PR TITLE
fix(scan): make npx package invocation deterministic

### DIFF
--- a/packages/scan/dist/authority/index.d.ts
+++ b/packages/scan/dist/authority/index.d.ts
@@ -1,5 +1,5 @@
 import type { AuthorityScanResult, DiscoveryOptions } from './types.js';
-export declare const AUTHORITY_SCAN_VERSION = "0.3.0";
+export declare const AUTHORITY_SCAN_VERSION = "0.3.1";
 export declare function runAuthorityScan(options?: DiscoveryOptions): AuthorityScanResult;
 export * from './types.js';
 export { describeSecret, safeValue, describeEnv, redactText, sanitizeForReport, sanitizeArgs, } from './redact.js';

--- a/packages/scan/dist/authority/index.js
+++ b/packages/scan/dist/authority/index.js
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { discoverAuthority } from './discover.js';
 import { detectAuthoritySignals } from './detect.js';
-export const AUTHORITY_SCAN_VERSION = '0.3.0';
+export const AUTHORITY_SCAN_VERSION = '0.3.1';
 export function runAuthorityScan(options = {}) {
     const inventory = discoverAuthority(options);
     const summary = {

--- a/packages/scan/package.json
+++ b/packages/scan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emilia-protocol/scan",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Passive local authority inventory plus fail-closed static classification for MCP and OpenAPI action surfaces.",
   "license": "Apache-2.0",
   "type": "module",
@@ -17,6 +17,7 @@
     }
   },
   "bin": {
+    "scan": "cli.mjs",
     "emilia-scan": "cli.mjs",
     "emilia-harden": "codemod.mjs"
   },

--- a/packages/scan/src/authority/index.ts
+++ b/packages/scan/src/authority/index.ts
@@ -4,7 +4,7 @@ import { discoverAuthority } from './discover.js';
 import { detectAuthoritySignals } from './detect.js';
 import type { AuthorityScanResult, DiscoveryOptions, OperationVisibility } from './types.js';
 
-export const AUTHORITY_SCAN_VERSION = '0.3.0';
+export const AUTHORITY_SCAN_VERSION = '0.3.1';
 
 export function runAuthorityScan(options: DiscoveryOptions = {}): AuthorityScanResult {
   const inventory = discoverAuthority(options);


### PR DESCRIPTION
Adds the unscoped scan binary alias so the documented npx package invocation resolves deterministically, bumps the scanner to 0.3.1, and preserves the existing emilia-scan and emilia-harden binary names.

Verification:
- package tests: 24/24
- TypeScript build: pass
- packed-tarball npx shorthand: pass
- explicit package execution: pass

This fixes the one-line launch defect discovered during post-publication consumer verification of 0.3.0.