### PR TITLE
chore: record Agent Adoption migrations

### DIFF
--- a/supabase/migration-history.v1.json
+++ b/supabase/migration-history.v1.json
@@ -1,21 +1,13 @@
 {
   "schema_version": "EP-MIGRATION-HISTORY-v1",
   "as_of": "2026-08-02",
-  "remote_head": "20260802193000",
+  "remote_head": "20260802232000",
   "private_remote_versions": [
     "20260723192504"
   ],
   "retroactive_pending_versions": [],
-  "forward_pending_versions": [
-    "20260802230000",
-    "20260802231000",
-    "20260802232000"
-  ],
-  "deployment_sequence": [
-    "20260802230000",
-    "20260802231000",
-    "20260802232000"
-  ],
+  "forward_pending_versions": [],
+  "deployment_sequence": [],
   "requires_include_all": false,
   "remote_versions": [
     "001",
@@ -203,7 +195,10 @@
     "20260802090000",
     "20260802091000",
     "20260802120000",
-    "20260802193000"
+    "20260802193000",
+    "20260802230000",
+    "20260802231000",
+    "20260802232000"
   ],
   "public_files": {
     "001_emilia_core_schema.sql": "f5e3c6c40fdaf54fbfc7a986f1b7cb021bfa8bee21a81bac39fe2da15f654060",
@@ -391,7 +386,7 @@
     "20260802091000_gate_allowance_status_fortress_db_security_invariants.sql": "7f220f1a213d75f36334787ab94087e1f9365d0ab2cbcd7ef640dcd924ff407e",
     "20260802120000_arena_synthetic_allowance.sql": "4c834f8c80e390bce0c77ea5b7dd3a76843df54fd450c0cd111a4f01eb5b0ee2",
     "20260802193000_arena_refusal_timestamp_normalization.sql": "2c9fb784084b60c06aaa8795599a0ef91300ca8c604e99becacfb2937f9a45bb",
-    "20260802230000_agent_adoption_v1.sql": "937e1c7983b6b628cf01351c849346961f1846679ec2e15b5dec6e484855735a",
+    "20260802230000_agent_adoption_v1.sql": "4dac867dd9bd695f9640d8623cbc68e3f0659ff0a87587b1f7f5994f20cb09bf",
     "20260802231000_restore_webauthn_directory_anchor.sql": "90bb596edff8f495de541ab5df582fb45023abff077fc527a48eea4e635afd76",
     "20260802232000_scim_authority_atomic.sql": "334619a03c3a089d3ae038ab9b20dd4c3dab28a9af0eff0b12ac3b2bdfd38e92"
   }


### PR DESCRIPTION
## Summary
- record the three applied Agent Adoption migrations in the governed migration ledger
- advance the remote head to 20260802232000
- clear the forward deployment queue
- update the corrected Agent Adoption migration hash pin

## Verification
- linked production migration list shows all three versions on both local and remote sides
- migration history validator: 189 remote, 1 private, 0 pending, 188 public SQL files

Signed-off-by: Iman Schrock <team@emiliaprotocol.ai>