### PR TITLE
Draft action authorization status field group for external review

### DIFF
--- a/docs/compliance/AI-INCIDENT-AUTHORIZATION-STATUS-CROSSWALK.md
+++ b/docs/compliance/AI-INCIDENT-AUTHORIZATION-STATUS-CROSSWALK.md
@@ -1,0 +1,128 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# AI incident authorization-status crosswalk
+
+**Source field group:** `ACTION-AUTHORIZATION-STATUS-v1`
+
+**Review date:** July 31, 2026
+
+**Status:** Proposed interoperability map. It is not an endorsement,
+certification, legal opinion, coverage position, or claim that any destination
+framework accepts this field group.
+
+## Why this is an extension, not another incident taxonomy
+
+Existing incident frameworks describe what happened, the system and deployment,
+the harms and losses, affected entities, suspected causes, and supporting
+material. The action-authorization field group adds a narrower forensic view:
+what authorization was required for one action, whether authority and action
+binding were established, what a named boundary did, what effect followed, and
+what evidence supports those statements.
+
+No row below means “equivalent.” It identifies where the added fields could be
+carried or referenced without displacing the destination framework's native
+semantics.
+
+## Underwriting the Agent Economy blueprint
+
+The blueprint's preliminary shared-database list contains nine field groups.
+
+| Blueprint field | Authorization-status relationship |
+| --- | --- |
+| Brief summary | A rendering MAY summarize the five independent status axes; the structured record remains authoritative. |
+| System type | `action.type` and the boundary role supplement, but do not describe, the model or full system. |
+| Deployment | `boundary.id` and `boundary.role` identify the assessed consequence boundary, not the full deployment topology. |
+| Harm type | No mapping. Authorization status does not classify harm. |
+| Estimated losses | No mapping. The field group does not estimate severity or loss. |
+| Entities implicated and impacted | Classifier, boundary, and artifact identifiers can be referenced, but do not determine responsibility or impact. |
+| Root causes identified | Invalid, stale, outside-bound, bypassed, or indeterminate values MAY be forensic observations. They are not causal findings by themselves. |
+| Forensic data | `evidence.artifacts`, verification state, evidence class, source systems, and limitations are the primary extension point. |
+| Metadata | Action reference, action time, evidence time, classification time, classifier, and ruleset digest supplement incident metadata. |
+
+The blueprint says a modular reporting template and matching incident taxonomy
+await future work. This proposed field group should be offered as one optional
+module, not as the general taxonomy itself.
+
+## OECD common reporting framework
+
+The OECD framework contains 29 criteria across incident metadata, harm details,
+AI-system details, and the incident context. The closest extension points are:
+
+| OECD criterion or dimension | Authorization-status relationship |
+| --- | --- |
+| Criterion 3, relationship of the AI system to the incident | The field group records action and boundary facts; it does not decide direct cause, contributing factor, failure to act, misuse, or human error. |
+| Criterion 7, supporting material | Artifact digests and verification states can index supporting material without embedding confidential evidence. |
+| Criteria 8–9, system/product and organizations | Action and boundary identifiers can be linked to the native system and organization records. |
+| Criteria 10–12, severity, harm type, and harm quantification | No mapping. Those remain OECD-native fields. |
+
+The OECD framework is a reporting benchmark. This field group does not make an
+incident report complete and does not determine whether an event is an AI
+incident.
+
+## AI Incident Database
+
+The AI Incident Database supports multiple contributed taxonomies rather than
+one canonical interpretation. The field group could be proposed as an
+additional classification with these boundaries:
+
+- CSET's high-level action/function and assurance-related fields provide system
+  context; they do not establish per-action authorization status.
+- GMF separates known from potential technical failure causes and grounds labels
+  in snippets and discussion. Authorization status should preserve the same
+  distinction through `indeterminate`, artifact verification states, and
+  limitations rather than translating conjecture into `valid`, `invalid`, or
+  `bypassed`.
+- AIID incident and report identifiers should remain native identifiers. An
+  authorization-status record may reference them but must not replace them.
+
+Any submission to AIID remains subject to its maintainers' quality, completeness,
+and governance requirements.
+
+## EU AI Act Article 73
+
+Article 73 requires providers of high-risk AI systems to report serious
+incidents, investigate them, perform a risk assessment, and take corrective
+action within the applicable legal process and deadlines.
+
+Authorization-status records MAY support an investigation by preserving action,
+boundary, evidence, and timing facts. They do not:
+
+- establish that an event is a “serious incident”;
+- establish a causal relationship or reasonable likelihood of one;
+- start, stop, or satisfy a reporting deadline;
+- replace the Commission's reporting template; or
+- demonstrate legal compliance.
+
+The Commission has sought alignment between its reporting work and the OECD AI
+Incidents Monitor and common reporting framework. That makes a narrow crosswalk
+preferable to an incompatible replacement format.
+
+## Zhu's agentic-AI insurance model
+
+Zhu defines `h_i(u)` as a human-approval indicator for an action and `beta_i` as
+an aggregate operational-authority variable. `ACTION-AUTHORIZATION-STATUS-v1`
+does not replace or validate that model.
+
+The record can supply more granular observations about one action:
+
+- whether authorization was exact, bounded, standing, absent, or unknown;
+- whether authority was valid, invalid, revoked, stale, or indeterminate;
+- whether evidence matched the action;
+- whether a named boundary admitted, refused, or was bypassed; and
+- whether the effect executed, failed, remained indeterminate, or is unknown.
+
+An actuary MAY derive model inputs from a governed population of these records,
+but the derivation, weighting, predictive validity, and pricing use remain the
+actuary's responsibility. Evidence classes are ordinal labels, not numeric risk
+weights.
+
+## Claim boundary
+
+This crosswalk does not claim novelty over incident reporting, human-approval
+indicators, operational-authority ratios, or insurance telemetry. It does not
+claim adoption by the blueprint authors, OECD, AIID, the European Commission,
+AIUC, ACORD, LMA, NIST, any carrier, or any reinsurer.
+
+The proposed contribution is narrower: a closed and testable way to preserve
+action-level authorization facts and their evidence limitations across systems
+that otherwise use different incident and claims formats.

