### PR TITLE
security: close canonical binding and enrollment input gaps

### DIFF
--- a/lib/gate-commit-binding.ts
+++ b/lib/gate-commit-binding.ts
@@ -61,6 +61,16 @@ function normalizeJson(value, path, state = { nodes: 0 }, depth = 0) {
     throw new GateCommitBindingError(`${path} must be a plain JSON object`);
   }
 
+  // Symbol-keyed members are invisible to Object.keys, so they would be absent
+  // from the normalized object this function returns and therefore absent from
+  // the binding hash, while remaining readable on the caller's original object.
+  // Every other canonicalizer in the tree routes through canonicalizeStrictJson,
+  // which refuses them ("symbol members are not JSON"); this one walks keys
+  // itself, so it needs the same refusal rather than a silent drop.
+  if (Object.getOwnPropertySymbols(value).length > 0) {
+    throw new GateCommitBindingError(`${path} contains symbol-keyed members`);
+  }
+
   const result = Object.create(null);
   for (const key of Object.keys(value).sort()) {
     if (FORBIDDEN_OBJECT_KEYS.has(key)) {

--- a/lib/mobile/attestation.ts
+++ b/lib/mobile/attestation.ts
@@ -263,6 +263,15 @@ export function createPlatformEnrollmentVerifier({
       return { valid: false };
     }
     try {
+      // Bound the input before it reaches the CBOR decoder. The sibling path in
+      // packages/mobile already enforces a base64url alphabet and a 128KB cap
+      // via unwrapOpaqueToken; this one decoded whatever arrived, bounded only
+      // by the HTTP body limit.
+      if (typeof input.token !== 'string'
+          || input.token.length > 174_764
+          || !/^[A-Za-z0-9_-]*$/.test(input.token)) {
+        return { valid: false, reason: 'attestation_token_out_of_bounds' };
+      }
       const attestationBytes = Buffer.from(input.token, 'base64url');
       const inspected = inspectAppleAttestation(attestationBytes);
       const signals = verifyAppleRuntimeSignals(inspected.authenticatorData, config);

--- a/tests/gate-commit-binding.test.ts
+++ b/tests/gate-commit-binding.test.ts
@@ -43,6 +43,24 @@ const issueRequest = {
 };
 
 describe('gate commit exact-action binding', () => {
+  it('refuses symbol-keyed members rather than dropping them from the hash', () => {
+    // Object.keys does not see symbol members, so without this refusal they
+    // would be absent from the normalized binding and therefore absent from the
+    // hash, while staying readable on the caller's original object. Every other
+    // canonicalizer in the tree routes through canonicalizeStrictJson, which
+    // refuses them; this walk needed the same rule.
+    const tainted: Record<string, unknown> = { ...gateRequest };
+    tainted.scope = { ...(gateRequest.scope as Record<string, unknown>) };
+    (tainted.scope as Record<symbol, unknown>)[Symbol.for('hidden_override')] = {
+      max_value_usd: 999_999,
+    };
+
+    expect(() => buildGateCommitBindingFromGateRequest(tainted))
+      .toThrow(GateCommitBindingError);
+    expect(() => buildGateCommitBindingFromGateRequest(tainted))
+      .toThrow(/symbol-keyed/i);
+  });
+
   it('joins equivalent gate and issue requests despite key order and ref placement', () => {
     const gateBinding = buildGateCommitBindingFromGateRequest(gateRequest);
     const issueBinding = buildGateCommitBindingFromIssueRequest(issueRequest);

--- a/tests/mobile-production-attestation.test.ts
+++ b/tests/mobile-production-attestation.test.ts
@@ -568,6 +568,22 @@ describe('mobile production attestation adapters', () => {
       expected_app_id: base.iosBundleId,
       expected_attestation_key_id: 'apple-key',
     };
+    const boundedInspector = vi.fn(() => ({ authenticatorData: appleAuthenticatorData() }));
+    const boundedVerifier = createPlatformEnrollmentVerifier({
+      config: base,
+      playDecoder: async () => ({}),
+      inspectAppleAttestation: boundedInspector,
+    });
+    await expect(boundedVerifier({ ...validInput, token: 'not+base64url' })).resolves.toEqual({
+      valid: false,
+      reason: 'attestation_token_out_of_bounds',
+    });
+    await expect(boundedVerifier({ ...validInput, token: 'a'.repeat(174_765) })).resolves.toEqual({
+      valid: false,
+      reason: 'attestation_token_out_of_bounds',
+    });
+    expect(boundedInspector).not.toHaveBeenCalled();
+
     const noAndroid = createPlatformEnrollmentVerifier({ config: base, playDecoder: async () => ({}) });
     await expect(noAndroid({ ...validInput, platform: 'android' })).resolves.toEqual({ valid: false });
     for (const mutation of [


### PR DESCRIPTION
## Summary

Closes the two remaining verified items from the hostile-audit sweep on current main:

- refuse symbol-keyed members in the gate commit-binding walk instead of silently omitting them from the hash
- reject malformed or oversized iOS enrollment attestation tokens before CBOR inspection

Thirteen other reported canonicalizers were executed and confirmed to delegate to the strict JSON implementation already; they were false positives, not additional fixes.

## Verification

- 43/43 targeted tests pass across gate commit binding and production mobile attestation
- `npm run typecheck:lib` passes
- symbol guard is mutation-discriminating
- token-bound regression proves malformed and oversized inputs never reach the attestation inspector
- all commits carry DCO sign-off

The symbol-key case is in-process only; symbols do not survive JSON parsing or structured cloning. The attestation-token case requires an authenticated paired mobile session. Both are fixed because the invariants are correct, without inflating the threat model.
