### PR TITLE
fix: publish the opening allowance status in the demo, and run it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,14 @@ jobs:
         run: |
           npm run check:standalone-runtimes
           node --test examples/action-escrow/scenario.test.mjs examples/action-escrow/standalone.test.mjs
+      # The allowance demo is the only executable end-to-end account of bounded
+      # spend: reserve, deplete, refuse a disallowed target, refuse an oversized
+      # payout, hold an indeterminate provider outcome, and rotate to a successor.
+      # It asserts its own outcomes and exits non-zero on any drift, but nothing
+      # ran it, so PR #469 could add a required allowance-status assertion and
+      # leave it broken on main undetected. It runs here now.
+      - name: Run the documented Gate allowance demo end to end
+        run: node examples/gate-allowance/demo.mjs
       - name: Verify the SYNC interoperability fixture and fail-closed chain boundary
         run: npm run test:sync-interop
       - name: Install the PostgreSQL client used by the live isolation test

--- a/examples/gate-allowance/demo.mjs
+++ b/examples/gate-allowance/demo.mjs
@@ -264,6 +264,22 @@ let activeStatus = {
   status_head_digest: digest('allowance-status:1'),
 };
 
+// Publish the opening status head before any spend is reserved. A spend whose
+// asserted status has no counterpart in the store is refused with
+// `allowance_status_not_initialized`, so an allowance that was signed but never
+// published cannot authorize anything. Initialization is the one advance that
+// asserts a null predecessor head; every later one names the head it replaces,
+// which is what makes the chain non-forkable.
+assert.equal((await capabilityStore.advanceAllowanceStatus({
+  allowance_profile_id: `${TENANT_ID}/${active.allowance.allowance_id}`,
+  allowance_digest: activeAllowanceDigest,
+  revision: active.allowance.revision,
+  expected_status_epoch: null,
+  expected_status_head_digest: null,
+  ...activeStatus,
+  status: 'active',
+})).ok, true);
+
 assert.equal(
   verifyGateAllowance(active.allowance, {
     trusted_keys: trustedAllowanceKeys,


### PR DESCRIPTION
The documented Gate allowance demo fails on `main` right now. Found while auditing what could actually be demonstrated to a partner from existing code.

## What broke

[#469](https://github.com/emiliaprotocol/emilia-protocol/pull/469) (`d19303be`, merged today) added a required allowance-status assertion to `reserveSpend`. `examples/gate-allowance/demo.mjs` advances the status head for the **successor** allowance at epoch 2, but never published epoch 1 for the original. So the first reserve was refused `allowance_status_not_initialized` and the run aborted at the in-policy payout, line 286.

```
$ node examples/gate-allowance/demo.mjs
AssertionError: false !== true
    at examples/gate-allowance/demo.mjs:286
```

**The refusal is correct and #469 is right.** An allowance that was signed but never published must not authorize a spend. The demo was asserting a spend against a status head that did not exist. Fixed by publishing the opening head before the first reserve. Initialization is the one advance that asserts a null predecessor head (`capability-receipt.ts:924-927`); every later advance names the head it replaces, which is what makes the chain non-forkable.

## The actual defect is the coverage gap

Nothing ran this file. Not a test, not a CI job:

```
$ grep -rn "gate-allowance" .github/workflows/ package.json tests/
(no matches)
```

It is the only executable end-to-end account of bounded spend in the repository: reserve, deplete, refuse a disallowed target, refuse an oversized payout, hold an indeterminate provider outcome without a blind retry, and rotate to a successor binding the predecessor digest. It asserts its own outcomes and exits non-zero on drift. It just was never invoked, so a correct hardening change could break the only runnable demonstration of the feature and merge green.

It now runs in CI beside the Action Escrow examples, in the same minimum-Node job.

## Verification

Demo exits 0 and reports every refusal path intact:

| Case | Result |
|---|---|
| in-policy payout | `allowed`, remaining **7500** |
| disallowed destination | `allowance_target_not_allowed` |
| oversized payout | `allowance_per_action_limit_exceeded` |
| provider response lost | `effect_indeterminate` |
| blind retry after indeterminate | `operation_already_committed` |
| retired allowance after rotation | `allowance_superseded` |
| successor payout | `allowed`, remaining **14000** |

`provider_calls: 3`, `credential_custody: local_process_only`, `hosted_service: not_used`.

**Mutation-tested.** Removing the initialization block returns the run to `allowance_status_not_initialized`, so the fix is load-bearing rather than cosmetic.

Two lines of scope discipline: no library code is touched, and the Stripe client in the demo is the existing local synthetic one. Nothing here reaches a real Stripe account.