### PR TITLE
fix: normalize Arena refusal timestamps

### DIFF
--- a/lib/arena/refusal.test.ts
+++ b/lib/arena/refusal.test.ts
@@ -78,6 +78,21 @@ describe('Arena refusal publication verification', () => {
     expect(result.current_reason).toBe('refusal_expired');
   });
 
+  it('accepts PostgreSQL microsecond rendering of the signed millisecond instant', () => {
+    const { projection } = fixture();
+    projection.attempt.created_at = '2026-08-02T12:00:00.000085+00:00';
+    const result = verifyArenaPublicProjection(projection, Date.parse('2026-08-02T12:01:00.000Z'));
+    expect(result.integrity_verified).toBe(true);
+  });
+
+  it('refuses a PostgreSQL timestamp in the next signed millisecond', () => {
+    const { projection } = fixture();
+    projection.attempt.created_at = '2026-08-02T12:00:00.001085+00:00';
+    const result = verifyArenaPublicProjection(projection, Date.parse('2026-08-02T12:01:00.000Z'));
+    expect(result.integrity_verified).toBe(false);
+    expect(result.reason).toBe('arena_projection_binding_mismatch');
+  });
+
   it.each(['amount', 'action_digest', 'public_key', 'reason', 'created_at'])('fails closed on projection or key substitution', (field) => {
     const { projection } = fixture();
     const tampered: any = structuredClone(projection);

--- a/lib/arena/refusal.ts
+++ b/lib/arena/refusal.ts
@@ -63,6 +63,13 @@ function isRecord(value: unknown): value is Record<string, any> {
     && Reflect.ownKeys(value).every((key) => typeof key === 'string');
 }
 
+function canonicalInstant(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const epochMilliseconds = Date.parse(value);
+  if (!Number.isFinite(epochMilliseconds)) return null;
+  return new Date(epochMilliseconds).toISOString();
+}
+
 function refusedResult(reason: string, currentReason = reason) {
   return {
     integrity_verified: false as const,
@@ -113,10 +120,14 @@ export function verifyArenaPublicProjection(projection: unknown, now = Date.now(
     if (!isRecord(statement.program) || typeof statement.nonce !== 'string') {
       return refusedResult('arena_refusal_invalid');
     }
+    const statementRefusedAt = canonicalInstant(statement.refused_at);
+    const attemptCreatedAt = canonicalInstant(projection.attempt.created_at);
     if (!Array.isArray(statement.failed_requirement_ids)
         || statement.failed_requirement_ids.length !== 1
         || statement.failed_requirement_ids[0] !== expectedRequirement
-        || statement.refused_at !== projection.attempt.created_at) {
+        || statementRefusedAt === null
+        || attemptCreatedAt === null
+        || statementRefusedAt !== attemptCreatedAt) {
       return refusedResult('arena_projection_binding_mismatch');
     }
     const trustedKeys = {

--- a/supabase/migration-history.v1.json
+++ b/supabase/migration-history.v1.json
@@ -6,8 +6,12 @@
     "20260723192504"
   ],
   "retroactive_pending_versions": [],
-  "forward_pending_versions": [],
-  "deployment_sequence": [],
+  "forward_pending_versions": [
+    "20260802193000"
+  ],
+  "deployment_sequence": [
+    "20260802193000"
+  ],
   "requires_include_all": false,
   "remote_versions": [
     "001",
@@ -380,6 +384,7 @@
     "20260801010000_trust_desk_review_transition.sql": "e36b6784bb2bb31da23e55b5d27a5eb237d07ea4ab7af23b7ef409fe3f0df4e9",
     "20260802090000_gate_allowance_currentness_atomicity.sql": "319a11f1430992bd7e9339d4ca55a61293ac8c6052af6870140dc64d37c91235",
     "20260802091000_gate_allowance_status_fortress_db_security_invariants.sql": "7f220f1a213d75f36334787ab94087e1f9365d0ab2cbcd7ef640dcd924ff407e",
-    "20260802120000_arena_synthetic_allowance.sql": "4c834f8c80e390bce0c77ea5b7dd3a76843df54fd450c0cd111a4f01eb5b0ee2"
+    "20260802120000_arena_synthetic_allowance.sql": "4c834f8c80e390bce0c77ea5b7dd3a76843df54fd450c0cd111a4f01eb5b0ee2",
+    "20260802193000_arena_refusal_timestamp_normalization.sql": "2c9fb784084b60c06aaa8795599a0ef91300ca8c604e99becacfb2937f9a45bb"
   }
 }

--- a/supabase/migrations/20260802193000_arena_refusal_timestamp_normalization.sql
+++ b/supabase/migrations/20260802193000_arena_refusal_timestamp_normalization.sql
@@ -1,0 +1,83 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Normalize the public Arena projection timestamp to the millisecond precision
+-- carried by EP-ACTION-REFUSAL-STATEMENT-v1. Existing projections remain
+-- verifiable through the runtime's instant-equivalence compatibility check.
+
+CREATE OR REPLACE FUNCTION public.publish_arena_refusal(
+  p_token_hash TEXT,
+  p_attempt_id TEXT
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $arena_publish$
+DECLARE
+  v_attempt public.arena_attempts%ROWTYPE;
+  v_session public.arena_sessions%ROWTYPE;
+  v_share public.arena_shares%ROWTYPE;
+  v_share_id TEXT;
+  v_projection JSONB;
+BEGIN
+  SELECT attempt.* INTO v_attempt
+  FROM public.arena_attempts AS attempt
+  JOIN public.arena_sessions AS session ON session.id = attempt.session_row_id
+  WHERE attempt.attempt_id = p_attempt_id AND session.token_hash = p_token_hash
+  FOR UPDATE OF attempt;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'status', 404, 'reason', 'arena_attempt_not_found');
+  END IF;
+  SELECT * INTO v_session
+  FROM public.arena_sessions
+  WHERE id = v_attempt.session_row_id;
+  IF v_attempt.decision <> 'refuse' OR v_attempt.evidence_status <> 'complete' THEN
+    RETURN jsonb_build_object('ok', false, 'status', 409, 'reason', 'arena_refusal_not_publishable');
+  END IF;
+
+  SELECT * INTO v_share FROM public.arena_shares WHERE attempt_id = p_attempt_id;
+  IF FOUND THEN
+    RETURN jsonb_build_object('ok', true, 'idempotent', true, 'share_id', v_share.share_id);
+  END IF;
+
+  v_share_id := 'arena_share_' || pg_catalog.encode(extensions.gen_random_bytes(20), 'hex');
+  v_projection := jsonb_build_object(
+    'profile', 'EP-ARENA-PUBLIC-REFUSAL-v1',
+    'challenge_id', v_session.challenge_id,
+    'challenge_version', v_session.challenge_version,
+    'attempt', jsonb_build_object(
+      'attempt_id', v_attempt.attempt_id,
+      'action', v_attempt.action,
+      'caid', v_attempt.caid,
+      'action_digest', v_attempt.action_digest,
+      'decision', v_attempt.decision,
+      'reason', v_attempt.reason,
+      'created_at', pg_catalog.to_char(
+        v_attempt.created_at AT TIME ZONE 'UTC',
+        'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+      )
+    ),
+    'refusal_artifact', v_attempt.refusal_artifact,
+    'refusal_digest', v_attempt.refusal_digest,
+    'issuer', jsonb_build_object(
+      'issuer_id', v_session.issuer_id,
+      'key_id', v_session.key_id,
+      'public_key', v_session.public_key
+    ),
+    'claim_boundary', 'synthetic_challenge_not_identity_competence_certification_money_or_production_authority'
+  );
+
+  INSERT INTO public.arena_shares (
+    share_id, tenant_id, session_row_id, session_id, challenge_id,
+    challenge_version, attempt_id, attempt_nonce, public_projection
+  ) VALUES (
+    v_share_id, v_session.tenant_id, v_session.id, v_session.session_id,
+    v_session.challenge_id, v_session.challenge_version, v_attempt.attempt_id,
+    v_attempt.attempt_nonce, v_projection
+  );
+  RETURN jsonb_build_object('ok', true, 'idempotent', false, 'share_id', v_share_id);
+END
+$arena_publish$;
+
+REVOKE ALL ON FUNCTION public.publish_arena_refusal(TEXT, TEXT)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.publish_arena_refusal(TEXT, TEXT)
+  TO service_role;

--- a/tests/arena-timestamp-migration-contract.test.ts
+++ b/tests/arena-timestamp-migration-contract.test.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const migration = readFileSync(
+  `${root}/supabase/migrations/20260802193000_arena_refusal_timestamp_normalization.sql`,
+  'utf8',
+);
+
+describe('Arena refusal timestamp normalization migration', () => {
+  it('replaces only the token-bound, service-role publication function', () => {
+    expect(migration.match(/CREATE OR REPLACE FUNCTION public\.publish_arena_refusal/g)).toHaveLength(1);
+    expect(migration).toContain('SECURITY DEFINER');
+    expect(migration).toContain("SET search_path = ''");
+    expect(migration).toMatch(
+      /WHERE attempt\.attempt_id = p_attempt_id AND session\.token_hash = p_token_hash/,
+    );
+    expect(migration).toContain(
+      'REVOKE ALL ON FUNCTION public.publish_arena_refusal(TEXT, TEXT)\n  FROM PUBLIC, anon, authenticated;',
+    );
+    expect(migration).toContain(
+      'GRANT EXECUTE ON FUNCTION public.publish_arena_refusal(TEXT, TEXT)\n  TO service_role;',
+    );
+  });
+
+  it('projects the refusal instant at the signed millisecond precision', () => {
+    expect(migration).toContain("v_attempt.created_at AT TIME ZONE 'UTC'");
+    expect(migration).toContain("'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"'");
+    expect(migration).not.toContain("'created_at', v_attempt.created_at\n");
+  });
+
+  it('keeps the public projection privacy-minimized', () => {
+    const projection = migration.match(
+      /v_projection := jsonb_build_object\(([\s\S]*?)\n  \);\n\n  INSERT INTO public\.arena_shares/,
+    );
+    expect(projection).not.toBeNull();
+    expect(projection![1]).not.toMatch(
+      /token_hash|private_key_encrypted|agent_name|allowance_profile|'limits'|tenant_id|session_id/,
+    );
+  });
+});


### PR DESCRIPTION
## Outcome\n- accepts PostgreSQL microsecond rendering for the same signed millisecond instant\n- still rejects a next-millisecond substitution\n- emits future public projections at canonical millisecond precision\n- preserves the applied Arena migration and records the forward migration\n\n## Verification\n- 55 focused Arena tests passed\n- lib and app TypeScript checks passed\n- migration history verified: 185 remote, 1 private, 1 pending\n- staged lint and license checks passed\n\n## Live finding\nProduction refusal signing and publication succeeded, but PostgreSQL rendered the attempt at microsecond precision while the signed statement uses JavaScript millisecond precision. All cryptographic and action bindings matched; only bytewise timestamp equality failed. This patch compares the same instant at the signed precision and canonicalizes future projections.