### PR TITLE
Release Verify 3.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14622,6 +14622,18 @@
         "ep-assure": "ep-assure.mjs"
       }
     },
+    "packages/gate/node_modules/@emilia-protocol/verify": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/@emilia-protocol/verify/-/verify-3.19.1.tgz",
+      "integrity": "sha512-lPkGxuaKONOwNFfnHjQRmevaj7ZCyqctquxC7RMC8HAYAQC1iDmmAkz5syHO7hOcjTTyylpGxToGiLNZNZ3kjg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "emilia-verify": "cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "packages/require-receipt": {
       "name": "@emilia-protocol/require-receipt",
       "version": "0.7.0",
@@ -14635,7 +14647,7 @@
     },
     "packages/verify": {
       "name": "@emilia-protocol/verify",
-      "version": "3.19.1",
+      "version": "3.20.0",
       "license": "Apache-2.0",
       "bin": {
         "emilia-verify": "cli.js"

--- a/packages/verify/CHANGELOG.md
+++ b/packages/verify/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to `@emilia-protocol/verify` are documented here.
 This package follows [Semantic Versioning](https://semver.org/).
 
+## 3.20.0 (2026-08-01)
+
+### Added
+
+- Memory Projection Record v1 construction and relying-party verification as
+  the public `@emilia-protocol/verify/memory-projection` export. The record
+  binds a candidate manifest, projection policy, source and projected memory
+  digests, transformation disclosure, freshness, and verifier-owned trust
+  configuration without treating projection as authorization.
+
+### Security
+
+- The projection verifier rejects unknown fields, malformed or accessor-bearing
+  JSON, untrusted issuers, substituted policies or contexts, stale records,
+  source and output digest mismatches, and unsupported transformation claims.
+
 ## 3.19.1 (2026-07-31)
 
 ### Security

--- a/packages/verify/package.json
+++ b/packages/verify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emilia-protocol/verify",
-  "version": "3.19.1",
+  "version": "3.20.0",
   "description": "Zero-dependency offline verification for EP authorization receipts: Ed25519 receipts, Merkle anchors, commitment proofs, Class-A WebAuthn device signoffs, multi-party quorum (M-of-N / ordered, two-person rule), portable revocation, trusted-time attestation, provenance chains, long-term evidence records, federated cross-operator receipts (PIP-006), and the opt-in transparency knobs (witness cosignatures, RFC 3161 timestamp proofs, currency evaluation, consumption proofs, initiator-software attestation). Node uses built-in crypto; the /web build runs in any browser, edge, or Deno via Web Crypto. No EP infrastructure required.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Publishes the already-merged Memory Projection Record v1 public API under a new minor version.

Verification:
- Verify: 672/672 core tests
- Gate Qualification in Verify: 34/34
- npm production audit: 0 vulnerabilities
- package dependency registry: 6/6
- lockfile clean-install verified

Gate remains pinned to the already-published Verify 3.19.1 bytes; no downstream dependency was silently widened.
