### PR TITLE
Fix conditional export target type narrowing

### DIFF
--- a/scripts/check-packed-package-exports.mts
+++ b/scripts/check-packed-package-exports.mts
@@ -55,7 +55,7 @@ export function packageTargets(
       const importPath = typeof exportValue === 'string'
         ? exportValue
         : exportValue && typeof exportValue === 'object' && !Array.isArray(exportValue)
-          ? exportValue.import
+          ? (exportValue as Record<string, unknown>).import
           : undefined;
       if (typeof importPath !== 'string') {
         throw new Error(`${name} export ${subpath} has no closed import target`);


### PR DESCRIPTION
## Outcome

Closes the `typecheck-rest` failure surfaced after PR #449. This is a type-only narrowing for conditional package exports; the generated runtime is byte-unchanged.

## Verification

- exact CI command: `npx tsc -p tsconfig.rest.json --incremental false`
- packed export regression: 2/2
- real tarball smoke: 2 packages, 123 module imports, 1 asset
- standalone runtimes regenerated with no generated diff
- LLM context check remains current

DCO sign-off included.