### PR TITLE
test: exercise Agent Record readiness in production E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1186,7 +1186,10 @@ jobs:
         env:
           # next build needs valid envs at compile time; supply minimal stubs
           # so the build doesn't fail trying to read real secrets.
-          NEXT_PUBLIC_SUPABASE_URL: 'https://e2e.supabase.local'
+          # The production page executes its readiness probe at request time.
+          # Compile the same loopback URL that Playwright's inert RPC stub owns
+          # so Agent Record recovery is exercised without a real deployment.
+          NEXT_PUBLIC_SUPABASE_URL: 'http://127.0.0.1:54321'
           NEXT_PUBLIC_SUPABASE_ANON_KEY: 'e2e-anon-key'
       - name: Run E2E smoke tests
         run: npx playwright test
@@ -1194,7 +1197,7 @@ jobs:
           CI: 'true'
           # `next start` re-reads NEXT_PUBLIC_* at boot for runtime config —
           # keep parity with the build step so the production server starts.
-          NEXT_PUBLIC_SUPABASE_URL: 'https://e2e.supabase.local'
+          NEXT_PUBLIC_SUPABASE_URL: 'http://127.0.0.1:54321'
           NEXT_PUBLIC_SUPABASE_ANON_KEY: 'e2e-anon-key'
       - name: Upload Playwright report
         if: always()

--- a/e2e/agent-record-readiness-stub.mjs
+++ b/e2e/agent-record-readiness-stub.mjs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'node:http';
+
+const HOST = '127.0.0.1';
+const PORT = 54_321;
+const SERVICE_ROLE_KEY = 'e2e-service-role-key';
+const UPSTASH_TOKEN = 'e2e-upstash-token';
+const CREATION_CAPABILITY = `earc1_${'0'.repeat(64)}`;
+
+const ERROR_CODE_BY_RPC = Object.freeze({
+  create_agent_record_with_capability: '22023',
+  read_agent_adoption_session: 'P0002',
+  read_agent_record_refusal_source: 'P0002',
+  read_agent_record_public: 'P0002',
+  revoke_agent_record: '22023',
+});
+
+function reply(response, status, body) {
+  response.writeHead(status, {
+    'content-type': 'application/json',
+    'cache-control': 'no-store',
+  });
+  response.end(JSON.stringify(body));
+}
+
+async function readJson(request) {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of request) {
+    size += chunk.length;
+    if (size > 64 * 1024) throw new Error('request_too_large');
+    chunks.push(chunk);
+  }
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+}
+
+const server = http.createServer(async (request, response) => {
+  if (request.method === 'GET' && request.url === '/health') {
+    return reply(response, 200, { status: 'ready' });
+  }
+  if (request.method === 'POST'
+      && request.url === '/upstash'
+      && request.headers.authorization === `Bearer ${UPSTASH_TOKEN}`) {
+    let command;
+    try {
+      command = await readJson(request);
+    } catch {
+      return reply(response, 400, { error: 'invalid_json' });
+    }
+    const maximum = Number(command?.[5]);
+    const windowSeconds = Number(command?.[6]);
+    if (!Array.isArray(command)
+        || command[0] !== 'EVAL'
+        || command[2] !== '1'
+        || !Number.isSafeInteger(maximum)
+        || maximum < 1
+        || !Number.isSafeInteger(windowSeconds)
+        || windowSeconds < 1) {
+      return reply(response, 400, { error: 'unexpected_rate_limit_command' });
+    }
+    return reply(response, 200, { result: [1, maximum - 1, windowSeconds] });
+  }
+  if (request.method !== 'POST'
+      || !request.url?.startsWith('/rest/v1/rpc/')
+      || request.headers.apikey !== SERVICE_ROLE_KEY
+      || request.headers.authorization !== `Bearer ${SERVICE_ROLE_KEY}`) {
+    return reply(response, 404, { code: 'not_found' });
+  }
+
+  const rpc = request.url.slice('/rest/v1/rpc/'.length);
+  let input;
+  try {
+    input = await readJson(request);
+  } catch {
+    return reply(response, 400, { code: 'invalid_json' });
+  }
+
+  if (rpc === 'check_agent_record_creation_capability') {
+    return reply(response, 200, input?.p_creation_capability === CREATION_CAPABILITY);
+  }
+  if (rpc === 'check_agent_record_storage_contract') {
+    return reply(response, 200, input && Object.keys(input).length === 0);
+  }
+
+  const expectedCode = ERROR_CODE_BY_RPC[rpc];
+  if (!expectedCode) return reply(response, 404, { code: 'unknown_rpc' });
+  return reply(response, 400, {
+    code: expectedCode,
+    details: null,
+    hint: null,
+    message: 'Expected inert E2E readiness probe.',
+  });
+});
+
+server.listen(PORT, HOST);
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => server.close(() => process.exit(0)));
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -8,6 +8,17 @@
 
 import { defineConfig, devices } from '@playwright/test';
 
+const agentRecordE2eEnvironment = {
+  NEXT_PUBLIC_SUPABASE_URL: 'http://127.0.0.1:54321',
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: 'e2e-anon-key',
+  SUPABASE_SERVICE_ROLE_KEY: 'e2e-service-role-key',
+  EP_COMMIT_SIGNING_KEY: Buffer.alloc(32, 1).toString('base64'),
+  EP_AGENT_RECORD_SIGNING_KEY_ID: 'e2e-agent-record-signing-key',
+  EP_AGENT_RECORD_CREATION_CAPABILITY: `earc1_${'0'.repeat(64)}`,
+  UPSTASH_REDIS_REST_URL: 'http://127.0.0.1:54321/upstash',
+  UPSTASH_REDIS_REST_TOKEN: 'e2e-upstash-token',
+};
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -35,10 +46,26 @@ export default defineConfig({
   // bundle). Locally, run against `npm run dev` for fast iteration. The dev
   // server's startup cost + hot-reload noise was the root cause of flaky CI
   // boots; the production server boots in ~3s and behaves exactly like prod.
-  webServer: {
-    command: process.env.CI ? 'npm run start' : 'npm run dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-  },
+  webServer: process.env.CI
+    ? [
+        {
+          command: 'node e2e/agent-record-readiness-stub.mjs',
+          url: 'http://127.0.0.1:54321/health',
+          reuseExistingServer: false,
+          timeout: 30_000,
+        },
+        {
+          command: 'npm run start',
+          url: 'http://localhost:3000',
+          reuseExistingServer: false,
+          timeout: 120_000,
+          env: agentRecordE2eEnvironment,
+        },
+      ]
+    : {
+        command: 'npm run dev',
+        url: 'http://localhost:3000',
+        reuseExistingServer: true,
+        timeout: 120_000,
+      },
 });


### PR DESCRIPTION
## Why

The main retry exposed that the Agent Record recovery E2E mocked browser APIs but never satisfied the production page's server-side readiness contract. The UI therefore correctly failed closed and four recovery tests became nondeterministic.

## Fix

- run a loopback-only inert PostgREST/Upstash contract during CI E2E
- exercise the real Agent Record readiness RPCs without a production bypass
- compile and boot the production bundle against the same loopback endpoint
- keep local developer Playwright behavior unchanged

## Verification

- production Next.js build: pass
- Playwright: 20 passed, 2 intentional skips
- focused Agent Record recovery: 5/5
- app typecheck: pass
- language governance: pass
- readiness/UI contracts: 25/25

No production credential, deployment, database, or public API behavior is changed.