### PR TITLE
feat(site): adopt slash product navigation

### DIFF
--- a/app/HomePageClient.tsx
+++ b/app/HomePageClient.tsx
@@ -306,7 +306,7 @@ export default function HomePage() {
               Diagnose, integrate, or adopt from code.
             </h2>
             <p style={{ fontSize: 17, color: color.t2, lineHeight: 1.72, maxWidth: 660, marginTop: 20 }}>
-              Amelia I can find the legacy workflow that most needs control. Engineering teams can
+              EMILIA Signal can find the legacy workflow that most needs control. Engineering teams can
               protect a known boundary directly, while developers can adopt Receipt Required around
               one privileged tool without changing the rest of the agent stack.
             </p>
@@ -316,9 +316,9 @@ export default function HomePage() {
               {
                 label: 'Legacy diagnostic',
                 title: 'Find where approval and effect stopped matching.',
-                body: 'Amelia I reviews one governed export, produces source-linked integrity cases, and generates the Action Control Manifest template for the selected workflow.',
-                href: '/health/program-integrity',
-                cta: 'Explore Amelia I',
+                body: 'EMILIA Signal reviews one governed export, produces source-linked integrity cases, and generates the Action Control Manifest template for the selected workflow.',
+                href: '/signal',
+                cta: 'Explore EMILIA Signal',
               },
               {
                 label: 'Developer adoption',

--- a/app/ep.css
+++ b/app/ep.css
@@ -533,7 +533,7 @@
   display: none;
 }
 
-@media (max-width: 860px) {
+@media (max-width: 1240px) {
   .ep-nav-links {
     display: none !important;
   }

--- a/app/grace/page.tsx
+++ b/app/grace/page.tsx
@@ -24,7 +24,7 @@ const BUYERS = [
 export default function GracePage() {
   return (
     <>
-      <SiteNav activePage="Solutions" />
+      <SiteNav activePage="GRACE" />
       <main style={styles.page}>
         {/* Hero */}
         <section style={{ ...styles.section, paddingTop: 80, paddingBottom: 56 }}>

--- a/app/health/program-integrity/_components/ProgramIntegrityGate.tsx
+++ b/app/health/program-integrity/_components/ProgramIntegrityGate.tsx
@@ -150,11 +150,11 @@ export default function ProgramIntegrityGate(): React.ReactElement {
           <div className={styles.heroCopy}>
             <div className={styles.kicker}>
               <HeartPulse aria-hidden="true" size={15} />
-              Amelia I + EMILIA Gate
+              EMILIA Signal + EMILIA Gate
             </div>
             <h1>Find the risky workflow. Then make the next payment prove its authorization.</h1>
             <p className={styles.heroLede}>
-              Amelia I reconstructs the approval-to-effect chain from a governed legacy
+              EMILIA Signal reconstructs the approval-to-effect chain from a governed legacy
               export. EMILIA Gate then binds the provider action, authorization,
               destination, amount, and named approval before the next protected effect.
             </p>
@@ -165,7 +165,7 @@ export default function ProgramIntegrityGate(): React.ReactElement {
             </p>
             <div className={styles.heroActions}>
               <a href="/pilot?v=health" className={styles.primaryAction}>
-                Scope the Amelia I diagnostic
+                Scope the EMILIA Signal diagnostic
                 <ArrowRight aria-hidden="true" size={16} />
               </a>
               <a href="#reference-lab" className={styles.secondaryAction}>
@@ -185,7 +185,7 @@ export default function ProgramIntegrityGate(): React.ReactElement {
             </div>
             <dl className={styles.valueFacts}>
               <div>
-                <dt>Amelia I</dt>
+                <dt>EMILIA Signal</dt>
                 <dd>Find the boundary</dd>
               </div>
               <div>
@@ -475,13 +475,13 @@ export default function ProgramIntegrityGate(): React.ReactElement {
           <div className={styles.eyebrow}>Practical next step</div>
           <h2 id="program-integrity-next-step">Start with one read-only workflow for 60 days.</h2>
           <p>
-            Begin with synthetic replay and a governed export. Amelia I surfaces the
+            Begin with synthetic replay and a governed export. EMILIA Signal surfaces the
             approval-to-effect gaps and produces an Action Control Manifest template.
             If the workflow justifies prospective enforcement, Gate becomes the separately
             scoped next engagement at the real system boundary.
           </p>
           <a href="/pilot?v=gov" className={styles.pilotAction}>
-            Scope the Amelia I diagnostic
+            Scope the EMILIA Signal diagnostic
             <ArrowRight aria-hidden="true" size={16} />
           </a>
         </div>

--- a/app/health/program-integrity/page.tsx
+++ b/app/health/program-integrity/page.tsx
@@ -5,15 +5,15 @@ import SiteNav from '@/components/SiteNav';
 import ProgramIntegrityGate from './_components/ProgramIntegrityGate';
 
 export const metadata: Metadata = {
-  title: 'Amelia I + Program Integrity Gate | EMILIA',
+  title: 'EMILIA Signal + Program Integrity Gate | EMILIA',
   description:
-    'Diagnose risky legacy workflows with Amelia I, then see a synthetic, PHI-free Gate demonstration of exact-action authorization, no-blind-replay handling, and portable evidence.',
+    'Diagnose risky legacy workflows with EMILIA Signal, then see a synthetic, PHI-free Gate demonstration of exact-action authorization, no-blind-replay handling, and portable evidence.',
 };
 
 export default function ProgramIntegrityPage() {
   return (
     <>
-      <SiteNav activePage="Solutions" />
+      <SiteNav activePage="Signal" />
       <ProgramIntegrityGate />
       <SiteFooter />
     </>

--- a/app/pilot/layout.tsx
+++ b/app/pilot/layout.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Request a Managed Gate Pilot — One Workflow, 60 Days — EMILIA Protocol',
   description:
-    'Scope one consequential workflow for a fixed 60-day Amelia I diagnostic: synthetic first, then a governed read-only export, source-linked findings, and a Gate implementation decision.',
+    'Scope one consequential workflow for a fixed 60-day EMILIA Signal diagnostic: synthetic first, then a governed read-only export, source-linked findings, and a Gate implementation decision.',
   alternates: { canonical: '/pilot' },
 };
 

--- a/app/pilot/page.tsx
+++ b/app/pilot/page.tsx
@@ -89,7 +89,7 @@ export default function PilotPage(): React.ReactElement {
         </h1>
         <p style={{ ...styles.body, maxWidth: 580 }}>
           Pick one consequential workflow and begin with synthetic replay plus a governed read-only export.
-          Amelia I reconstructs the approval-to-effect chain, surfaces source-linked integrity cases, and
+          EMILIA Signal reconstructs the approval-to-effect chain, surfaces source-linked integrity cases, and
           produces the material-field map and Action Control Manifest template. You leave with evidence,
           a Gate implementation scope, and a clear decision about whether prospective enforcement is worth it.
         </p>

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -161,7 +161,7 @@ export default function PricingPage(): React.ReactElement {
             Diagnose the past. Protect the next effect. Operate the boundary.
           </h1>
           <p style={{ fontSize: 18, color: color.t2, maxWidth: 620, lineHeight: 1.7, margin: 0 }}>
-            The open protocol is free. Amelia I finds the workflow that needs control. Gate Qualification
+            The open protocol is free. EMILIA Signal finds the workflow that needs control. Gate Qualification
             can carry accepted evaluation evidence into that decision when needed. Implementation is scoped;
             Operated Gate is quoted only for a customer-specific deployment.
           </p>
@@ -253,7 +253,7 @@ export default function PricingPage(): React.ReactElement {
               Find the right boundary before asking engineering to change it.
             </h2>
             <p style={{ fontSize: 16, color: 'rgba(250,250,249,0.72)', lineHeight: 1.7, marginBottom: 30, maxWidth: 620 }}>
-              Amelia I starts with a synthetic replay and one governed export over {MANAGED_PILOT.durationLabel}.
+              EMILIA Signal starts with a synthetic replay and one governed export over {MANAGED_PILOT.durationLabel}.
               It reconstructs action groups, separates deterministic findings from heuristic leads, and produces a
               decision-ready manifest and implementation scope. No production path is changed in this first engagement.
             </p>
@@ -266,8 +266,8 @@ export default function PricingPage(): React.ReactElement {
               ))}
             </div>
             <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-              <Link href="/pilot" className="ep-cta" style={{ ...cta.primary, background: color.gold, color: '#1C1917' }}>Scope the Amelia I diagnostic &rarr;</Link>
-              <Link href="/health/program-integrity" className="ep-cta-secondary" style={{ ...cta.secondary, color: 'rgba(250,250,249,0.8)', borderColor: 'rgba(255,255,255,0.15)' }}>See the prospective Gate</Link>
+              <Link href="/pilot" className="ep-cta" style={{ ...cta.primary, background: color.gold, color: '#1C1917' }}>Scope the EMILIA Signal diagnostic &rarr;</Link>
+              <Link href="/signal" className="ep-cta-secondary" style={{ ...cta.secondary, color: 'rgba(250,250,249,0.8)', borderColor: 'rgba(255,255,255,0.15)' }}>Explore EMILIA Signal</Link>
             </div>
           </div>
         </C>
@@ -370,7 +370,7 @@ export default function PricingPage(): React.ReactElement {
                 Start with one consequential workflow.
               </h2>
               <p style={{ fontSize: 16, color: color.t2, lineHeight: 1.6, maxWidth: 440, margin: 0 }}>
-                Diagnose an uncertain legacy path with Amelia I, or put Gate directly before a known high-risk mutation.
+                Diagnose an uncertain legacy path with EMILIA Signal, or put Gate directly before a known high-risk mutation.
               </p>
             </div>
             <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>

--- a/app/signal/page.tsx
+++ b/app/signal/page.tsx
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { Metadata } from 'next';
+import SiteFooter from '@/components/SiteFooter';
+import SiteNav from '@/components/SiteNav';
+import ProgramIntegrityGate from '../health/program-integrity/_components/ProgramIntegrityGate';
+
+export const metadata: Metadata = {
+  title: 'EMILIA Signal | Find the Consequence Boundary',
+  description:
+    'EMILIA Signal reconstructs consequential workflows from governed exports, surfaces source-linked review leads, and prepares the exact boundary EMILIA Gate can protect.',
+  alternates: { canonical: '/signal' },
+  openGraph: {
+    title: 'EMILIA Signal',
+    description: 'Find the consequential workflow. Bind the next decision. Preserve the evidence.',
+    url: 'https://www.emiliaprotocol.ai/signal',
+    type: 'website',
+  },
+};
+
+export default function SignalPage(): React.ReactElement {
+  return (
+    <>
+      <SiteNav activePage="Signal" />
+      <ProgramIntegrityGate />
+      <SiteFooter />
+    </>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -20,8 +20,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
   // Top-level marketing surfaces — highest crawl priority.
   const marketing = [
     { path: '/',                      priority: 1.0, changeFrequency: 'weekly' },
+    { path: '/signal',                priority: 0.98, changeFrequency: 'weekly' },
     { path: '/gate',                  priority: 0.98, changeFrequency: 'weekly' },
     { path: '/assurance',             priority: 0.92, changeFrequency: 'weekly' },
+    { path: '/model-to-matter',       priority: 0.9, changeFrequency: 'monthly' },
     { path: '/agent-guard',           priority: 0.85, changeFrequency: 'monthly' },
     { path: '/fire-drill',            priority: 0.95, changeFrequency: 'weekly' },
     { path: '/fire-drill/cf-1',       priority: 0.9,  changeFrequency: 'monthly' },

--- a/components/SiteFooter.tsx
+++ b/components/SiteFooter.tsx
@@ -4,10 +4,12 @@ import { ENTITY } from '@/lib/site-config';
 type FooterLink = [string, string];
 
 const COL_PRODUCT: FooterLink[] = [
+  ['/signal', 'EMILIA Signal'],
   ['/gate', 'EMILIA Gate'],
   ['/gate/live', 'Live Gate'],
-  ['/product/accountable-signoff', 'Approver Apps'],
   ['/assurance', 'Assurance Plane'],
+  ['/grace', 'GRACE'],
+  ['/model-to-matter', 'Model-to-Matter'],
   ['/pricing', 'Pricing'],
 ];
 

--- a/components/SiteNav.tsx
+++ b/components/SiteNav.tsx
@@ -8,13 +8,16 @@ import { color, font, radius, cta } from '@/lib/tokens';
 type NavLink = [string, string];
 
 const NAV_LINKS: NavLink[] = [
-  ['/gate', 'Gate'],
-  ['/use-cases', 'Solutions'],
-  ['/assurance', 'Assurance'],
-  ['/protocol', 'Protocol'],
-  ['/proof', 'Proof'],
-  ['/docs', 'Docs'],
-  ['/pricing', 'Pricing'],
+  ['/signal', '/signal'],
+  ['/gate', '/gate'],
+  ['/use-cases', '/solutions'],
+  ['/assurance', '/assurance'],
+  ['/grace', '/grace'],
+  ['/model-to-matter', '/model-to-matter'],
+  ['/protocol', '/protocol'],
+  ['/proof', '/proof'],
+  ['/docs', '/docs'],
+  ['/pricing', '/pricing'],
 ];
 
 type SiteNavProps = {
@@ -23,6 +26,10 @@ type SiteNavProps = {
 
 export default function SiteNav({ activePage }: SiteNavProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
+  const activeKey = activePage?.replace(/^\/+/, '').toLowerCase();
+  const linkIsActive = (href: string, label: string): boolean => (
+    href.slice(1) === activeKey || label.slice(1) === activeKey
+  );
 
   useEffect(() => {
     if (!mobileOpen) return undefined;
@@ -68,13 +75,13 @@ export default function SiteNav({ activePage }: SiteNavProps) {
           </Link>
 
           {/* Desktop links */}
-          <div className="ep-nav-links" style={{ display: 'flex', alignItems: 'center', gap: 18, margin: '0 auto' }}>
+          <div className="ep-nav-links" style={{ display: 'flex', alignItems: 'center', gap: 14, margin: '0 auto' }}>
             {NAV_LINKS.map(([href, label]) => (
               <a
                 key={label}
                 href={href}
                 className="ep-nav-link"
-                data-active={label === activePage ? 'true' : undefined}
+                data-active={linkIsActive(href, label) ? 'true' : undefined}
                 target={href.startsWith('http') ? '_blank' : undefined}
                 rel={href.startsWith('http') ? 'noopener noreferrer' : undefined}
               >{label}</a>
@@ -113,7 +120,7 @@ export default function SiteNav({ activePage }: SiteNavProps) {
           <a
             key={label}
             href={href}
-            data-active={label === activePage ? 'true' : undefined}
+            data-active={linkIsActive(href, label) ? 'true' : undefined}
             onClick={() => setMobileOpen(false)}
           >{label}</a>
         ))}

--- a/lib/commercial-offer.ts
+++ b/lib/commercial-offer.ts
@@ -5,7 +5,7 @@
  * so price, duration, scope, and rollout posture cannot drift independently.
  */
 export const MANAGED_PILOT = Object.freeze({
-  name: 'Amelia I Diagnostic',
+  name: 'EMILIA Signal Diagnostic',
   priceUsd: 25_000,
   priceLabel: '$25,000',
   shortPriceLabel: '$25K',

--- a/next.config.js
+++ b/next.config.js
@@ -83,6 +83,10 @@ const nextConfig = {
       // old URL into the destination instead of indexing it as "Page with redirect".
       { source: '/score', destination: '/explorer', permanent: true },
       { source: '/enterprise', destination: '/product/enterprise', permanent: true },
+      { source: '/m2m', destination: '/model-to-matter', permanent: true },
+      { source: '/amelia-i', destination: '/signal', permanent: true },
+      { source: '/amelia-integrity', destination: '/signal', permanent: true },
+      { source: '/amelia-grip', destination: '/signal', permanent: true },
     ];
   },
   async headers() {

--- a/tests/commercial-offer-contract.test.ts
+++ b/tests/commercial-offer-contract.test.ts
@@ -17,7 +17,7 @@ describe('commercial offer contract', () => {
     expect(pricing).toContain('MANAGED_PILOT');
     expect(pricing).toContain('GATE_IMPLEMENTATION');
     expect(pricing).toContain('PRODUCTION_GATE');
-    expect(pricing).toContain('Amelia I');
+    expect(pricing).toContain('EMILIA Signal');
     expect(commercialOffer).toContain('$150K');
     expect(commercialOffer).toContain('$250K');
     expect(commercialOffer).toContain('$500K');

--- a/tests/site-product-navigation.test.ts
+++ b/tests/site-product-navigation.test.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const read = (path: string): string => readFileSync(resolve(ROOT, path), 'utf8');
+
+describe('public product naming and navigation contract', () => {
+  it('keeps every top-navigation destination with a slash-form label', () => {
+    const navigation = read('components/SiteNav.tsx');
+    const expectedLinks = [
+      ['/signal', '/signal'],
+      ['/gate', '/gate'],
+      ['/use-cases', '/solutions'],
+      ['/assurance', '/assurance'],
+      ['/grace', '/grace'],
+      ['/model-to-matter', '/model-to-matter'],
+      ['/protocol', '/protocol'],
+      ['/proof', '/proof'],
+      ['/docs', '/docs'],
+      ['/pricing', '/pricing'],
+    ];
+    for (const [href, label] of expectedLinks) {
+      expect(navigation).toContain(`[\'${href}\', \'${label}\']`);
+    }
+  });
+
+  it('keeps stable entry points for the renamed products', () => {
+    expect(read('app/signal/page.tsx')).toContain('EMILIA Signal');
+    expect(read('app/model-to-matter/layout.tsx')).toContain("canonical: '/model-to-matter'");
+    const redirects = read('next.config.js');
+    expect(redirects).toContain("source: '/m2m', destination: '/model-to-matter'");
+    expect(redirects).toContain("source: '/amelia-i', destination: '/signal'");
+  });
+
+  it('does not expose the retired Amelia I or Amelia Grip names in buyer-facing source', () => {
+    const buyerFacing = [
+      'app/HomePageClient.tsx',
+      'app/health/program-integrity/page.tsx',
+      'app/health/program-integrity/_components/ProgramIntegrityGate.tsx',
+      'app/pilot/page.tsx',
+      'app/pilot/layout.tsx',
+      'app/pricing/page.tsx',
+      'lib/commercial-offer.ts',
+    ].map(read).join('\n');
+    expect(buyerFacing).not.toMatch(/Amelia I|Amelia Grip/);
+    expect(buyerFacing).toContain('EMILIA Signal');
+  });
+});


### PR DESCRIPTION
## Outcome

Uses the compact slash-style product navigation, adds the `/signal` route, and keeps all product links route-accurate.

## Verification

- 6 focused navigation/commercial contract tests passed
- app TypeScript check passed
- production Next.js build completed across 764 pages
- npm audit reported 0 vulnerabilities

No deployment is performed by this PR.