### PR TITLE
fix: restore Agent Adoption migration role

### DIFF
--- a/supabase/migrations/20260802230000_agent_adoption_v1.sql
+++ b/supabase/migrations/20260802230000_agent_adoption_v1.sql
@@ -38,6 +38,15 @@ BEGIN
 END
 $least_privilege_role$;
 
+-- Supabase may execute with a managed migration role over a different wire
+-- login. Remember the actual migration role before switching to the private
+-- owner so cleanup restores and revokes the same principal on every PostgreSQL
+-- 17 deployment, without assuming that a role named `postgres` exists.
+SELECT pg_catalog.set_config(
+  'ep.agent_adoption_migration_role',
+  CURRENT_USER,
+  TRUE
+);
 GRANT agent_adoption_store_owner TO CURRENT_USER
   WITH INHERIT FALSE, SET TRUE;
 GRANT USAGE, CREATE ON SCHEMA public TO agent_adoption_store_owner;
@@ -2513,6 +2522,16 @@ COMMENT ON TABLE agent_adoption_private.adoption_revocations IS
 COMMENT ON TABLE agent_adoption_private.share_revocations IS
   'Append-only public-share revocations; source shares remain immutable.';
 
-RESET ROLE;
+-- RESET ROLE can return the Supabase CLI to its restricted wire login rather
+-- than the managed migration role. Restore the exact role captured above;
+-- SET ROLE authorization is checked against the session identity.
+DO $restore_migration_role$
+BEGIN
+  EXECUTE pg_catalog.format(
+    'SET ROLE %I',
+    pg_catalog.current_setting('ep.agent_adoption_migration_role')
+  );
+END
+$restore_migration_role$;
 REVOKE CREATE ON SCHEMA public FROM agent_adoption_store_owner;
 REVOKE agent_adoption_store_owner FROM CURRENT_USER;

--- a/tests/agent-adoption-migration-contract.test.ts
+++ b/tests/agent-adoption-migration-contract.test.ts
@@ -47,6 +47,21 @@ function functionBody(name: string, delimiter: string): string {
 }
 
 describe('Agent Adoption v1 migration contract', () => {
+  it('restores the exact migration role before removing temporary owner membership', () => {
+    expect(migration).toContain(
+      "SELECT pg_catalog.set_config(\n  'ep.agent_adoption_migration_role',\n  CURRENT_USER,\n  TRUE\n);",
+    );
+    expect(migration).toContain(
+      'GRANT agent_adoption_store_owner TO CURRENT_USER\n  WITH INHERIT FALSE, SET TRUE;',
+    );
+    expect(migration).toContain(
+      "EXECUTE pg_catalog.format(\n    'SET ROLE %I',\n    pg_catalog.current_setting('ep.agent_adoption_migration_role')\n  );",
+    );
+    expect(migration).toContain(
+      'REVOKE CREATE ON SCHEMA public FROM agent_adoption_store_owner;\nREVOKE agent_adoption_store_owner FROM CURRENT_USER;',
+    );
+  });
+
   it('uses a private least-privilege owner, forced RLS, owner-only policies, and no direct API-role ACLs', () => {
     expect(migration).toContain('CREATE SCHEMA agent_adoption_private\n  AUTHORIZATION agent_adoption_store_owner;');
     expect(migration).toContain(


### PR DESCRIPTION
## Summary
- preserve the exact managed migration role before entering the private owner role
- restore that role dynamically instead of resetting to Supabase's restricted wire login
- remove the temporary owner membership after object creation

## Verification
- agent-adoption migration contract: 14/14
- clean PostgreSQL 17 Agent Adoption integration: 8/8
- production dry run previously selected exactly the three Agent Adoption migrations

This fixes the fail-closed production migration refusal observed before any migration history advanced.

Signed-off-by: Iman Schrock <team@emiliaprotocol.ai>