--- a/public/schemas/action-authorization-status.v1.schema.json
+++ b/public/schemas/action-authorization-status.v1.schema.json
@@ -1,0 +1,330 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.emiliaprotocol.ai/schemas/action-authorization-status.v1.schema.json",
+  "title": "Action Authorization Status and Evidence Field Group v1",
+  "description": "A closed, implementation-neutral classification of an action's authorization requirement, authority state, binding, admission, effect, and supporting evidence. It does not decide causation, liability, coverage, or population completeness.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "@version",
+    "action",
+    "boundary",
+    "classification",
+    "evidence",
+    "classified_at",
+    "classifier"
+  ],
+  "properties": {
+    "@version": { "const": "ACTION-AUTHORIZATION-STATUS-v1" },
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reference", "type", "occurred_at"],
+      "properties": {
+        "reference": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["scheme", "value"],
+          "properties": {
+            "scheme": { "$ref": "#/$defs/identifier" },
+            "value": { "type": "string", "minLength": 1, "maxLength": 2048 }
+          }
+        },
+        "type": { "$ref": "#/$defs/identifier" },
+        "occurred_at": { "$ref": "#/$defs/timestamp" }
+      }
+    },
+    "boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "role"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "role": {
+          "enum": [
+            "credential_broker",
+            "resource_server",
+            "provider_gateway",
+            "execution_service",
+            "other"
+          ]
+        }
+      }
+    },
+    "classification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requirement", "authority", "binding", "admission", "effect"],
+      "properties": {
+        "requirement": {
+          "enum": ["exact_action", "bounded_program", "standing_scope", "none", "unknown"]
+        },
+        "authority": {
+          "enum": ["valid", "invalid", "revoked", "stale", "indeterminate", "not_evaluated"]
+        },
+        "binding": {
+          "enum": ["exact_action", "within_bound", "outside_bound", "none", "indeterminate", "not_evaluated"]
+        },
+        "admission": {
+          "enum": ["admitted", "refused", "bypassed", "indeterminate", "not_observed"]
+        },
+        "effect": {
+          "enum": ["executed", "failed", "not_executed", "indeterminate", "unknown"]
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["class", "as_of", "population_basis", "source_systems", "verification_profile", "artifacts", "limitations"],
+      "properties": {
+        "class": {
+          "enum": [
+            "E0_NONE",
+            "E1_SELF_ASSERTED",
+            "E2_OPERATOR_RECORDED",
+            "E3_ACTION_BOUND_SIGNED",
+            "E4_OFFLINE_PINNED_VERIFIABLE",
+            "E5_RECONCILED_NAMED_POPULATION"
+          ]
+        },
+        "as_of": { "$ref": "#/$defs/timestamp" },
+        "population_basis": {
+          "enum": ["single_action", "declared_population", "reconciled_named_systems", "independent_observation"]
+        },
+        "source_systems": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/identifier" }
+        },
+        "verification_profile": {
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/verification_profile" }
+          ]
+        },
+        "artifacts": {
+          "type": "array",
+          "maxItems": 64,
+          "items": { "$ref": "#/$defs/artifact" }
+        },
+        "limitations": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": { "type": "string", "minLength": 1, "maxLength": 2048 }
+        }
+      }
+    },
+    "classified_at": { "$ref": "#/$defs/timestamp" },
+    "classifier": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "method", "ruleset_digest"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "method": { "enum": ["manual", "ruleset", "mixed"] },
+        "ruleset_digest": { "$ref": "#/$defs/digest" }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "classification": {
+            "type": "object",
+            "properties": { "requirement": { "const": "none" } },
+            "required": ["requirement"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "classification": {
+            "type": "object",
+            "properties": {
+              "authority": { "const": "not_evaluated" },
+              "binding": { "const": "not_evaluated" }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "classification": {
+            "type": "object",
+            "properties": { "requirement": { "const": "unknown" } },
+            "required": ["requirement"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "classification": {
+            "type": "object",
+            "properties": {
+              "authority": { "const": "indeterminate" },
+              "binding": { "const": "indeterminate" }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "evidence": {
+            "type": "object",
+            "properties": { "class": { "const": "E0_NONE" } },
+            "required": ["class"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence": {
+            "type": "object",
+            "properties": { "artifacts": { "type": "array", "maxItems": 0 } }
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "evidence": {
+            "type": "object",
+            "properties": { "artifacts": { "type": "array", "minItems": 1 } }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "evidence": {
+            "type": "object",
+            "properties": {
+              "class": {
+                "enum": [
+                  "E3_ACTION_BOUND_SIGNED",
+                  "E4_OFFLINE_PINNED_VERIFIABLE",
+                  "E5_RECONCILED_NAMED_POPULATION"
+                ]
+              }
+            },
+            "required": ["class"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence": {
+            "type": "object",
+            "properties": {
+              "artifacts": {
+                "type": "array",
+                "contains": {
+                  "type": "object",
+                  "properties": { "verification": { "const": "verified" } },
+                  "required": ["verification"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "evidence": {
+            "type": "object",
+            "properties": {
+              "class": {
+                "enum": ["E4_OFFLINE_PINNED_VERIFIABLE", "E5_RECONCILED_NAMED_POPULATION"]
+              }
+            },
+            "required": ["class"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence": {
+            "type": "object",
+            "properties": {
+              "verification_profile": { "$ref": "#/$defs/verification_profile" },
+              "artifacts": {
+                "type": "array",
+                "not": {
+                  "contains": {
+                    "type": "object",
+                    "properties": { "verification": { "const": "failed" } },
+                    "required": ["verification"]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "evidence": {
+            "type": "object",
+            "properties": { "class": { "const": "E5_RECONCILED_NAMED_POPULATION" } },
+            "required": ["class"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "evidence": {
+            "type": "object",
+            "properties": {
+              "population_basis": { "const": "reconciled_named_systems" },
+              "source_systems": { "type": "array", "minItems": 1 }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9:_.@/+\\-]{0,511}$"
+    },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,9})?Z$"
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "digest", "verification"],
+      "properties": {
+        "type": { "$ref": "#/$defs/identifier" },
+        "digest": { "$ref": "#/$defs/digest" },
+        "verification": { "enum": ["verified", "failed", "not_checked", "indeterminate"] }
+      }
+    },
+    "verification_profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "digest"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "digest": { "$ref": "#/$defs/digest" }
+      }
+    }
+  }
+}

--- a/standards/rubric/ACTION-AUTHORIZATION-STATUS-v1.md
+++ b/standards/rubric/ACTION-AUTHORIZATION-STATUS-v1.md
@@ -1,0 +1,238 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Action Authorization Status and Evidence Field Group v1
+
+**Identifier:** `ACTION-AUTHORIZATION-STATUS-v1`
+
+**Status:** Proposed implementation-neutral field group. This is not an IETF
+Internet-Draft, insurance standard, rating rule, coverage determination, or
+claim of adoption.
+
+## 1. Purpose
+
+AI incident and claims records commonly describe the system, deployment, harm,
+loss, entities, suspected causes, forensic material, and incident metadata.
+Those fields do not answer a narrower question:
+
+> For this action, at this named consequence boundary, what authorization was
+> required, what authority and action binding existed, what did the boundary
+> do, what effect followed, and what evidence supports the classification?
+
+This field group answers that question without replacing a broader incident or
+loss taxonomy. It is designed to be embedded in, or cross-referenced by,
+existing reporting formats.
+
+The unit is one action at one named boundary. A system-wide label such as
+“human supervised” is not a substitute.
+
+## 2. Claims this field group does not make
+
+A conforming record does not establish:
+
+- that an AI system caused a loss;
+- that a person or organization is at fault;
+- that an action or loss is covered under an insurance contract;
+- that every consequential action entered the reported boundary;
+- that the named source systems constitute the complete population; or
+- that a verified artifact was adequate under a relying party's policy.
+
+The record classifies available evidence. It does not turn that evidence into
+authorization, liability, or coverage.
+
+## 3. Five independent status axes
+
+The axes MUST remain separate. A producer MUST NOT infer one from another.
+
+### 3.1 Authorization requirement
+
+| Code | Meaning |
+| --- | --- |
+| `exact_action` | The policy required authorization bound to this exact material action. |
+| `bounded_program` | The policy allowed an action reachable within a bounded, authorized program. |
+| `standing_scope` | The policy relied on a standing scope or role rather than action-specific approval. |
+| `none` | The established policy imposed no authorization requirement for the action. |
+| `unknown` | The applicable requirement could not be established. |
+
+### 3.2 Authority state
+
+| Code | Meaning |
+| --- | --- |
+| `valid` | The presented authority was current and valid under the evaluated rules. |
+| `invalid` | The presented authority failed those rules. |
+| `revoked` | The authority was revoked at the relevant evaluation time. |
+| `stale` | Freshness requirements were not met. |
+| `indeterminate` | Available evidence could not establish the state. |
+| `not_evaluated` | No authority evaluation applied or occurred. |
+
+### 3.3 Action binding
+
+| Code | Meaning |
+| --- | --- |
+| `exact_action` | Evidence bound the exact material action. |
+| `within_bound` | The action was within a stated program or standing bound. |
+| `outside_bound` | The action fell outside the evidence's bound. |
+| `none` | The evidence contained no action binding. |
+| `indeterminate` | The binding relation could not be established. |
+| `not_evaluated` | No binding evaluation applied or occurred. |
+
+### 3.4 Admission state at the named boundary
+
+| Code | Meaning |
+| --- | --- |
+| `admitted` | The boundary admitted the action. |
+| `refused` | The boundary refused the action. |
+| `bypassed` | The action reached an effect path without traversing the named required boundary. |
+| `indeterminate` | Available evidence cannot establish the boundary decision. |
+| `not_observed` | No boundary observation is available. |
+
+### 3.5 Observed effect
+
+| Code | Meaning |
+| --- | --- |
+| `executed` | The material effect was observed as executed. |
+| `failed` | An attempted effect failed. |
+| `not_executed` | Evidence establishes that the effect did not execute. |
+| `indeterminate` | Entry occurred or may have occurred, but the outcome is unresolved. |
+| `unknown` | No reliable effect determination is available. |
+
+Combinations that look contradictory are often the incident. A record MAY say
+`refused` and `executed` when one boundary refused but the effect was observed
+through another or unmediated path. It MAY say `admitted` with `invalid`
+authority when a boundary made an erroneous decision. Consumers MUST preserve
+those combinations rather than “correcting” them.
+
+## 4. Evidence classes
+
+The evidence class describes support for the classification, not the quality of
+the underlying authorization policy.
+
+| Class | Meaning |
+| --- | --- |
+| `E0_NONE` | No supporting artifact is available. |
+| `E1_SELF_ASSERTED` | A party states the classification without an operator record sufficient to recheck it. |
+| `E2_OPERATOR_RECORDED` | An operator-controlled record supports the classification. |
+| `E3_ACTION_BOUND_SIGNED` | At least one successfully verified signed artifact binds one or more classification claims to the action. |
+| `E4_OFFLINE_PINNED_VERIFIABLE` | A verifier can recheck at least one verified artifact offline using the explicitly identified and digest-pinned verification profile. This does not imply an independently operated issuer. |
+| `E5_RECONCILED_NAMED_POPULATION` | Action records were reconciled against explicitly named systems for a stated population. This does not prove that unnamed or bypass paths did not exist. |
+
+Most historical incidents will begin at `E0`, `E1`, or `E2`. A deployment MUST
+NOT be assigned `E3` merely because an unchecked signature exists, MUST NOT be
+assigned `E4` without binding the verification profile used, and MUST NOT be
+assigned `E5` without naming the reconciled systems.
+
+Every record MUST include a non-empty `limitations` array. An evidence class is
+not a universal confidence score and MUST NOT be averaged as if the distance
+between adjacent classes were numeric.
+
+## 5. Record shape
+
+The normative machine-readable shape is defined by:
+
+- [`public/schemas/action-authorization-status.v1.schema.json`](../../public/schemas/action-authorization-status.v1.schema.json)
+- [`standards/staged/action-authorization-status.v1.vectors.json`](../staged/action-authorization-status.v1.vectors.json)
+- [`standards/staged/action-authorization-status.reference.ts`](../staged/action-authorization-status.reference.ts)
+- [`standards/staged/action-authorization-status.selftest.ts`](../staged/action-authorization-status.selftest.ts)
+
+The vectors are staged outside the governed live conformance manifest until an
+external implementation runs them and the clean-room bundle is re-frozen. A
+same-team implementation is not counted as independent interoperability.
+
+The top-level members are closed:
+
+```json
+{
+  "@version": "ACTION-AUTHORIZATION-STATUS-v1",
+  "action": {
+    "reference": { "scheme": "caid", "value": "caid:1:example:release-payment" },
+    "type": "payment.release",
+    "occurred_at": "2026-07-30T18:00:00Z"
+  },
+  "boundary": { "id": "gate:production", "role": "provider_gateway" },
+  "classification": {
+    "requirement": "exact_action",
+    "authority": "valid",
+    "binding": "exact_action",
+    "admission": "admitted",
+    "effect": "executed"
+  },
+  "evidence": {
+    "class": "E4_OFFLINE_PINNED_VERIFIABLE",
+    "as_of": "2026-07-30T18:05:00Z",
+    "population_basis": "single_action",
+    "source_systems": ["gate:production"],
+    "verification_profile": {
+      "id": "ep-verify:3.14.0",
+      "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    },
+    "artifacts": [{
+      "type": "authorization-receipt",
+      "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "verification": "verified"
+    }],
+    "limitations": [
+      "This classification does not establish causation, legal liability, coverage, or population completeness."
+    ]
+  },
+  "classified_at": "2026-07-30T18:06:00Z",
+  "classifier": {
+    "id": "adjuster:example",
+    "method": "mixed",
+    "ruleset_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  }
+}
+```
+
+The action reference is scheme-neutral. CAID is one available scheme; use of
+this field group does not require adoption of CAID or any EMILIA receipt.
+
+## 6. Population and ratio discipline
+
+This field group can support period summaries only after the denominator is
+defined. A summary MUST state:
+
+1. the period;
+2. the action classes in scope;
+3. every named source system used to construct the population;
+4. unknown, unclassified, and unmatched records;
+5. the population basis and evidence class; and
+6. known routes that could bypass collection.
+
+A ratio such as “fraction of consequential actions admitted with exact-action
+authorization” MUST NOT be called a coverage rate unless the numerator and
+denominator share the same named population and unknowns remain visible.
+Reconciliation against named systems is not proof that no unnamed system or
+credential path existed.
+
+## 7. Prior art and contribution boundary
+
+The idea that human approval and operational authority affect agent risk is not
+new. Quanyan Zhu's July 2026 paper defines a per-action human-approval indicator
+and an aggregate operational-authority variable for agentic-AI insurance.
+
+This field group's narrower contribution is engineering semantics for an
+incident or claims record: five non-collapsing action-level axes, a named
+admission boundary, evidence classes, closed validation, explicit unknowns, and
+population limitations. It does not claim a new actuarial model.
+
+The July 2026 *Underwriting the Agent Economy* blueprint proposes a shared AI
+incident database with nine preliminary field groups and says a modular
+reporting template and matching taxonomy await future work. This document is a
+proposed authorization-status extension, not a competing general taxonomy.
+
+## 8. Versioning and governance
+
+Version 1 is closed. Unknown members are invalid rather than silently ignored.
+New codes require a version change, definitions, at least one positive vector,
+at least one confusion or laundering vector, and a published explanation of
+the evidence and population consequences.
+
+Suggested corrections and external mappings should be proposed against the
+rubric and vectors, not against a vendor implementation.
+
+## 9. References
+
+- *Underwriting the Agent Economy: The Blueprint for an AI Insurance Stack*, July 2026: <https://arxiv.org/abs/2607.11999>
+- Quanyan Zhu, *AI-Native Insurance for Agentic AI: Pricing, Underwriting, and End-to-End Automation*, July 2026: <https://arxiv.org/abs/2607.13230>
+- OECD, *Towards a Common Reporting Framework for AI Incidents*, February 2025: <https://doi.org/10.1787/f326d4ac-en>
+- AI Incident Database taxonomies: <https://incidentdatabase.ai/taxonomies/>
+- EU AI Act, Article 73: <https://ai-act-service-desk.ec.europa.eu/en/ai-act/article-73>

--- a/standards/staged/action-authorization-status.reference.ts
+++ b/standards/staged/action-authorization-status.reference.ts
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Implementation-neutral action-authorization status coding for incident,
+ * claims, and underwriting records. This module validates a classification;
+ * it does not decide authorization, causation, liability, or coverage.
+ */
+
+import crypto from 'node:crypto';
+
+export const ACTION_AUTHORIZATION_STATUS_VERSION = 'ACTION-AUTHORIZATION-STATUS-v1' as const;
+
+export const AUTHORIZATION_REQUIREMENTS = [
+  'exact_action',
+  'bounded_program',
+  'standing_scope',
+  'none',
+  'unknown',
+] as const;
+
+export const AUTHORITY_STATES = [
+  'valid',
+  'invalid',
+  'revoked',
+  'stale',
+  'indeterminate',
+  'not_evaluated',
+] as const;
+
+export const ACTION_BINDINGS = [
+  'exact_action',
+  'within_bound',
+  'outside_bound',
+  'none',
+  'indeterminate',
+  'not_evaluated',
+] as const;
+
+export const ADMISSION_STATES = [
+  'admitted',
+  'refused',
+  'bypassed',
+  'indeterminate',
+  'not_observed',
+] as const;
+
+export const EFFECT_STATES = [
+  'executed',
+  'failed',
+  'not_executed',
+  'indeterminate',
+  'unknown',
+] as const;
+
+export const AUTHORIZATION_EVIDENCE_CLASSES = [
+  'E0_NONE',
+  'E1_SELF_ASSERTED',
+  'E2_OPERATOR_RECORDED',
+  'E3_ACTION_BOUND_SIGNED',
+  'E4_OFFLINE_PINNED_VERIFIABLE',
+  'E5_RECONCILED_NAMED_POPULATION',
+] as const;
+
+export const BOUNDARY_ROLES = [
+  'credential_broker',
+  'resource_server',
+  'provider_gateway',
+  'execution_service',
+  'other',
+] as const;
+
+export const POPULATION_BASES = [
+  'single_action',
+  'declared_population',
+  'reconciled_named_systems',
+  'independent_observation',
+] as const;
+
+export const ARTIFACT_VERIFICATION_STATES = [
+  'verified',
+  'failed',
+  'not_checked',
+  'indeterminate',
+] as const;
+
+export interface ActionAuthorizationStatusValidation {
+  valid: boolean;
+  errors: string[];
+  digest?: string;
+}
+
+const MAX_CANONICAL_DEPTH = 64;
+
+function hasUnpairedUtf16Surrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return true;
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function canonicalDomainError(path: string, reason: string): TypeError {
+  return new TypeError(`value is outside the strict canonical JSON domain at ${path}: ${reason}`);
+}
+
+function canonicalizeValue(value: unknown, path: string, ancestors: Set<object>, depth: number): string {
+  if (depth > MAX_CANONICAL_DEPTH) throw canonicalDomainError(path, 'nesting depth exceeded');
+  if (value === null) return 'null';
+  if (typeof value === 'string') {
+    if (hasUnpairedUtf16Surrogate(value)) throw canonicalDomainError(path, 'unpaired Unicode surrogate');
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value)) throw canonicalDomainError(path, 'numbers must be safe integers');
+    return JSON.stringify(value);
+  }
+  if (typeof value !== 'object') throw canonicalDomainError(path, `${typeof value} is not a JSON value`);
+
+  const object = value as object;
+  if (ancestors.has(object)) throw canonicalDomainError(path, 'cyclic reference');
+  ancestors.add(object);
+  try {
+    if (Array.isArray(value)) {
+      const ownKeys = Reflect.ownKeys(value);
+      const expectedKeys = new Set(['length', ...Array.from({ length: value.length }, (_, index) => String(index))]);
+      if (ownKeys.some((key) => typeof key !== 'string')
+          || ownKeys.length !== expectedKeys.size
+          || ownKeys.some((key) => !expectedKeys.has(key as string))) {
+        throw canonicalDomainError(path, 'sparse arrays and extra members are not permitted');
+      }
+      const entries: string[] = [];
+      for (let index = 0; index < value.length; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+        if (!descriptor || !('value' in descriptor)) {
+          throw canonicalDomainError(`${path}[${index}]`, 'array holes and accessors are not permitted');
+        }
+        entries.push(canonicalizeValue(descriptor.value, `${path}[${index}]`, ancestors, depth + 1));
+      }
+      return `[${entries.join(',')}]`;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw canonicalDomainError(path, 'only plain objects are permitted');
+    }
+    const ownKeys = Reflect.ownKeys(value);
+    if (ownKeys.some((key) => typeof key !== 'string')) throw canonicalDomainError(path, 'symbol members are not JSON');
+    const members: string[] = [];
+    for (const key of (ownKeys as string[]).sort()) {
+      if (hasUnpairedUtf16Surrogate(key)) throw canonicalDomainError(`${path}.${key}`, 'invalid member name');
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor || descriptor.enumerable !== true || !('value' in descriptor)) {
+        throw canonicalDomainError(`${path}.${key}`, 'non-enumerable members and accessors are not permitted');
+      }
+      members.push(`${JSON.stringify(key)}:${canonicalizeValue(descriptor.value, `${path}.${key}`, ancestors, depth + 1)}`);
+    }
+    return `{${members.join(',')}}`;
+  } finally {
+    ancestors.delete(object);
+  }
+}
+
+function canonicalizeStrictJson(value: unknown): string {
+  return canonicalizeValue(value, '$', new Set<object>(), 0);
+}
+
+export type AuthorizationRequirement = typeof AUTHORIZATION_REQUIREMENTS[number];
+export type AuthorityState = typeof AUTHORITY_STATES[number];
+export type ActionBinding = typeof ACTION_BINDINGS[number];
+export type AdmissionState = typeof ADMISSION_STATES[number];
+export type EffectState = typeof EFFECT_STATES[number];
+export type AuthorizationEvidenceClass = typeof AUTHORIZATION_EVIDENCE_CLASSES[number];
+export type BoundaryRole = typeof BOUNDARY_ROLES[number];
+export type PopulationBasis = typeof POPULATION_BASES[number];
+export type ArtifactVerificationState = typeof ARTIFACT_VERIFICATION_STATES[number];
+
+export interface ActionAuthorizationStatusRecord {
+  '@version': typeof ACTION_AUTHORIZATION_STATUS_VERSION;
+  action: {
+    reference: { scheme: string; value: string };
+    type: string;
+    occurred_at: string;
+  };
+  boundary: {
+    id: string;
+    role: BoundaryRole;
+  };
+  classification: {
+    requirement: AuthorizationRequirement;
+    authority: AuthorityState;
+    binding: ActionBinding;
+    admission: AdmissionState;
+    effect: EffectState;
+  };
+  evidence: {
+    class: AuthorizationEvidenceClass;
+    as_of: string;
+    population_basis: PopulationBasis;
+    source_systems: string[];
+    verification_profile: {
+      id: string;
+      digest: string;
+    } | null;
+    artifacts: Array<{
+      type: string;
+      digest: string;
+      verification: ArtifactVerificationState;
+    }>;
+    limitations: string[];
+  };
+  classified_at: string;
+  classifier: {
+    id: string;
+    method: 'manual' | 'ruleset' | 'mixed';
+    ruleset_digest: string;
+  };
+}
+
+const DIGEST = /^sha256:[0-9a-f]{64}$/;
+const IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9:_.@/+\-]{0,511}$/;
+const UTC_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function isOneOf<T extends readonly string[]>(value: unknown, values: T): value is T[number] {
+  return typeof value === 'string' && values.includes(value as T[number]);
+}
+
+function timestampMillis(value: unknown): number | null {
+  if (typeof value !== 'string' || !UTC_TIMESTAMP.test(value)) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function add(errors: string[], condition: boolean, code: string): void {
+  if (!condition) errors.push(code);
+}
+
+function uniqueStrings(value: unknown): value is string[] {
+  return Array.isArray(value)
+    && value.every((entry) => typeof entry === 'string' && IDENTIFIER.test(entry))
+    && new Set(value).size === value.length;
+}
+
+function digestStrictRecord(record: unknown): string {
+  const canonical = canonicalizeStrictJson(record);
+  return `sha256:${crypto.createHash('sha256').update(canonical, 'utf8').digest('hex')}`;
+}
+
+export function validateActionAuthorizationStatus(record: unknown): ActionAuthorizationStatusValidation {
+  const errors: string[] = [];
+  try {
+    canonicalizeStrictJson(record);
+  } catch {
+    return { valid: false, errors: ['record_outside_strict_json_domain'] };
+  }
+
+  if (!isObject(record)) return { valid: false, errors: ['record_must_be_object'] };
+  add(errors, hasExactKeys(record, [
+    '@version', 'action', 'boundary', 'classification', 'evidence', 'classified_at', 'classifier',
+  ]), 'record_members_not_closed');
+  add(errors, record['@version'] === ACTION_AUTHORIZATION_STATUS_VERSION, 'unsupported_version');
+
+  const action = record.action;
+  if (!isObject(action)) {
+    errors.push('invalid_action');
+  } else {
+    add(errors, hasExactKeys(action, ['reference', 'type', 'occurred_at']), 'action_members_not_closed');
+    const reference = action.reference;
+    if (!isObject(reference)) {
+      errors.push('invalid_action_reference');
+    } else {
+      add(errors, hasExactKeys(reference, ['scheme', 'value']), 'action_reference_members_not_closed');
+      add(errors, typeof reference.scheme === 'string' && IDENTIFIER.test(reference.scheme), 'invalid_action_reference_scheme');
+      add(errors, typeof reference.value === 'string' && reference.value.length > 0 && reference.value.length <= 2048, 'invalid_action_reference_value');
+    }
+    add(errors, typeof action.type === 'string' && IDENTIFIER.test(action.type), 'invalid_action_type');
+    add(errors, timestampMillis(action.occurred_at) !== null, 'invalid_action_timestamp');
+  }
+
+  const boundary = record.boundary;
+  if (!isObject(boundary)) {
+    errors.push('invalid_boundary');
+  } else {
+    add(errors, hasExactKeys(boundary, ['id', 'role']), 'boundary_members_not_closed');
+    add(errors, typeof boundary.id === 'string' && IDENTIFIER.test(boundary.id), 'invalid_boundary_id');
+    add(errors, isOneOf(boundary.role, BOUNDARY_ROLES), 'invalid_boundary_role');
+  }
+
+  const classification = record.classification;
+  if (!isObject(classification)) {
+    errors.push('invalid_classification');
+  } else {
+    add(errors, hasExactKeys(classification, ['requirement', 'authority', 'binding', 'admission', 'effect']), 'classification_members_not_closed');
+    add(errors, isOneOf(classification.requirement, AUTHORIZATION_REQUIREMENTS), 'invalid_requirement');
+    add(errors, isOneOf(classification.authority, AUTHORITY_STATES), 'invalid_authority_state');
+    add(errors, isOneOf(classification.binding, ACTION_BINDINGS), 'invalid_action_binding');
+    add(errors, isOneOf(classification.admission, ADMISSION_STATES), 'invalid_admission_state');
+    add(errors, isOneOf(classification.effect, EFFECT_STATES), 'invalid_effect_state');
+
+    if (classification.requirement === 'none') {
+      add(errors, classification.authority === 'not_evaluated', 'no_requirement_requires_authority_not_evaluated');
+      add(errors, classification.binding === 'not_evaluated', 'no_requirement_requires_binding_not_evaluated');
+    }
+    if (classification.requirement === 'unknown') {
+      add(errors, classification.authority === 'indeterminate', 'unknown_requirement_requires_indeterminate_authority');
+      add(errors, classification.binding === 'indeterminate', 'unknown_requirement_requires_indeterminate_binding');
+    }
+  }
+
+  const evidence = record.evidence;
+  if (!isObject(evidence)) {
+    errors.push('invalid_evidence');
+  } else {
+    add(errors, hasExactKeys(evidence, [
+      'class', 'as_of', 'population_basis', 'source_systems', 'verification_profile',
+      'artifacts', 'limitations',
+    ]), 'evidence_members_not_closed');
+    add(errors, isOneOf(evidence.class, AUTHORIZATION_EVIDENCE_CLASSES), 'invalid_evidence_class');
+    add(errors, timestampMillis(evidence.as_of) !== null, 'invalid_evidence_timestamp');
+    add(errors, isOneOf(evidence.population_basis, POPULATION_BASES), 'invalid_population_basis');
+    add(errors, uniqueStrings(evidence.source_systems), 'invalid_source_systems');
+    const verificationProfile = evidence.verification_profile;
+    if (verificationProfile !== null) {
+      if (!isObject(verificationProfile)) {
+        errors.push('invalid_verification_profile');
+      } else {
+        add(errors, hasExactKeys(verificationProfile, ['id', 'digest']), 'verification_profile_members_not_closed');
+        add(errors, typeof verificationProfile.id === 'string' && IDENTIFIER.test(verificationProfile.id), 'invalid_verification_profile_id');
+        add(errors, typeof verificationProfile.digest === 'string' && DIGEST.test(verificationProfile.digest), 'invalid_verification_profile_digest');
+      }
+    }
+    add(errors, Array.isArray(evidence.limitations)
+      && evidence.limitations.length > 0
+      && evidence.limitations.length <= 32
+      && evidence.limitations.every((entry) => typeof entry === 'string' && entry.length > 0 && entry.length <= 2048), 'invalid_limitations');
+
+    const artifacts = evidence.artifacts;
+    if (!Array.isArray(artifacts) || artifacts.length > 64) {
+      errors.push('invalid_artifacts');
+    } else {
+      const artifactDigests: string[] = [];
+      for (const artifact of artifacts) {
+        if (!isObject(artifact)) {
+          errors.push('invalid_artifact');
+          continue;
+        }
+        add(errors, hasExactKeys(artifact, ['type', 'digest', 'verification']), 'artifact_members_not_closed');
+        add(errors, typeof artifact.type === 'string' && IDENTIFIER.test(artifact.type), 'invalid_artifact_type');
+        add(errors, typeof artifact.digest === 'string' && DIGEST.test(artifact.digest), 'invalid_artifact_digest');
+        add(errors, isOneOf(artifact.verification, ARTIFACT_VERIFICATION_STATES), 'invalid_artifact_verification');
+        if (typeof artifact.digest === 'string') artifactDigests.push(artifact.digest);
+      }
+      add(errors, new Set(artifactDigests).size === artifactDigests.length, 'duplicate_artifact_digest');
+      if (evidence.class === 'E0_NONE') {
+        add(errors, artifacts.length === 0, 'e0_forbids_artifacts');
+      } else if (isOneOf(evidence.class, AUTHORIZATION_EVIDENCE_CLASSES)) {
+        add(errors, artifacts.length > 0, 'evidence_class_requires_artifact');
+      }
+      if (evidence.class === 'E3_ACTION_BOUND_SIGNED'
+          || evidence.class === 'E4_OFFLINE_PINNED_VERIFIABLE'
+          || evidence.class === 'E5_RECONCILED_NAMED_POPULATION') {
+        add(errors, artifacts.some((artifact) => isObject(artifact) && artifact.verification === 'verified'), 'signed_class_requires_verified_artifact');
+      }
+      if (evidence.class === 'E4_OFFLINE_PINNED_VERIFIABLE'
+          || evidence.class === 'E5_RECONCILED_NAMED_POPULATION') {
+        add(errors, isObject(verificationProfile), 'verified_class_requires_verification_profile');
+        add(errors, !artifacts.some((artifact) => isObject(artifact) && artifact.verification === 'failed'), 'verified_class_forbids_failed_artifact');
+      }
+      if (evidence.class === 'E5_RECONCILED_NAMED_POPULATION') {
+        add(errors, evidence.population_basis === 'reconciled_named_systems', 'e5_requires_reconciled_population_basis');
+        add(errors, Array.isArray(evidence.source_systems) && evidence.source_systems.length > 0, 'e5_requires_named_source_systems');
+      }
+    }
+  }
+
+  const classifier = record.classifier;
+  if (!isObject(classifier)) {
+    errors.push('invalid_classifier');
+  } else {
+    add(errors, hasExactKeys(classifier, ['id', 'method', 'ruleset_digest']), 'classifier_members_not_closed');
+    add(errors, typeof classifier.id === 'string' && IDENTIFIER.test(classifier.id), 'invalid_classifier_id');
+    add(errors, isOneOf(classifier.method, ['manual', 'ruleset', 'mixed'] as const), 'invalid_classifier_method');
+    add(errors, typeof classifier.ruleset_digest === 'string' && DIGEST.test(classifier.ruleset_digest), 'invalid_ruleset_digest');
+  }
+
+  const occurredAt = isObject(action) ? timestampMillis(action.occurred_at) : null;
+  const evidenceAsOf = isObject(evidence) ? timestampMillis(evidence.as_of) : null;
+  const classifiedAt = timestampMillis(record.classified_at);
+  add(errors, classifiedAt !== null, 'invalid_classified_at');
+  if (occurredAt !== null && evidenceAsOf !== null) {
+    add(errors, evidenceAsOf >= occurredAt, 'evidence_precedes_action');
+  }
+  if (evidenceAsOf !== null && classifiedAt !== null) {
+    add(errors, classifiedAt >= evidenceAsOf, 'classification_precedes_evidence');
+  }
+
+  const uniqueErrors = [...new Set(errors)];
+  if (uniqueErrors.length > 0) return { valid: false, errors: uniqueErrors };
+  return { valid: true, errors: [], digest: digestStrictRecord(record) };
+}
+
+export function authorizationStatusDigest(record: unknown): string {
+  const result = validateActionAuthorizationStatus(record);
+  if (!result.valid || !result.digest) {
+    throw new TypeError(`invalid action authorization status: ${result.errors.join(',')}`);
+  }
+  return result.digest;
+}
+
+const actionAuthorizationStatus = {
+  ACTION_AUTHORIZATION_STATUS_VERSION,
+  AUTHORIZATION_REQUIREMENTS,
+  AUTHORITY_STATES,
+  ACTION_BINDINGS,
+  ADMISSION_STATES,
+  EFFECT_STATES,
+  AUTHORIZATION_EVIDENCE_CLASSES,
+  BOUNDARY_ROLES,
+  POPULATION_BASES,
+  ARTIFACT_VERIFICATION_STATES,
+  validateActionAuthorizationStatus,
+  authorizationStatusDigest,
+};
+
+export default actionAuthorizationStatus;

--- a/standards/staged/action-authorization-status.selftest.ts
+++ b/standards/staged/action-authorization-status.selftest.ts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+import {
+  ACTION_AUTHORIZATION_STATUS_VERSION,
+  authorizationStatusDigest,
+  validateActionAuthorizationStatus,
+} from './action-authorization-status.reference.js';
+import type { ActionAuthorizationStatusRecord } from './action-authorization-status.reference.js';
+
+function validRecord(): ActionAuthorizationStatusRecord {
+  return {
+    '@version': ACTION_AUTHORIZATION_STATUS_VERSION,
+    action: {
+      reference: {
+        scheme: 'caid',
+        value: 'caid:1:example:release-payment',
+      },
+      type: 'payment.release',
+      occurred_at: '2026-07-30T18:00:00Z',
+    },
+    boundary: {
+      id: 'gate:production',
+      role: 'provider_gateway',
+    },
+    classification: {
+      requirement: 'exact_action',
+      authority: 'valid',
+      binding: 'exact_action',
+      admission: 'admitted',
+      effect: 'executed',
+    },
+    evidence: {
+      class: 'E4_OFFLINE_PINNED_VERIFIABLE',
+      as_of: '2026-07-30T18:05:00Z',
+      population_basis: 'single_action',
+      source_systems: ['gate:production'],
+      verification_profile: {
+        id: 'ep-verify:3.14.0',
+        digest: `sha256:${'c'.repeat(64)}`,
+      },
+      artifacts: [
+        {
+          type: 'authorization-receipt',
+          digest: `sha256:${'a'.repeat(64)}`,
+          verification: 'verified',
+        },
+      ],
+      limitations: [
+        'This classification does not establish causation, legal liability, or population completeness.',
+      ],
+    },
+    classified_at: '2026-07-30T18:06:00Z',
+    classifier: {
+      id: 'adjuster:example',
+      method: 'mixed',
+      ruleset_digest: `sha256:${'b'.repeat(64)}`,
+    },
+  };
+}
+
+describe('ACTION-AUTHORIZATION-STATUS-v1', () => {
+  it('accepts a closed exact-action classification with pinned verification evidence', () => {
+    const result = validateActionAuthorizationStatus(validRecord());
+    assert.equal(result.valid, true);
+    assert.deepEqual(result.errors, []);
+    assert.match(result.digest ?? '', /^sha256:[0-9a-f]{64}$/);
+  });
+
+  it('derives the same digest regardless of object key insertion order', () => {
+    const first = validRecord();
+    const second = {
+      classifier: first.classifier,
+      classified_at: first.classified_at,
+      evidence: first.evidence,
+      classification: first.classification,
+      boundary: first.boundary,
+      action: first.action,
+      '@version': first['@version'],
+    };
+    assert.equal(authorizationStatusDigest(first), authorizationStatusDigest(second));
+  });
+
+  it('rejects unknown members and hidden non-JSON surfaces', () => {
+    const unknown = { ...validRecord(), vendor_score: 99 };
+    assert.equal(validateActionAuthorizationStatus(unknown).valid, false);
+
+    const hidden = validRecord();
+    Object.defineProperty(hidden, Symbol('hidden'), { value: 'exfiltrate', enumerable: false });
+    assert.ok(validateActionAuthorizationStatus(hidden).errors.includes('record_outside_strict_json_domain'));
+  });
+
+  it('preserves refused-plus-executed as evidence of bypass or failed mediation', () => {
+    const record = validRecord();
+    record.classification.admission = 'refused';
+    record.evidence.limitations = [
+      'The named boundary refused the action, but the effect was observed through an unmediated or different path.',
+    ];
+    assert.equal(validateActionAuthorizationStatus(record).valid, true);
+  });
+
+  it('does not let a no-requirement record imply evaluated authority or action binding', () => {
+    const record = validRecord();
+    record.classification = {
+      requirement: 'none',
+      authority: 'valid',
+      binding: 'exact_action',
+      admission: 'admitted',
+      effect: 'executed',
+    };
+    const errors = validateActionAuthorizationStatus(record).errors;
+    assert.ok(errors.includes('no_requirement_requires_authority_not_evaluated'));
+    assert.ok(errors.includes('no_requirement_requires_binding_not_evaluated'));
+  });
+
+  it('keeps an unknown requirement from being promoted into a positive authorization claim', () => {
+    const record = validRecord();
+    record.classification = {
+      requirement: 'unknown',
+      authority: 'valid',
+      binding: 'exact_action',
+      admission: 'admitted',
+      effect: 'executed',
+    };
+    const errors = validateActionAuthorizationStatus(record).errors;
+    assert.ok(errors.includes('unknown_requirement_requires_indeterminate_authority'));
+    assert.ok(errors.includes('unknown_requirement_requires_indeterminate_binding'));
+    assert.ok(!errors.includes('unknown_requirement_cannot_claim_admission'));
+  });
+
+  it('requires evidence for every class above E0 and forbids laundering evidence into E0', () => {
+    const missing = validRecord();
+    missing.evidence.artifacts = [];
+    assert.ok(validateActionAuthorizationStatus(missing).errors.includes('evidence_class_requires_artifact'));
+
+    const laundered = validRecord();
+    laundered.evidence.class = 'E0_NONE';
+    assert.ok(validateActionAuthorizationStatus(laundered).errors.includes('e0_forbids_artifacts'));
+  });
+
+  it('requires E4 evidence to contain a successfully verified artifact', () => {
+    const record = validRecord();
+    record.evidence.artifacts[0].verification = 'not_checked';
+    assert.ok(validateActionAuthorizationStatus(record).errors.includes('signed_class_requires_verified_artifact'));
+  });
+
+  it('requires E4 and E5 to bind the verification profile used', () => {
+    const record = validRecord();
+    record.evidence.verification_profile = null;
+    assert.ok(validateActionAuthorizationStatus(record).errors.includes('verified_class_requires_verification_profile'));
+  });
+
+  it('does not promote an unchecked signed artifact into E3 evidence', () => {
+    const record = validRecord();
+    record.evidence.class = 'E3_ACTION_BOUND_SIGNED';
+    record.evidence.verification_profile = null;
+    record.evidence.artifacts[0].verification = 'not_checked';
+    assert.ok(validateActionAuthorizationStatus(record).errors.includes('signed_class_requires_verified_artifact'));
+  });
+
+  it('limits E5 to reconciliation against named systems and refuses an empty source set', () => {
+    const record = validRecord();
+    record.evidence.class = 'E5_RECONCILED_NAMED_POPULATION';
+    record.evidence.population_basis = 'declared_population';
+    record.evidence.source_systems = [];
+    const errors = validateActionAuthorizationStatus(record).errors;
+    assert.ok(errors.includes('e5_requires_reconciled_population_basis'));
+    assert.ok(errors.includes('e5_requires_named_source_systems'));
+  });
+
+  it('rejects malformed time ordering and non-canonical digests', () => {
+    const record = validRecord();
+    record.action.occurred_at = '2026-07-30T18:10:00Z';
+    record.evidence.artifacts[0].digest = 'SHA256:ABC';
+    const errors = validateActionAuthorizationStatus(record).errors;
+    assert.ok(errors.includes('evidence_precedes_action'));
+    assert.ok(errors.includes('invalid_artifact_digest'));
+  });
+
+  it('matches the language-neutral conformance vectors', () => {
+    const suite = JSON.parse(readFileSync(
+      new URL('./action-authorization-status.v1.vectors.json', import.meta.url),
+      'utf8',
+    ));
+    for (const vector of suite.vectors) {
+      const result = validateActionAuthorizationStatus(vector.record);
+      assert.equal(result.valid, vector.expect.valid, vector.id);
+      for (const expectedError of vector.expect.errors ?? []) {
+        assert.ok(result.errors.includes(expectedError), `${vector.id}: missing ${expectedError}`);
+      }
+    }
+  });
+});

--- a/standards/staged/action-authorization-status.v1.vectors.json
+++ b/standards/staged/action-authorization-status.v1.vectors.json
@@ -1,0 +1,234 @@
+{
+  "@version": "ACTION-AUTHORIZATION-STATUS-VECTORS-v1",
+  "schema": "../../public/schemas/action-authorization-status.v1.schema.json",
+  "description": "Language-neutral validity and semantic-boundary vectors for ACTION-AUTHORIZATION-STATUS-v1.",
+  "vectors": [
+    {
+      "id": "valid_exact_action_offline_verifiable",
+      "record": {
+        "@version": "ACTION-AUTHORIZATION-STATUS-v1",
+        "action": {
+          "reference": { "scheme": "caid", "value": "caid:1:example:release-payment" },
+          "type": "payment.release",
+          "occurred_at": "2026-07-30T18:00:00Z"
+        },
+        "boundary": { "id": "gate:production", "role": "provider_gateway" },
+        "classification": {
+          "requirement": "exact_action",
+          "authority": "valid",
+          "binding": "exact_action",
+          "admission": "admitted",
+          "effect": "executed"
+        },
+        "evidence": {
+          "class": "E4_OFFLINE_PINNED_VERIFIABLE",
+          "as_of": "2026-07-30T18:05:00Z",
+          "population_basis": "single_action",
+          "source_systems": ["gate:production"],
+          "verification_profile": {
+            "id": "ep-verify:3.14.0",
+            "digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999"
+          },
+          "artifacts": [
+            {
+              "type": "authorization-receipt",
+              "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "verification": "verified"
+            }
+          ],
+          "limitations": [
+            "This classification does not establish causation, legal liability, coverage, or population completeness."
+          ]
+        },
+        "classified_at": "2026-07-30T18:06:00Z",
+        "classifier": {
+          "id": "adjuster:example",
+          "method": "mixed",
+          "ruleset_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }
+      },
+      "expect": { "valid": true }
+    },
+    {
+      "id": "valid_refusal_with_observed_effect",
+      "record": {
+        "@version": "ACTION-AUTHORIZATION-STATUS-v1",
+        "action": {
+          "reference": { "scheme": "caid", "value": "caid:1:example:create-relay" },
+          "type": "infrastructure.resource.create",
+          "occurred_at": "2026-07-30T18:00:00Z"
+        },
+        "boundary": { "id": "gateway:declared", "role": "resource_server" },
+        "classification": {
+          "requirement": "exact_action",
+          "authority": "invalid",
+          "binding": "outside_bound",
+          "admission": "refused",
+          "effect": "executed"
+        },
+        "evidence": {
+          "class": "E3_ACTION_BOUND_SIGNED",
+          "as_of": "2026-07-30T18:05:00Z",
+          "population_basis": "single_action",
+          "source_systems": ["gateway:declared", "provider:effect-log"],
+          "verification_profile": null,
+          "artifacts": [
+            {
+              "type": "signed-refusal",
+              "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+              "verification": "verified"
+            },
+            {
+              "type": "effect-record",
+              "digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+              "verification": "not_checked"
+            }
+          ],
+          "limitations": [
+            "The named boundary refused the action, but the effect was observed through an unmediated or different path."
+          ]
+        },
+        "classified_at": "2026-07-30T18:06:00Z",
+        "classifier": {
+          "id": "forensics:example",
+          "method": "manual",
+          "ruleset_digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        }
+      },
+      "expect": { "valid": true }
+    },
+    {
+      "id": "invalid_unknown_requirement_promoted_to_valid_authority",
+      "record": {
+        "@version": "ACTION-AUTHORIZATION-STATUS-v1",
+        "action": {
+          "reference": { "scheme": "local", "value": "incident-action-17" },
+          "type": "data.write",
+          "occurred_at": "2026-07-30T18:00:00Z"
+        },
+        "boundary": { "id": "service:unknown", "role": "other" },
+        "classification": {
+          "requirement": "unknown",
+          "authority": "valid",
+          "binding": "exact_action",
+          "admission": "admitted",
+          "effect": "executed"
+        },
+        "evidence": {
+          "class": "E1_SELF_ASSERTED",
+          "as_of": "2026-07-30T18:05:00Z",
+          "population_basis": "single_action",
+          "source_systems": ["operator:statement"],
+          "verification_profile": null,
+          "artifacts": [
+            {
+              "type": "operator-statement",
+              "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+              "verification": "not_checked"
+            }
+          ],
+          "limitations": ["The authorization requirement could not be established." ]
+        },
+        "classified_at": "2026-07-30T18:06:00Z",
+        "classifier": {
+          "id": "reviewer:example",
+          "method": "manual",
+          "ruleset_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+        }
+      },
+      "expect": {
+        "valid": false,
+        "errors": [
+          "unknown_requirement_requires_indeterminate_authority",
+          "unknown_requirement_requires_indeterminate_binding"
+        ]
+      }
+    },
+    {
+      "id": "invalid_reconciled_population_without_named_sources",
+      "record": {
+        "@version": "ACTION-AUTHORIZATION-STATUS-v1",
+        "action": {
+          "reference": { "scheme": "caid", "value": "caid:1:example:delete-record" },
+          "type": "records.delete",
+          "occurred_at": "2026-07-30T18:00:00Z"
+        },
+        "boundary": { "id": "gate:production", "role": "execution_service" },
+        "classification": {
+          "requirement": "exact_action",
+          "authority": "valid",
+          "binding": "exact_action",
+          "admission": "admitted",
+          "effect": "executed"
+        },
+        "evidence": {
+          "class": "E5_RECONCILED_NAMED_POPULATION",
+          "as_of": "2026-07-30T18:05:00Z",
+          "population_basis": "declared_population",
+          "source_systems": [],
+          "verification_profile": {
+            "id": "reconciliation-profile:example",
+            "digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777"
+          },
+          "artifacts": [
+            {
+              "type": "period-reconciliation",
+              "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+              "verification": "verified"
+            }
+          ],
+          "limitations": ["No systems of record were named." ]
+        },
+        "classified_at": "2026-07-30T18:06:00Z",
+        "classifier": {
+          "id": "auditor:example",
+          "method": "mixed",
+          "ruleset_digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+        }
+      },
+      "expect": {
+        "valid": false,
+        "errors": [
+          "e5_requires_reconciled_population_basis",
+          "e5_requires_named_source_systems"
+        ]
+      }
+    },
+    {
+      "id": "invalid_unregistered_extension_member",
+      "record": {
+        "@version": "ACTION-AUTHORIZATION-STATUS-v1",
+        "action": {
+          "reference": { "scheme": "caid", "value": "caid:1:example:release-payment" },
+          "type": "payment.release",
+          "occurred_at": "2026-07-30T18:00:00Z"
+        },
+        "boundary": { "id": "gate:production", "role": "provider_gateway" },
+        "classification": {
+          "requirement": "exact_action",
+          "authority": "valid",
+          "binding": "exact_action",
+          "admission": "admitted",
+          "effect": "executed"
+        },
+        "evidence": {
+          "class": "E0_NONE",
+          "as_of": "2026-07-30T18:05:00Z",
+          "population_basis": "single_action",
+          "source_systems": [],
+          "verification_profile": null,
+          "artifacts": [],
+          "limitations": ["No supporting artifact was available." ]
+        },
+        "classified_at": "2026-07-30T18:06:00Z",
+        "classifier": {
+          "id": "reviewer:example",
+          "method": "manual",
+          "ruleset_digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+        },
+        "vendor_score": 99
+      },
+      "expect": { "valid": false, "errors": ["record_members_not_closed"] }
+    }
+  ]
+}


### PR DESCRIPTION
## Status

This is a public standards-side review proposal. It is not an IETF submission, npm release, insurance product, or claim of adoption.

## What changed

- Adds `ACTION-AUTHORIZATION-STATUS-v1`, a closed, implementation-neutral field group for preserving five separate facts: requirement, authority, action binding, admission, and observed effect.
- Defines evidence classes from self-asserted through action-bound/offline-verifiable and reconciled named-population evidence.
- Requires a verification profile and verified artifact for the stronger E4/E5 labels.
- Includes a TypeScript reference validator, JSON Schema, conformance vectors, and the incident/claims crosswalk.
- Keeps causation, liability, coverage, population completeness, and authorization decisions outside this field group.

## External review requested

Please review the mapping and boundaries from:

1. authors of the insurance-stack and reliance drafts;
2. AIUC, ACORD, and LMA standards contacts;
3. one independent actuary; and
4. authors of the adjacent agent-authorization, human-approval, audit, and incident-reporting drafts.

The review request is to validate the action/evidence vocabulary and identify errors in the mappings—not to ask anyone to adopt EMILIA or surrender ownership of a native protocol. No outreach has been sent by this PR.

## Verification

- Action-status selftest: 13/13 pass
- Strict TypeScript reference check: pass
- AJV 2020 schema/vector check: 5/5 expected validity outcomes pass
- `npm run check:protocol`: pass, 0 critical findings
- `npm run check:repository-boundary`: pass
- `npm run conformance:clean-room:v2:selftest`: 8/8 pass
- `npm run conformance:manifest:check`: pass, 21 suites / 331 vectors
- Full TypeScript matrix: pass
- Full test suite: 7,908 passed, 77 skipped across 456 files
- Live proof gate with authenticated TLC 1.7.4: pass, 7,985 test cases; 20 verified Tamarin lemmas; 35 executable security claims; 331 conformance vectors; 359 external hostility cases

The existing public engineering count remains unchanged at 7,985; this proposal does not revise that generated claim.