### PR TITLE
ci(deps): update CodeQL action coherently to 4.37.4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,9 +32,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4
         with:
           languages: javascript
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -40,6 +40,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Outcome

Supersedes Dependabot PRs #490, #491, and #493 by updating CodeQL `init`, `analyze`, and `upload-sarif` together to 4.37.4 at the exact peeled commit `f205ea1c3313d32999d8d6a48b4f6530d4437b38`.

## Why one change

The split bot PRs are semantically unsafe alone: one mixes `init@4.37.4` with `analyze@4.37.3`, and another creates the inverse mismatch. This commit preserves one version across the complete CodeQL lifecycle.

## Verification

- exact three-reference SHA/version contract
- actionlint 1.7.12
- YAML syntax parsing
- write-discipline check
- diff boundary and DCO Signed-off-by

