### PR TITLE
ops: record Arena production migration

### DIFF
--- a/supabase/migration-history.v1.json
+++ b/supabase/migration-history.v1.json
@@ -1,23 +1,13 @@
 {
   "schema_version": "EP-MIGRATION-HISTORY-v1",
   "as_of": "2026-08-02",
-  "remote_head": "20260728210700",
+  "remote_head": "20260802120000",
   "private_remote_versions": [
     "20260723192504"
   ],
   "retroactive_pending_versions": [],
-  "forward_pending_versions": [
-    "20260801010000",
-    "20260802090000",
-    "20260802091000",
-    "20260802120000"
-  ],
-  "deployment_sequence": [
-    "20260801010000",
-    "20260802090000",
-    "20260802091000",
-    "20260802120000"
-  ],
+  "forward_pending_versions": [],
+  "deployment_sequence": [],
   "requires_include_all": false,
   "remote_versions": [
     "001",
@@ -200,7 +190,11 @@
     "20260725203000",
     "20260725204500",
     "20260725210000",
-    "20260728210700"
+    "20260728210700",
+    "20260801010000",
+    "20260802090000",
+    "20260802091000",
+    "20260802120000"
   ],
   "public_files": {
     "001_emilia_core_schema.sql": "f5e3c6c40fdaf54fbfc7a986f1b7cb021bfa8bee21a81bac39fe2da15f654060",


### PR DESCRIPTION
Records the verified production journal after the Arena deployment.

- remote head: 20260802120000
- 185 public remote versions + 1 intentionally private historical version
- 0 pending migrations
- governed dry run: remote database up to date
- live schema-security: 765 assertions passed
- journal-vs-reality reconciliation: every declared object exists in production