### PR TITLE
ops: record Arena timestamp migration

### DIFF
--- a/supabase/migration-history.v1.json
+++ b/supabase/migration-history.v1.json
@@ -1,17 +1,13 @@
 {
   "schema_version": "EP-MIGRATION-HISTORY-v1",
   "as_of": "2026-08-02",
-  "remote_head": "20260802120000",
+  "remote_head": "20260802193000",
   "private_remote_versions": [
     "20260723192504"
   ],
   "retroactive_pending_versions": [],
-  "forward_pending_versions": [
-    "20260802193000"
-  ],
-  "deployment_sequence": [
-    "20260802193000"
-  ],
+  "forward_pending_versions": [],
+  "deployment_sequence": [],
   "requires_include_all": false,
   "remote_versions": [
     "001",
@@ -198,7 +194,8 @@
     "20260801010000",
     "20260802090000",
     "20260802091000",
-    "20260802120000"
+    "20260802120000",
+    "20260802193000"
   ],
   "public_files": {
     "001_emilia_core_schema.sql": "f5e3c6c40fdaf54fbfc7a986f1b7cb021bfa8bee21a81bac39fe2da15f654060",


### PR DESCRIPTION
Records production application of the Arena refusal timestamp normalization.\n\nVerification:\n- live schema contract: 765 assertions passed\n- migration journal vs reality: every declared object exists\n- governed Supabase dry run: remote database is up to date\n- migration history checker: 186 remote, 1 private, 0 pending