### PR TITLE
Standards Track Authorization Receipts -09

### DIFF
--- a/scripts/check-authorization-receipts-09.mjs
+++ b/scripts/check-authorization-receipts-09.mjs
@@ -29,7 +29,7 @@ invariant(
 const xml = readFileSync(new URL(`UPLOAD-THIS/${basename}.xml`, root), 'utf8');
 invariant(xml.includes(`docName="${basename}"`), 'docName must match the -09 filename');
 invariant(xml.includes('category="std"'), 'The -09 candidate must be Standards Track');
-invariant(xml.includes('submissionType="IETF"'), 'submissionType must be IETF');
+invariant(!xml.includes('submissionType='), 'An individual draft must not claim an adopted document stream');
 invariant(xml.includes('<xref target="EP-CAID"/>'), 'CAID must be cited in the text');
 invariant(xml.includes('<xref target="EP-QUORUM"/>'), 'EP-QUORUM must be cited in the text');
 

--- a/scripts/check-authorization-receipts-09.mjs
+++ b/scripts/check-authorization-receipts-09.mjs
@@ -1,0 +1,57 @@
+import { createHash } from 'node:crypto';
+import { readFileSync, readdirSync } from 'node:fs';
+
+const root = new URL('../standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/', import.meta.url);
+const upload = new URL('UPLOAD-THIS/', root);
+const renders = new URL('RENDERS/', root);
+const basename = 'draft-schrock-ep-authorization-receipts-09';
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+const uploadFiles = readdirSync(upload).sort();
+invariant(
+  JSON.stringify(uploadFiles) === JSON.stringify([`${basename}.xml`]),
+  'The -09 upload directory must contain exactly one XML source',
+);
+
+const renderFiles = readdirSync(renders).sort();
+invariant(
+  JSON.stringify(renderFiles) === JSON.stringify([`${basename}.html`, `${basename}.txt`]),
+  'The -09 render directory must contain exactly one HTML and TXT rendering',
+);
+
+const xml = readFileSync(new URL(`UPLOAD-THIS/${basename}.xml`, root), 'utf8');
+invariant(xml.includes(`docName="${basename}"`), 'docName must match the -09 filename');
+invariant(xml.includes('category="std"'), 'The -09 candidate must be Standards Track');
+invariant(xml.includes('submissionType="IETF"'), 'submissionType must be IETF');
+invariant(xml.includes('<xref target="EP-CAID"/>'), 'CAID must be cited in the text');
+invariant(xml.includes('<xref target="EP-QUORUM"/>'), 'EP-QUORUM must be cited in the text');
+
+const resources = JSON.parse(readFileSync(new URL('ADDITIONAL-RESOURCES.json', root), 'utf8'));
+const resourceRows = resources[basename];
+invariant(Array.isArray(resourceRows) && resourceRows.length >= 3, 'Additional Resources are incomplete');
+for (const row of resourceRows) {
+  invariant(['github_repo', 'related_implementations'].includes(row.tag), `Unexpected resource tag: ${row.tag}`);
+  invariant(/^https:\/\//.test(row.url), `Resource URL must be HTTPS: ${row.url}`);
+}
+
+const manifest = readFileSync(new URL('SHA256SUMS.txt', root), 'utf8').trim().split('\n');
+const expectedPaths = [
+  `UPLOAD-THIS/${basename}.xml`,
+  `RENDERS/${basename}.html`,
+  `RENDERS/${basename}.txt`,
+];
+invariant(manifest.length === expectedPaths.length, 'Checksum manifest must contain exactly three entries');
+for (const [index, relative] of expectedPaths.entries()) {
+  const match = /^([a-f0-9]{64})  (.+)$/.exec(manifest[index]);
+  invariant(match && match[2] === relative, `Malformed checksum entry for ${relative}`);
+  invariant(sha256(readFileSync(new URL(relative, root))) === match[1], `Checksum mismatch for ${relative}`);
+}
+
+console.log('Authorization Receipts -09: source, renders, metadata, and checksums PASS.');

--- a/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/ADDITIONAL-RESOURCES.json
+++ b/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/ADDITIONAL-RESOURCES.json
@@ -1,0 +1,20 @@
+{
+  "draft-schrock-ep-authorization-receipts-09": [
+    {
+      "tag": "github_repo",
+      "url": "https://github.com/emiliaprotocol/emilia-protocol"
+    },
+    {
+      "tag": "related_implementations",
+      "url": "https://github.com/emiliaprotocol/emilia-protocol/blob/main/packages/verify/src/index.ts"
+    },
+    {
+      "tag": "related_implementations",
+      "url": "https://github.com/emiliaprotocol/emilia-protocol/blob/main/packages/issue/src/index.ts"
+    },
+    {
+      "tag": "related_implementations",
+      "url": "https://github.com/emiliaprotocol/emilia-protocol/blob/main/conformance/external/rust-cleanroom-jdieselny.v1.json"
+    }
+  ]
+}

--- a/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/ADDITIONAL-RESOURCES.md
+++ b/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/ADDITIONAL-RESOURCES.md
@@ -1,0 +1,11 @@
+# Datatracker Additional Resources
+
+Enter the tag token and URL into the Datatracker's separate fields. Do not
+paste `tag: URL` into the Tag field.
+
+| Tag | URL |
+| --- | --- |
+| `github_repo` | `https://github.com/emiliaprotocol/emilia-protocol` |
+| `related_implementations` | `https://github.com/emiliaprotocol/emilia-protocol/blob/main/packages/verify/src/index.ts` |
+| `related_implementations` | `https://github.com/emiliaprotocol/emilia-protocol/blob/main/packages/issue/src/index.ts` |
+| `related_implementations` | `https://github.com/emiliaprotocol/emilia-protocol/blob/main/conformance/external/rust-cleanroom-jdieselny.v1.json` |

--- a/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/README.md
+++ b/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/README.md
@@ -1,0 +1,16 @@
+# Authorization Receipts -09 upload packet
+
+This directory is the isolated upload packet for
+`draft-schrock-ep-authorization-receipts-09`. It is deliberately separate from
+the immutable August 3 six-draft provenance packet in `../UPLOAD-THIS/`.
+
+Upload only:
+
+- `UPLOAD-THIS/draft-schrock-ep-authorization-receipts-09.xml`
+
+Revision -09 changes the intended status to Standards Track and clarifies how
+the receipt composes with adjacent authorization work. It does not change the
+receipt schema, canonicalization, signature inputs, or consumption rules.
+
+The document remains an individual Internet-Draft. Submission does not make it
+an RFC, a working-group document, IETF consensus, or IETF endorsement.

--- a/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/RENDERS/draft-schrock-ep-authorization-receipts-09.html
+++ b/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/RENDERS/draft-schrock-ep-authorization-receipts-09.html
@@ -1,0 +1,3503 @@
+<!DOCTYPE html>
+<html lang="en" class="Internet-Draft">
+<head>
+<meta charset="utf-8">
+<meta content="Common,Latin" name="scripts">
+<meta content="initial-scale=1.0" name="viewport">
+<title>Authorization Receipts for High-Risk Agent Actions</title>
+<meta content="Iman Schrock" name="author">
+<meta content="
+       This document defines the EMILIA Protocol (EP) authorization
+      receipt, an evidence artifact binding an enrolled approver key to
+      one canonical action before execution. An approver-held key signs an
+      Authorization Context containing the action hash, policy reference,
+      nonce, audience, and validity window. A Trust Receipt carries the
+      signed contexts, terminal consumption record, and Merkle inclusion
+      material so a relying party can verify the recorded event offline
+      under independently selected log, directory, policy, and approver
+      trust inputs.
+       The receipt establishes only the guarantees of the selected
+      verification profile. The mapping from an enrolled approver
+      identifier to a natural person is asserted by the directory
+      authority. Offline verification does not establish current
+      revocation status, global non-replay, comprehension, legality,
+      safety, or execution. Replay prevention requires an online atomic
+      consumption store at the executor. The state-machine invariants are
+      machine-checked under the assumptions stated in this document.
+       A receipt is evidence, not authorization. This document does not
+      treat a local user interaction as an authorization decision. Section
+      10.7 of   states that an agent
+      MUST NOT treat local UI confirmation alone as sufficient
+      authorization, and notes that additional specification or design work
+      may be needed for user confirmation occurring mid-execution, since CIBA accounts
+      only for client initiation. This document defines one evidence
+      artifact that an authorization architecture can use in such a flow:
+      the signed Authorization Context is action-bound confirmation evidence
+      an authorization server MAY validate and bind to the grant it issues.
+      The resulting Trust Receipt records terminal consumption and remains
+      evidence; neither object makes the authorization decision. That
+      decision remains with the authorization server.
+    " name="description">
+<meta content="xml2rfc 3.34.0" name="generator">
+<meta content="AI agents" name="keyword">
+<meta content="authorization" name="keyword">
+<meta content="receipts" name="keyword">
+<meta content="WebAuthn" name="keyword">
+<meta content="separation of duties" name="keyword">
+<meta content="draft-schrock-ep-authorization-receipts-09" name="ietf.draft">
+<!-- Generator version information:
+  xml2rfc 3.34.0
+    Python 3.14.5
+    ConfigArgParse 1.7.5
+    google-i18n-address 3.1.1
+    intervaltree 3.2.1
+    Jinja2 3.1.6
+    lxml 6.1.1
+    natsort 8.4.0
+    platformdirs 4.10.0
+    pycountry 26.2.16
+    PyYAML 6.0.3
+    requests 2.34.2
+    wcwidth 0.8.1
+-->
+<link href="draft-schrock-ep-authorization-receipts-09.xml" rel="alternate" type="application/rfc+xml">
+<link href="#copyright" rel="license">
+<style type="text/css">/*
+
+  NOTE: Changes at the bottom of this file overrides some earlier settings.
+
+  Once the style has stabilized and has been adopted as an official RFC style,
+  this can be consolidated so that style settings occur only in one place, but
+  for now the contents of this file consists first of the initial CSS work as
+  provided to the RFC Formatter (xml2rfc) work, followed by itemized and
+  commented changes found necessary during the development of the v3
+  formatters.
+
+*/
+
+/* fonts */
+@import url('https://static.ietf.org/fonts/noto-sans/import.css'); /* Sans-serif */
+@import url('https://static.ietf.org/fonts/noto-serif/import.css'); /* Serif (print) */
+@import url('https://static.ietf.org/fonts/roboto-mono/import.css'); /* Monospace */
+
+:root {
+  --font-sans: 'Noto Sans', Arial, Helvetica, sans-serif;
+  --font-serif: 'Noto Serif', 'Times', 'Times New Roman', serif;
+  --font-mono: 'Roboto Mono', Courier, 'Courier New', monospace;
+}
+
+@viewport {
+  zoom: 1.0;
+}
+@-ms-viewport {
+  width: extend-to-zoom;
+  zoom: 1.0;
+}
+/* general and mobile first */
+html {
+}
+body {
+  max-width: 90%;
+  margin: 1.5em auto;
+  color: #222;
+  background-color: #fff;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  line-height: 1.6;
+  scroll-behavior: smooth;
+  overflow-wrap: break-word;
+}
+.ears {
+  display: none;
+}
+
+/* headings */
+#title, h1, h2, h3, h4, h5, h6 {
+  margin: 1em 0 0.5em;
+  font-weight: bold;
+  line-height: 1.3;
+}
+#title {
+  clear: both;
+  border-bottom: 1px solid #ddd;
+  margin: 0 0 0.5em 0;
+  padding: 1em 0 0.5em;
+}
+.author {
+  padding-bottom: 4px;
+}
+h1 {
+  font-size: 26px;
+  margin: 1em 0;
+}
+h2 {
+  font-size: 22px;
+  margin-top: -20px;  /* provide offset for in-page anchors */
+  padding-top: 33px;
+}
+h3 {
+  font-size: 18px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h4 {
+  font-size: 16px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h5, h6 {
+  font-size: 14px;
+}
+#n-copyright-notice {
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 1em;
+  margin-bottom: 1em;
+}
+/* general structure */
+p {
+  padding: 0;
+  margin: 0 0 1em 0;
+  text-align: left;
+}
+div, span {
+  position: relative;
+}
+div {
+  margin: 0;
+}
+.alignRight.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignRight.art-text pre {
+  padding: 0;
+}
+.alignRight {
+  margin: 1em 0;
+}
+.alignRight > *:first-child {
+  border: none;
+  margin: 0;
+  float: right;
+  clear: both;
+}
+.alignRight > *:nth-child(2) {
+  clear: both;
+  display: block;
+  border: none;
+}
+svg {
+  display: block;
+}
+@media print {
+  svg {
+    max-height: 850px;
+    max-width: 660px;
+  }
+}
+svg[font-family~="serif" i], svg [font-family~="serif" i] {
+  font-family: var(--font-serif);
+}
+svg[font-family~="sans-serif" i], svg [font-family~="sans-serif" i] {
+  font-family: var(--font-sans);
+}
+svg[font-family~="monospace" i], svg [font-family~="monospace" i] {
+  font-family: var(--font-mono);
+}
+.alignCenter.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignCenter.art-text pre {
+  padding: 0;
+}
+.alignCenter {
+  margin: 1em 0;
+}
+.alignCenter > *:first-child {
+  display: table;
+  border: none;
+  margin: 0 auto;
+}
+
+/* lists */
+ol, ul {
+  padding: 0;
+  margin: 0 0 1em 2em;
+}
+ol ol, ul ul, ol ul, ul ol {
+  margin-left: 1em;
+}
+li {
+  margin: 0 0 0.25em 0;
+}
+.ulCompact li {
+  margin: 0;
+}
+ul.empty, .ulEmpty {
+  list-style-type: none;
+}
+ul.empty li, .ulEmpty li {
+  margin-top: 0.5em;
+}
+ul.ulBare, li.ulBare {
+  margin-left: 0em !important;
+}
+ul.compact, .ulCompact,
+ol.compact, .olCompact {
+  line-height: 100%;
+  margin: 0 0 0 2em;
+}
+
+/* definition lists */
+dl {
+}
+dl > dt {
+  float: left;
+  margin-right: 1em;
+}
+/*
+dl.nohang > dt {
+  float: none;
+}
+*/
+dl > dd {
+  margin-bottom: .8em;
+  min-height: 1.3em;
+}
+dl.compact > dd, .dlCompact > dd {
+  margin-bottom: 0em;
+}
+dl > dd > dl {
+  margin-top: 0.5em;
+  margin-bottom: 0em;
+}
+
+/* links */
+a {
+  text-decoration: none;
+}
+a[href] {
+  color: #22e; /* Arlen: WCAG 2019 */
+}
+a[href]:hover {
+  background-color: #f2f2f2;
+}
+figcaption a[href],
+a[href].selfRef {
+  color: #222;
+}
+/* XXX probably not this:
+a.selfRef:hover {
+  background-color: transparent;
+  cursor: default;
+} */
+
+/* Figures */
+tt, code, pre {
+  background-color: #f9f9f9;
+  font-family: var(--font-mono);
+}
+pre {
+  border: 1px solid #eee;
+  margin: 0;
+  padding: 1em;
+}
+img {
+  max-width: 100%;
+}
+figure {
+  margin: 0;
+}
+figure blockquote {
+  margin: 0.8em 0.4em 0.4em;
+}
+figcaption {
+  font-style: italic;
+  margin: 0 0 1em 0;
+}
+@media screen {
+  pre {
+    overflow-x: auto;
+    max-width: 100%;
+    max-width: calc(100% - 22px);
+  }
+}
+
+/* aside, blockquote */
+aside, blockquote {
+  margin-left: 0;
+  padding: 1.2em 2em;
+}
+blockquote {
+  background-color: #f9f9f9;
+  color: #111; /* Arlen: WCAG 2019 */
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  margin: 1em 0;
+}
+blockquote > *:last-child {
+  margin-bottom: 0;
+}
+cite {
+  display: block;
+  text-align: right;
+  font-style: italic;
+}
+.xref {
+  overflow-wrap: normal;
+}
+
+/* tables */
+table {
+  width: 100%;
+  margin: 0 0 1em;
+  border-collapse: collapse;
+  border: 1px solid #eee;
+}
+th, td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.5em 0.75em;
+}
+th {
+  text-align: left;
+  background-color: #e9e9e9;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f5f5f5;
+}
+table caption {
+  font-style: italic;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+}
+table p {
+  /* XXX to avoid bottom margin on table row signifiers. If paragraphs should
+     be allowed within tables more generally, it would be far better to select on a class. */
+  margin: 0;
+}
+
+/* pilcrow */
+a.pilcrow {
+  color: #666; /* Arlen: AHDJ 2019 */
+  text-decoration: none;
+  visibility: hidden;
+  user-select: none;
+  -ms-user-select: none;
+  -o-user-select:none;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+@media screen {
+  aside:hover > a.pilcrow,
+  p:hover > a.pilcrow,
+  blockquote:hover > a.pilcrow,
+  div:hover > a.pilcrow,
+  li:hover > a.pilcrow,
+  pre:hover > a.pilcrow {
+    visibility: visible;
+  }
+  a.pilcrow:hover {
+    background-color: transparent;
+  }
+}
+
+/* misc */
+hr {
+  border: 0;
+  border-top: 1px solid #eee;
+}
+.bcp14 {
+  font-variant: small-caps;
+}
+
+.role {
+  font-variant: all-small-caps;
+}
+
+/* info block */
+#identifiers {
+  margin: 0;
+  font-size: 0.9em;
+}
+#identifiers dt {
+  width: 3em;
+  clear: left;
+}
+#identifiers dd {
+  float: left;
+  margin-bottom: 0;
+}
+/* Fix PDF info block run off issue */
+@media print {
+  #identifiers dd {
+    max-width: 100%;
+  }
+}
+#identifiers .authors .author {
+  display: inline-block;
+  margin-right: 1.5em;
+}
+#identifiers .authors .org {
+  font-style: italic;
+}
+
+/* The prepared/rendered info at the very bottom of the page */
+.docInfo {
+  color: #666; /* Arlen: WCAG 2019 */
+  font-size: 0.9em;
+  font-style: italic;
+  margin-top: 2em;
+}
+.docInfo .prepared {
+  float: left;
+}
+.docInfo .prepared {
+  float: right;
+}
+
+/* table of contents */
+#toc  {
+  padding: 0.75em 0 2em 0;
+  margin-bottom: 1em;
+}
+nav.toc ul {
+  margin: 0 0.5em 0 0;
+  padding: 0;
+  list-style: none;
+}
+nav.toc li {
+  line-height: 1.3em;
+  margin: 0.75em 0;
+  padding-left: 1.2em;
+  text-indent: -1.2em;
+}
+/* references */
+.references dt {
+  text-align: right;
+  font-weight: bold;
+  min-width: 7em;
+}
+.references dd {
+  margin-left: 8em;
+  overflow: auto;
+}
+
+.refInstance {
+  margin-bottom: 1.25em;
+}
+
+.refSubseries {
+  margin-bottom: 1.25em;
+}
+
+.references .ascii {
+  margin-bottom: 0.25em;
+}
+
+/* index */
+.index ul {
+  margin: 0 0 0 1em;
+  padding: 0;
+  list-style: none;
+}
+.index ul ul {
+  margin: 0;
+}
+.index li {
+  margin: 0;
+  text-indent: -2em;
+  padding-left: 2em;
+  padding-bottom: 5px;
+}
+.indexIndex {
+  margin: 0.5em 0 1em;
+}
+.index a {
+  font-weight: 700;
+}
+/* make the index two-column on all but the smallest screens */
+@media (min-width: 600px) {
+  .index ul {
+    -moz-column-count: 2;
+    -moz-column-gap: 20px;
+  }
+  .index ul ul {
+    -moz-column-count: 1;
+    -moz-column-gap: 0;
+  }
+}
+
+/* authors */
+address.vcard {
+  font-style: normal;
+  margin: 1em 0;
+}
+
+address.vcard .nameRole {
+  font-weight: 700;
+  margin-left: 0;
+}
+address.vcard .label {
+  font-family: var(--font-sans);
+  margin: 0.5em 0;
+}
+address.vcard .type {
+  display: none;
+}
+.alternative-contact {
+  margin: 1.5em 0 1em;
+}
+hr.addr {
+  border-top: 1px dashed;
+  margin: 0;
+  color: #ddd;
+  max-width: calc(100% - 16px);
+}
+
+/* temporary notes */
+.rfcEditorRemove::before {
+  position: absolute;
+  top: 0.2em;
+  right: 0.2em;
+  padding: 0.2em;
+  content: "The RFC Editor will remove this note";
+  color: #9e2a00; /* Arlen: WCAG 2019 */
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+}
+.rfcEditorRemove {
+  position: relative;
+  padding-top: 1.8em;
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  border-radius: 3px;
+}
+.cref {
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  padding: 2px 4px;
+}
+.crefSource {
+  font-style: italic;
+}
+/* alternative layout for smaller screens */
+@media screen and (max-width: 1023px) {
+  body {
+    padding-top: 2em;
+  }
+  #title {
+    padding: 1em 0;
+  }
+  h1 {
+    font-size: 24px;
+  }
+  h2 {
+    font-size: 20px;
+    margin-top: -18px;  /* provide offset for in-page anchors */
+    padding-top: 38px;
+  }
+  #identifiers dd {
+    max-width: 60%;
+  }
+  #toc {
+    position: fixed;
+    z-index: 2;
+    top: 0;
+    right: 0;
+    padding: 0;
+    margin: 0;
+    background-color: inherit;
+    border-bottom: 1px solid #ccc;
+  }
+  #toc h2 {
+    margin: -1px 0 0 0;
+    padding: 4px 0 4px 6px;
+    padding-right: 1em;
+    min-width: 190px;
+    font-size: 1.1em;
+    text-align: right;
+    background-color: #444;
+    color: white;
+    cursor: pointer;
+  }
+  #toc h2::before { /* css hamburger */
+    float: right;
+    position: relative;
+    width: 1em;
+    height: 1px;
+    left: -164px;
+    margin: 6px 0 0 0;
+    background: white none repeat scroll 0 0;
+    box-shadow: 0 4px 0 0 white, 0 8px 0 0 white;
+    content: "";
+  }
+  #toc nav {
+    display: none;
+    padding: 0.5em 1em 1em;
+    overflow: auto;
+    height: calc(100vh - 48px);
+    border-left: 1px solid #ddd;
+  }
+}
+
+/* alternative layout for wide screens */
+@media screen and (min-width: 1024px) {
+  body {
+    max-width: 724px;
+    margin: 42px auto;
+    padding-left: 1.5em;
+    padding-right: 29em;
+  }
+  #toc {
+    position: fixed;
+    top: 42px;
+    right: 42px;
+    width: 25%;
+    margin: 0;
+    padding: 0 1em;
+    z-index: 1;
+  }
+  #toc h2 {
+    border-top: none;
+    border-bottom: 1px solid #ddd;
+    font-size: 1em;
+    font-weight: normal;
+    margin: 0;
+    padding: 0.25em 1em 1em 0;
+  }
+  #toc nav {
+    display: block;
+    height: calc(90vh - 84px);
+    bottom: 0;
+    padding: 0.5em 0 0;
+    overflow: auto;
+  }
+  img { /* future proofing */
+    max-width: 100%;
+    height: auto;
+  }
+}
+
+/* pagination */
+@media print {
+  body {
+    width: 100%;
+  }
+  p {
+    orphans: 3;
+    widows: 3;
+  }
+  #n-copyright-notice {
+    border-bottom: none;
+  }
+  #toc, #n-introduction {
+    page-break-before: always;
+  }
+  #toc {
+    border-top: none;
+    padding-top: 0;
+  }
+  figure, pre {
+    page-break-inside: avoid;
+  }
+  figure {
+    overflow: scroll;
+  }
+  .breakable pre {
+    break-inside: auto;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    page-break-after: avoid;
+  }
+  h2+*, h3+*, h4+*, h5+*, h6+* {
+    page-break-before: avoid;
+  }
+  pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-size: 10pt;
+  }
+  table {
+    border: 1px solid #ddd;
+  }
+  td {
+    border-top: 1px solid #ddd;
+  }
+}
+
+/* This is commented out here, as the string-set: doesn't
+   pass W3C validation currently */
+/*
+.ears thead .left {
+  string-set: ears-top-left content();
+}
+
+.ears thead .center {
+  string-set: ears-top-center content();
+}
+
+.ears thead .right {
+  string-set: ears-top-right content();
+}
+
+.ears tfoot .left {
+  string-set: ears-bottom-left content();
+}
+
+.ears tfoot .center {
+  string-set: ears-bottom-center content();
+}
+
+.ears tfoot .right {
+  string-set: ears-bottom-right content();
+}
+*/
+
+@page :first {
+  padding-top: 0;
+  @top-left {
+    content: normal;
+    border: none;
+  }
+  @top-center {
+    content: normal;
+    border: none;
+  }
+  @top-right {
+    content: normal;
+    border: none;
+  }
+}
+
+@page {
+  size: A4;
+  margin-bottom: 45mm;
+  padding-top: 20px;
+  /* The following is commented out here, but set appropriately by in code, as
+     the content depends on the document */
+  /*
+  @top-left {
+    content: 'Internet-Draft';
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-left {
+    content: string(ears-top-left);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-center {
+    content: string(ears-top-center);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-right {
+    content: string(ears-top-right);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @bottom-left {
+    content: string(ears-bottom-left);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-center {
+    content: string(ears-bottom-center);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-right {
+      content: '[Page ' counter(page) ']';
+      vertical-align: top;
+      border-top: solid 1px #ccc;
+  }
+  */
+
+}
+
+/* Changes introduced to fix issues found during implementation */
+/* Make sure links are clickable even if overlapped by following H* */
+a {
+  z-index: 2;
+}
+/* Separate body from document info even without intervening H1 */
+section {
+  clear: both;
+}
+
+
+/* Top align author divs, to avoid names without organization dropping level with org names */
+.author {
+  vertical-align: top;
+}
+
+/* Leave room in document info to show Internet-Draft on one line */
+#identifiers dt {
+  width: 8em;
+}
+
+/* Don't waste quite as much whitespace between label and value in doc info */
+#identifiers dd {
+  margin-left: 1em;
+}
+
+/* Give floating toc a background color (needed when it's a div inside section */
+#toc {
+  background-color: white;
+}
+
+/* Make the collapsed ToC header render white on gray also when it's a link */
+@media screen and (max-width: 1023px) {
+  #toc h2 a,
+  #toc h2 a:link,
+  #toc h2 a:focus,
+  #toc h2 a:hover,
+  #toc a.toplink,
+  #toc a.toplink:hover {
+    color: white;
+    background-color: #444;
+    text-decoration: none;
+  }
+}
+
+/* Give the bottom of the ToC some whitespace */
+@media screen and (min-width: 1024px) {
+  #toc {
+    padding: 0 0 1em 1em;
+  }
+}
+
+/* Style section numbers with more space between number and title */
+.section-number {
+  padding-right: 0.5em;
+}
+
+/* prevent monospace from becoming overly large */
+tt, code, pre {
+  font-size: 95%;
+}
+
+/* Fix the height/width aspect for ascii art*/
+.sourcecode pre,
+.art-text pre {
+  line-height: 1.12;
+}
+
+
+/* Add styling for a link in the ToC that points to the top of the document */
+a.toplink {
+  float: right;
+  margin-right: 0.5em;
+}
+
+/* Fix the dl styling to match the RFC 7992 attributes */
+dl > dt,
+dl.dlParallel > dt {
+  float: left;
+  margin-right: 1em;
+}
+dl.dlNewline > dt {
+  float: none;
+}
+
+/* Provide styling for table cell text alignment */
+table td.text-left,
+table th.text-left {
+  text-align: left;
+}
+table td.text-center,
+table th.text-center {
+  text-align: center;
+}
+table td.text-right,
+table th.text-right {
+  text-align: right;
+}
+
+/* Make the alternative author contact information look less like just another
+   author, and group it closer with the primary author contact information */
+.alternative-contact {
+  margin: 0.5em 0 0.25em 0;
+}
+address .non-ascii {
+  margin: 0 0 0 2em;
+}
+
+/* With it being possible to set tables with alignment
+  left, center, and right, { width: 100%; } does not make sense */
+table {
+  width: auto;
+}
+
+/* Avoid reference text that sits in a block with very wide left margin,
+   because of a long floating dt label.*/
+.references dd {
+  overflow: visible;
+}
+
+/* Control caption placement */
+caption {
+  caption-side: bottom;
+}
+
+/* Limit the width of the author address vcard, so names in right-to-left
+   script don't end up on the other side of the page. */
+
+address.vcard {
+  max-width: 30em;
+  margin-right: auto;
+}
+
+/* For address alignment dependent on LTR or RTL scripts */
+address div.left {
+  text-align: left;
+}
+address div.right {
+  text-align: right;
+}
+
+/* Provide table alignment support.  We can't use the alignX classes above
+   since they do unwanted things with caption and other styling. */
+table.right {
+ margin-left: auto;
+ margin-right: 0;
+}
+table.center {
+ margin-left: auto;
+ margin-right: auto;
+}
+table.left {
+ margin-left: 0;
+ margin-right: auto;
+}
+
+/* Give the table caption label the same styling as the figcaption */
+caption a[href] {
+  color: #222;
+}
+
+@media print {
+  .toplink {
+    display: none;
+  }
+
+  /* avoid overwriting the top border line with the ToC header */
+  #toc {
+    padding-top: 1px;
+  }
+
+  /* Avoid page breaks inside dl and author address entries */
+  .vcard {
+    page-break-inside: avoid;
+  }
+
+}
+/* Tweak the bcp14 keyword presentation */
+.bcp14 {
+  font-variant: small-caps;
+  font-weight: bold;
+  font-size: 0.9em;
+}
+/* Tweak the invisible space above H* in order not to overlay links in text above */
+ h2 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 31px;
+ }
+ h3 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+ h4 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+/* Float artwork pilcrow to the right */
+@media screen {
+  .artwork a.pilcrow {
+    display: block;
+    line-height: 0.7;
+    margin-top: 0.15em;
+  }
+}
+/* Make pilcrows on dd visible */
+@media screen {
+  dd:hover > a.pilcrow {
+    visibility: visible;
+  }
+}
+/* Make the placement of figcaption match that of a table's caption
+   by removing the figure's added bottom margin */
+.alignLeft.art-text,
+.alignCenter.art-text,
+.alignRight.art-text {
+   margin-bottom: 0;
+}
+.alignLeft,
+.alignCenter,
+.alignRight {
+  margin: 1em 0 0 0;
+}
+/* In print, the pilcrow won't show on hover, so prevent it from taking up space,
+   possibly even requiring a new line */
+@media print {
+  a.pilcrow {
+    display: none;
+  }
+}
+/* Styling for the external metadata */
+div#external-metadata {
+  background-color: #eee;
+  padding: 0.5em;
+  margin-bottom: 0.5em;
+  display: none;
+}
+div#internal-metadata {
+  padding: 0.5em;                       /* to match the external-metadata padding */
+}
+/* Styling for title RFC Number */
+h1#rfcnum {
+  clear: both;
+  margin: 0 0 -1em;
+  padding: 1em 0 0 0;
+}
+/* Make .olPercent look the same as <ol><li> */
+dl.olPercent > dd {
+  margin-bottom: 0.25em;
+  min-height: initial;
+}
+/* Give aside some styling to set it apart */
+aside {
+  border-left: 1px solid #ddd;
+  margin: 1em 0 1em 2em;
+  padding: 0.2em 2em;
+}
+aside > dl,
+aside > ol,
+aside > ul,
+aside > table,
+aside > p {
+  margin-bottom: 0.5em;
+}
+/* Additional page break settings */
+@media print {
+  figcaption, table caption {
+    page-break-before: avoid;
+  }
+}
+/* Font size adjustments for print */
+@media print {
+  body  { font-size: 10pt;      line-height: normal; max-width: 96%; }
+  h1    { font-size: 1.72em;    padding-top: 1.5em; } /* 1*1.2*1.2*1.2 */
+  h2    { font-size: 1.44em;    padding-top: 1.5em; } /* 1*1.2*1.2 */
+  h3    { font-size: 1.2em;     padding-top: 1.5em; } /* 1*1.2 */
+  h4    { font-size: 1em;       padding-top: 1.5em; }
+  h5, h6 { font-size: 1em;      margin: initial; padding: 0.5em 0 0.3em; }
+}
+/* Sourcecode margin in print, when there's no pilcrow */
+@media print {
+  .artwork,
+  .artwork > pre,
+  .sourcecode {
+    margin-bottom: 1em;
+  }
+}
+/* Avoid narrow tables forcing too narrow table captions, which may render badly */
+table {
+  min-width: 20em;
+}
+/* ol type a */
+ol.type-a { list-style-type: lower-alpha; }
+ol.type-A { list-style-type: upper-alpha; }
+ol.type-i { list-style-type: lower-roman; }
+ol.type-I { list-style-type: upper-roman; }
+/* Apply the print table and row borders in general, on request from the RPC,
+and increase the contrast between border and odd row background slightly */
+table {
+  border: 1px solid #ddd;
+}
+td {
+  border-top: 1px solid #ddd;
+}
+tr {
+  break-inside: avoid;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f8f8f8;
+}
+/* Use style rules to govern display of the TOC. */
+@media screen and (max-width: 1023px) {
+  #toc nav { display: none; }
+  #toc.active nav { display: block; }
+}
+/* Add support for keepWithNext */
+.keepWithNext {
+  break-after: avoid-page;
+  break-after: avoid-page;
+}
+/* Add support for keepWithPrevious */
+.keepWithPrevious {
+  break-before: avoid-page;
+}
+/* Change the approach to avoiding breaks inside artwork etc. */
+figure, pre, table, .artwork, .sourcecode  {
+  break-before: auto;
+  break-after: auto;
+}
+/* Avoid breaks between <dt> and <dd> */
+dl {
+  break-before: auto;
+  break-inside: auto;
+}
+dt {
+  break-before: auto;
+  break-after: avoid-page;
+}
+dd {
+  break-before: avoid-page;
+  break-after: auto;
+  orphans: 3;
+  widows: 3
+}
+span.break, dd.break {
+  margin-bottom: 0;
+  min-height: 0;
+  break-before: auto;
+  break-inside: auto;
+  break-after: auto;
+}
+/* Undo break-before ToC */
+@media print {
+  #toc {
+    break-before: auto;
+  }
+}
+/* Text in compact lists should not get extra bottom margin space,
+   since that would makes the list not compact */
+ul.compact p, .ulCompact p,
+ol.compact p, .olCompact p {
+ margin: 0;
+}
+/* But the list as a whole needs the extra space at the end */
+section ul.compact,
+section .ulCompact,
+section ol.compact,
+section .olCompact {
+  margin-bottom: 1em;                    /* same as p not within ul.compact etc. */
+}
+/* The tt and code background above interferes with for instance table cell
+   backgrounds.  Changed to something a bit more selective. */
+tt, code {
+  background-color: transparent;
+}
+p tt, p code, li tt, li code, dt tt, dt code {
+  background-color: #f8f8f8;
+}
+/* Tweak the pre margin -- 0px doesn't come out well */
+pre {
+   margin-top: 0.5px;
+}
+/* Tweak the compact list text */
+ul.compact, .ulCompact,
+ol.compact, .olCompact,
+dl.compact, .dlCompact {
+  line-height: normal;
+}
+/* Don't add top margin for nested lists */
+li > ul, li > ol, li > dl,
+dd > ul, dd > ol, dd > dl,
+dl > dd > dl {
+  margin-top: initial;
+}
+/* Elements that should not be rendered on the same line as a <dt> */
+/* This should match the element list in writer.text.TextWriter.render_dl() */
+dd > div.artwork:first-child,
+dd > aside:first-child,
+dd > blockquote:first-child,
+dd > figure:first-child,
+dd > ol:first-child,
+dd > div.sourcecode:first-child,
+dd > table:first-child,
+dd > ul:first-child {
+  clear: left;
+}
+/* fix for weird browser behaviour when <dd/> is empty */
+dt+dd:empty::before{
+  content: "\00a0";
+}
+/* Make paragraph spacing inside <li> smaller than in body text, to fit better within the list */
+li > p {
+  margin-bottom: 0.5em
+}
+/* Don't let p margin spill out from inside list items */
+li > p:last-of-type:only-child {
+  margin-bottom: 0;
+}
+</style>
+<link href="rfc-local.css" rel="stylesheet" type="text/css">
+<script type="application/javascript">async function addMetadata(){try{const e=document.styleSheets[0].cssRules;for(let t=0;t<e.length;t++)if(/#identifiers/.exec(e[t].selectorText)){const a=e[t].cssText.replace("#identifiers","#external-updates");document.styleSheets[0].insertRule(a,document.styleSheets[0].cssRules.length)}}catch(e){console.log(e)}const e=document.getElementById("external-metadata");if(e)try{var t,a="",o=function(e){const t=document.getElementsByTagName("meta");for(let a=0;a<t.length;a++)if(t[a].getAttribute("name")===e)return t[a].getAttribute("content");return""}("rfc.number");if(o){t="https://www.rfc-editor.org/rfc/rfc"+o+".json";try{const e=await fetch(t);a=await e.json()}catch(e){t=document.URL.indexOf("html")>=0?document.URL.replace(/html$/,"json"):document.URL+".json";const o=await fetch(t);a=await o.json()}}if(!a)return;e.style.display="block";const s="",d="https://datatracker.ietf.org/doc",n="https://datatracker.ietf.org/ipr/search",c="https://www.rfc-editor.org/info",l=a.doc_id.toLowerCase(),i=a.doc_id.slice(0,3).toLowerCase(),f=a.doc_id.slice(3).replace(/^0+/,""),u={status:"Status",obsoletes:"Obsoletes",obsoleted_by:"Obsoleted By",updates:"Updates",updated_by:"Updated By",see_also:"See Also",errata_url:"Errata"};let h="<dl style='overflow:hidden' id='external-updates'>";["status","obsoletes","obsoleted_by","updates","updated_by","see_also","errata_url"].forEach(e=>{if("status"==e){a[e]=a[e].toLowerCase();var t=a[e].split(" "),o=t.length,w="",p=1;for(let e=0;e<o;e++)p<o?w=w+r(t[e])+" ":w+=r(t[e]),p++;a[e]=w}else if("obsoletes"==e||"obsoleted_by"==e||"updates"==e||"updated_by"==e){var g,m="",b=1;g=a[e].length;for(let t=0;t<g;t++)a[e][t]&&(a[e][t]=String(a[e][t]).toLowerCase(),m=b<g?m+"<a href='"+s+"/rfc/".concat(a[e][t])+"'>"+a[e][t].slice(3)+"</a>, ":m+"<a href='"+s+"/rfc/".concat(a[e][t])+"'>"+a[e][t].slice(3)+"</a>",b++);a[e]=m}else if("see_also"==e){var y,L="",C=1;y=a[e].length;for(let t=0;t<y;t++)if(a[e][t]){a[e][t]=String(a[e][t]);var _=a[e][t].slice(0,3),v=a[e][t].slice(3).replace(/^0+/,"");L=C<y?"RFC"!=_?L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+_+" "+v+"</a>, ":L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+v+"</a>, ":"RFC"!=_?L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+_+" "+v+"</a>":L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+v+"</a>",C++}a[e]=L}else if("errata_url"==e){var R="";R=a[e]?R+"<a href='"+a[e]+"'>Errata exist</a> | <a href='"+d+"/"+l+"'>Datatracker</a>| <a href='"+n+"/?"+i+"="+f+"&submit="+i+"'>IPR</a> | <a href='"+c+"/"+l+"'>Info page</a>":"<a href='"+d+"/"+l+"'>Datatracker</a> | <a href='"+n+"/?"+i+"="+f+"&submit="+i+"'>IPR</a> | <a href='"+c+"/"+l+"'>Info page</a>",a[e]=R}""!=a[e]?"Errata"==u[e]?h+=`<dt>More info:</dt><dd>${a[e]}</dd>`:h+=`<dt>${u[e]}:</dt><dd>${a[e]}</dd>`:"Errata"==u[e]&&(h+=`<dt>More info:</dt><dd>${a[e]}</dd>`)}),h+="</dl>",e.innerHTML=h}catch(e){console.log(e)}else console.log("Could not locate metadata <div> element");function r(e){return e.charAt(0).toUpperCase()+e.slice(1)}}window.removeEventListener("load",addMetadata),window.addEventListener("load",addMetadata);</script>
+</head>
+<body class="xml2rfc">
+<table class="ears">
+<thead><tr>
+<td class="left">Internet-Draft</td>
+<td class="center">EP Authorization Receipts</td>
+<td class="right">August 2026</td>
+</tr></thead>
+<tfoot><tr>
+<td class="left">Schrock</td>
+<td class="center">Expires 4 February 2027</td>
+<td class="right">[Page]</td>
+</tr></tfoot>
+</table>
+<div id="external-metadata" class="document-information"></div>
+<div id="internal-metadata" class="document-information">
+<dl id="identifiers">
+<dt class="label-workgroup">Workgroup:</dt>
+<dd class="workgroup">Network Working Group</dd>
+<dt class="label-internet-draft">Internet-Draft:</dt>
+<dd class="internet-draft">draft-schrock-ep-authorization-receipts-09</dd>
+<dt class="label-published">Published:</dt>
+<dd class="published">
+<time datetime="2026-08-03" class="published">3 August 2026</time>
+    </dd>
+<dt class="label-intended-status">Intended Status:</dt>
+<dd class="intended-status">Standards Track</dd>
+<dt class="label-expires">Expires:</dt>
+<dd class="expires"><time datetime="2027-02-04">4 February 2027</time></dd>
+<dt class="label-authors">Author:</dt>
+<dd class="authors">
+<div class="author">
+      <div class="author-name">I. Schrock</div>
+<div class="org">EMILIA Protocol, Inc.</div>
+</div>
+</dd>
+</dl>
+</div>
+<h1 id="title">Authorization Receipts for High-Risk Agent Actions</h1>
+<section id="section-abstract">
+      <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
+<p id="section-abstract-1">This document defines the EMILIA Protocol (EP) authorization
+      receipt, an evidence artifact binding an enrolled approver key to
+      one canonical action before execution. An approver-held key signs an
+      Authorization Context containing the action hash, policy reference,
+      nonce, audience, and validity window. A Trust Receipt carries the
+      signed contexts, terminal consumption record, and Merkle inclusion
+      material so a relying party can verify the recorded event offline
+      under independently selected log, directory, policy, and approver
+      trust inputs.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
+<p id="section-abstract-2">The receipt establishes only the guarantees of the selected
+      verification profile. The mapping from an enrolled approver
+      identifier to a natural person is asserted by the directory
+      authority. Offline verification does not establish current
+      revocation status, global non-replay, comprehension, legality,
+      safety, or execution. Replay prevention requires an online atomic
+      consumption store at the executor. The state-machine invariants are
+      machine-checked under the assumptions stated in this document.<a href="#section-abstract-2" class="pilcrow">¶</a></p>
+<p id="section-abstract-3">A receipt is evidence, not authorization. This document does not
+      treat a local user interaction as an authorization decision. Section
+      10.7 of <span>[<a href="#I-D.klrc-aiagent-auth" class="cite xref">I-D.klrc-aiagent-auth</a>]</span> states that an agent
+      MUST NOT treat local UI confirmation alone as sufficient
+      authorization, and notes that additional specification or design work
+      may be needed for user confirmation occurring mid-execution, since CIBA accounts
+      only for client initiation. This document defines one evidence
+      artifact that an authorization architecture can use in such a flow:
+      the signed Authorization Context is action-bound confirmation evidence
+      an authorization server MAY validate and bind to the grant it issues.
+      The resulting Trust Receipt records terminal consumption and remains
+      evidence; neither object makes the authorization decision. That
+      decision remains with the authorization server.<a href="#section-abstract-3" class="pilcrow">¶</a></p>
+</section>
+<div id="status-of-memo">
+<section id="section-boilerplate.1">
+        <h2 id="name-status-of-this-memo">
+<a href="#name-status-of-this-memo" class="section-name selfRef">Status of This Memo</a>
+        </h2>
+<p id="section-boilerplate.1-1">
+        This Internet-Draft is submitted in full conformance with the
+        provisions of BCP 78 and BCP 79.<a href="#section-boilerplate.1-1" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-2">
+        Internet-Drafts are working documents of the Internet Engineering Task
+        Force (IETF). Note that other groups may also distribute working
+        documents as Internet-Drafts. The list of current Internet-Drafts is
+        at <span><a href="https://datatracker.ietf.org/drafts/current/">https://datatracker.ietf.org/drafts/current/</a></span>.<a href="#section-boilerplate.1-2" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-3">
+        Internet-Drafts are draft documents valid for a maximum of six months
+        and may be updated, replaced, or obsoleted by other documents at any
+        time. It is inappropriate to use Internet-Drafts as reference
+        material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-4">
+        This Internet-Draft will expire on 4 February 2027.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="copyright">
+<section id="section-boilerplate.2">
+        <h2 id="name-copyright-notice">
+<a href="#name-copyright-notice" class="section-name selfRef">Copyright Notice</a>
+        </h2>
+<p id="section-boilerplate.2-1">
+            Copyright (c) 2026 IETF Trust and the persons identified as the
+            document authors. All rights reserved.<a href="#section-boilerplate.2-1" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.2-2">
+            This document is subject to BCP 78 and the IETF Trust's Legal
+            Provisions Relating to IETF Documents
+            (<span><a href="https://trustee.ietf.org/license-info">https://trustee.ietf.org/license-info</a></span>) in effect on the date of
+            publication of this document. Please review these documents
+            carefully, as they describe your rights and restrictions with
+            respect to this document. Code Components extracted from this
+            document must include Revised BSD License text as described in
+            Section 4.e of the Trust Legal Provisions and are provided without
+            warranty as described in the Revised BSD License.<a href="#section-boilerplate.2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="toc">
+<section id="section-toc.1">
+        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
+<a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
+        </h2>
+<nav class="toc"><ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1">
+            <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="auto internal xref">1</a>.  <a href="#name-introduction" class="internal xref">Introduction</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1.2.1">
+                <p id="section-toc.1-1.1.2.1.1" class="keepWithNext"><a href="#section-1.1" class="auto internal xref">1.1</a>.  <a href="#name-design-goals" class="internal xref">Design Goals</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1.2.2">
+                <p id="section-toc.1-1.1.2.2.1" class="keepWithNext"><a href="#section-1.2" class="auto internal xref">1.2</a>.  <a href="#name-scope-of-identity" class="internal xref">Scope of Identity</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2">
+            <p id="section-toc.1-1.2.1"><a href="#section-2" class="auto internal xref">2</a>.  <a href="#name-terminology" class="internal xref">Terminology</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3">
+            <p id="section-toc.1-1.3.1"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-the-action-object-and-actio" class="internal xref">The Action Object and Action Hash</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="auto internal xref">4</a>.  <a href="#name-the-authorization-context" class="internal xref">The Authorization Context</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.1">
+                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="auto internal xref">4.1</a>.  <a href="#name-initiator-attestation-optio" class="internal xref">Initiator Attestation (OPTIONAL)</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.2">
+                <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="auto internal xref">4.2</a>.  <a href="#name-agent-binding-optional" class="internal xref">Agent Binding (OPTIONAL)</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="auto internal xref">5</a>.  <a href="#name-approver-keys-and-the-signo" class="internal xref">Approver Keys and the Signoff Signature</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.1">
+                <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="auto internal xref">5.1</a>.  <a href="#name-key-classes" class="internal xref">Key Classes</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.2">
+                <p id="section-toc.1-1.5.2.2.1"><a href="#section-5.2" class="auto internal xref">5.2</a>.  <a href="#name-enrollment-and-the-approver" class="internal xref">Enrollment and the Approver Directory</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.3">
+                <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="auto internal xref">5.3</a>.  <a href="#name-the-signoff" class="internal xref">The Signoff</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-consumption-commitment-and-" class="internal xref">Consumption, Commitment, and the Trust Receipt</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1">
+                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="auto internal xref">6.1</a>.  <a href="#name-state-machine" class="internal xref">State Machine</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2">
+                <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="auto internal xref">6.2</a>.  <a href="#name-the-trust-receipt" class="internal xref">The Trust Receipt</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.3">
+                <p id="section-toc.1-1.6.2.3.1"><a href="#section-6.3" class="auto internal xref">6.3</a>.  <a href="#name-offline-verification-algori" class="internal xref">Offline Verification Algorithm</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="auto internal xref">7</a>.  <a href="#name-companion-receipt-extension" class="internal xref">Companion Receipt Extensions and Digest Binding</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.1">
+                <p id="section-toc.1-1.7.2.1.1"><a href="#section-7.1" class="auto internal xref">7.1</a>.  <a href="#name-provisional-extension-regis" class="internal xref">Provisional Extension Registry</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.2">
+                <p id="section-toc.1-1.7.2.2.1"><a href="#section-7.2" class="auto internal xref">7.2</a>.  <a href="#name-relationship-to-the-action-" class="internal xref">Relationship to the Action Lifecycle</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="auto internal xref">8</a>.  <a href="#name-multi-approver-policies-m-o" class="internal xref">Multi-Approver Policies (m-of-n)</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="auto internal xref">9</a>.  <a href="#name-delegation-constraints" class="internal xref">Delegation Constraints</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
+            <p id="section-toc.1-1.10.1"><a href="#section-10" class="auto internal xref">10</a>. <a href="#name-conformance-classes-and-exe" class="internal xref">Conformance Classes and Execution-Side Enforcement</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
+            <p id="section-toc.1-1.11.1"><a href="#section-11" class="auto internal xref">11</a>. <a href="#name-relationship-to-other-work" class="internal xref">Relationship to Other Work</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
+            <p id="section-toc.1-1.12.1"><a href="#section-12" class="auto internal xref">12</a>. <a href="#name-security-considerations" class="internal xref">Security Considerations</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.1">
+                <p id="section-toc.1-1.12.2.1.1"><a href="#section-12.1" class="auto internal xref">12.1</a>.  <a href="#name-operator-compromise" class="internal xref">Operator Compromise</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.2">
+                <p id="section-toc.1-1.12.2.2.1"><a href="#section-12.2" class="auto internal xref">12.2</a>.  <a href="#name-approver-device-compromise" class="internal xref">Approver Device Compromise</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.3">
+                <p id="section-toc.1-1.12.2.3.1"><a href="#section-12.3" class="auto internal xref">12.3</a>.  <a href="#name-presentation-attacks" class="internal xref">Presentation Attacks</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.4">
+                <p id="section-toc.1-1.12.2.4.1"><a href="#section-12.4" class="auto internal xref">12.4</a>.  <a href="#name-log-equivocation" class="internal xref">Log Equivocation</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.5">
+                <p id="section-toc.1-1.12.2.5.1"><a href="#section-12.5" class="auto internal xref">12.5</a>.  <a href="#name-what-the-formal-models-do-a" class="internal xref">What the Formal Models Do and Do Not Prove</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.6">
+                <p id="section-toc.1-1.12.2.6.1"><a href="#section-12.6" class="auto internal xref">12.6</a>.  <a href="#name-directory-authority" class="internal xref">Directory Authority</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.7">
+                <p id="section-toc.1-1.12.2.7.1"><a href="#section-12.7" class="auto internal xref">12.7</a>.  <a href="#name-what-separation-of-duties-d" class="internal xref">What Separation of Duties Does and Does Not Provide</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.8">
+                <p id="section-toc.1-1.12.2.8.1"><a href="#section-12.8" class="auto internal xref">12.8</a>.  <a href="#name-approver-fatigue" class="internal xref">Approver Fatigue</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.9">
+                <p id="section-toc.1-1.12.2.9.1"><a href="#section-12.9" class="auto internal xref">12.9</a>.  <a href="#name-initiator-attestation-as-an" class="internal xref">Initiator Attestation as an Attack Surface</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.10">
+                <p id="section-toc.1-1.12.2.10.1"><a href="#section-12.10" class="auto internal xref">12.10</a>. <a href="#name-no-symmetric-key-on-the-ver" class="internal xref">No symmetric key on the verification trust path</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.11">
+                <p id="section-toc.1-1.12.2.11.1"><a href="#section-12.11" class="auto internal xref">12.11</a>. <a href="#name-canonicalization-robustness" class="internal xref">Canonicalization Robustness</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13">
+            <p id="section-toc.1-1.13.1"><a href="#section-13" class="auto internal xref">13</a>. <a href="#name-iana-considerations" class="internal xref">IANA Considerations</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14">
+            <p id="section-toc.1-1.14.1"><a href="#section-14" class="auto internal xref">14</a>. <a href="#name-normative-references" class="internal xref">Normative References</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15">
+            <p id="section-toc.1-1.15.1"><a href="#section-15" class="auto internal xref">15</a>. <a href="#name-informative-references" class="internal xref">Informative References</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.16">
+            <p id="section-toc.1-1.16.1"><a href="#appendix-A" class="auto internal xref">Appendix A</a>.  <a href="#name-changes-since-08" class="internal xref">Changes since -08</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.17">
+            <p id="section-toc.1-1.17.1"><a href="#appendix-B" class="auto internal xref">Appendix B</a>.  <a href="#name-changes-since-07" class="internal xref">Changes since -07</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.18">
+            <p id="section-toc.1-1.18.1"><a href="#appendix-C" class="auto internal xref">Appendix C</a>.  <a href="#name-changes-since-06" class="internal xref">Changes since -06</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.19">
+            <p id="section-toc.1-1.19.1"><a href="#appendix-D" class="auto internal xref">Appendix D</a>.  <a href="#name-changes-since-04" class="internal xref">Changes since -04</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.20">
+            <p id="section-toc.1-1.20.1"><a href="#appendix-E" class="auto internal xref">Appendix E</a>.  <a href="#name-changes-since-00-through-04" class="internal xref">Changes since -00 (through -04)</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.21">
+            <p id="section-toc.1-1.21.1"><a href="#appendix-F" class="auto internal xref"></a><a href="#name-authors-address" class="internal xref">Author's Address</a></p>
+</li>
+        </ul>
+</nav>
+</section>
+</div>
+<section id="section-1">
+      <h2 id="name-introduction">
+<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction" class="section-name selfRef">Introduction</a>
+      </h2>
+<p id="section-1-1">Agentic AI systems increasingly hold credentials sufficient to
+      perform irreversible operations: releasing payments, modifying
+      beneficiary records, rotating production credentials, deleting
+      data. Session-level authentication and authorization alone answer
+      whether an actor may operate within a scope. A deployment can
+      separately require evidence that an enrolled approver key signed one
+      exact proposed action before execution.<a href="#section-1-1" class="pilcrow">¶</a></p>
+<p id="section-1-2">Three structural gaps follow:<a href="#section-1-2" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-1-3">
+        <li id="section-1-3.1">
+          <strong>The action gap.</strong> Identity and access
+        management authorizes <em>sessions and scopes</em>, not
+        individual actions. Fraud that occurs inside a valid session
+        through approved channels (e.g., business email compromise
+        leading to a beneficiary change) is invisible to session-level
+        controls.<a href="#section-1-3.1" class="pilcrow">¶</a>
+</li>
+        <li id="section-1-3.2">
+          <strong>The accountability gap.</strong> Where human approval
+        exists, it is typically a click in a workflow tool, recorded in a
+        mutable application database controlled by the operator of the
+        approval system. A deployment can instead require portable
+        evidence binding an enrolled approver key to the specific
+        action.<a href="#section-1-3.2" class="pilcrow">¶</a>
+</li>
+        <li id="section-1-3.3">
+          <strong>The verification gap.</strong> Auditors,
+        counterparties, and regulators may need to evaluate evidence
+        outside the operator that produced it, including after the live
+        service is unavailable or the operators disagree.<a href="#section-1-3.3" class="pilcrow">¶</a>
+</li>
+      </ol>
+<p id="section-1-4">This document addresses those deployment requirements with a
+      receipt profile: before an
+      irreversible action executes, an enrolled approver signs the exact
+      action with an approver-held key; an executor records terminal
+      consumption through an atomic state transition; and the resulting
+      receipt remains independently verifiable offline for as long as its
+      algorithms and trust material remain acceptable or are renewed.<a href="#section-1-4" class="pilcrow">¶</a></p>
+<p id="section-1-5">Adjacent mechanisms answer related but non-identical questions.
+      The distinctions below are profile boundaries, not claims that
+      portable approval or intent evidence exists nowhere else.<a href="#section-1-5" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-1-6.1">OAuth 2.0 with Rich Authorization Requests (RFC 9396) and
+        GNAP (RFC 9635) authorize a client's <em>requested scope</em>;
+        they do not produce a named human's offline-verifiable signature
+        over the exact action that executed.<a href="#section-1-6.1" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-1-6.2">The OAuth Step-Up Authentication Challenge (RFC 9470) can
+        <em>demand</em> fresh human authentication for a sensitive
+        operation, but yields no durable, portable artifact of that
+        approval.<a href="#section-1-6.2" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-1-6.3">Transaction Tokens (draft-ietf-oauth-transaction-tokens)
+        propagate call context across workloads within a trust domain;
+        they are short-lived, online-validated, and assert
+        <em>workload</em> identity, not a human's authorization of an
+        action.<a href="#section-1-6.3" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-1-6.4">The Security Event Token (RFC 8417) and CAEP convey, as
+        issuer assertions, that an event <em>occurred</em>; they are not
+        a human's pre-execution approval bound to one exact action.<a href="#section-1-6.4" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-1-6.5">RATS (RFC 9334) and the Entity Attestation Token (RFC 9711)
+        attest the trustworthiness of a <em>platform or workload</em>,
+        not that a named human authorized an action -- a different trust
+        root.<a href="#section-1-6.5" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-1-6.6">SCITT (RFC 9943) provides an append-only transparency log
+        and inclusion receipts, but is deliberately agnostic about the
+        application semantics and authority behind a statement. An EP
+        receipt can be carried as one such application statement.<a href="#section-1-6.6" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-1-6.7">The agent-action evidence work now emerging around that
+        architecture -- per-action receipt envelopes, action capsules,
+        post-execution profiles, pre-execution permits, and refusal
+        events -- makes agent actions transparent, logged, and
+        policy-checked. Some define approval or intent evidence with
+        different ceremony, identity, freshness, or consumption
+        guarantees.<a href="#section-1-6.7" class="pilcrow">¶</a>
+</li>
+      </ul>
+<p id="section-1-7">The use case for this receipt is narrower than agent logging in
+      general: a relying party needs an action-bound approval event under
+      a named verification profile, portable outside the operator, agent
+      runtime, and transparency service. EP is one such artifact and is
+      not a replacement for any of the above: it composes with them
+      (<a href="#related-work" class="auto internal xref">Section 11</a>) and can be carried in their
+      formats -- for example, an EP receipt expressed as a COSE Signed
+      Statement and logged by a SCITT Transparency Service, or
+      referenced by digest from an action receipt, capsule, or
+      permit.<a href="#section-1-7" class="pilcrow">¶</a></p>
+<p id="section-1-8">The human-approval mechanism this document specifies -- a
+      user-verification-gated signature over the exact Authorization
+      Context (<a href="#key-classes" class="auto internal xref">Section 5.1</a>, Class A) -- is native to EP
+      and self-contained. It does not depend on, and is not a profile of,
+      any other draft's acquiescence, consent, or confirmation mechanism;
+      a conforming EP signoff is produced entirely by the controls defined
+      here. Where EP composes with adjacent work
+      (<a href="#related-work" class="auto internal xref">Section 11</a>), that composition is by reference,
+      not dependency.<a href="#section-1-8" class="pilcrow">¶</a></p>
+<section id="section-1.1">
+        <h3 id="name-design-goals">
+<a href="#section-1.1" class="section-number selfRef">1.1. </a><a href="#name-design-goals" class="section-name selfRef">Design Goals</a>
+        </h3>
+<ul class="normal">
+<li class="normal" id="section-1.1-1.1">
+            <strong>G1 -- Action binding.</strong> An approval is
+          cryptographically bound to one exact action. It cannot
+          authorize anything else.<a href="#section-1.1-1.1" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-1.1-1.2">
+            <strong>G2 -- Approver-held keys.</strong> The approver's
+          signature is produced by a key the EP operator does not
+          possess. The operator orchestrates; it cannot forge.<a href="#section-1.1-1.2" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-1.1-1.3">
+            <strong>G3 -- One-time consumption.</strong> An
+          authorization reaches a terminal state at most once within the
+          executor's shared atomic consumption domain. Replay presented to
+          that domain <span class="bcp14">MUST</span> be rejected. An offline receipt
+          alone cannot prove that no independent executor consumed the same
+          authorization.<a href="#section-1.1-1.3" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-1.1-1.4">
+            <strong>G4 -- Separation of duties.</strong> The initiator
+          of an action <span class="bcp14">MUST NOT</span> be an approver of that
+          action. Policies <span class="bcp14">MAY</span> require m-of-n distinct
+          approvers.<a href="#section-1.1-1.4" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-1.1-1.5">
+            <strong>G5 -- Offline verifiability.</strong> A receipt is
+          verifiable with no network access, using only the receipt, the
+          approver's public key material, and a published log checkpoint.
+          Offline verification establishes authenticity and log inclusion
+          as of commit time, not current revocation status
+          (<a href="#offline-verification" class="auto internal xref">Section 6.3</a>).<a href="#section-1.1-1.5" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-1.1-1.6">
+            <strong>G6 -- Execution-side enforcement.</strong> The
+          strongest deployment places verification at the system of
+          record: the executing service verifies the receipt before
+          performing the action. Middleware-only deployments are
+          explicitly defined as a weaker conformance class
+          (<a href="#conformance" class="auto internal xref">Section 10</a>).<a href="#section-1.1-1.6" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-1.1-1.7">
+            <strong>G7 -- Machine-checked safety.</strong> The protocol
+          state machine's safety properties are maintained as formal
+          models (TLA+, Alloy, and Tamarin) and checked in continuous integration.
+          Implementations can be tested against a published conformance
+          suite.<a href="#section-1.1-1.7" class="pilcrow">¶</a>
+</li>
+        </ul>
+</section>
+<div id="scope-of-identity">
+<section id="section-1.2">
+        <h3 id="name-scope-of-identity">
+<a href="#section-1.2" class="section-number selfRef">1.2. </a><a href="#name-scope-of-identity" class="section-name selfRef">Scope of Identity</a>
+        </h3>
+<p id="section-1.2-1">This document binds an approval to an <em>approver
+        identifier</em> whose key is enrolled in the Approver Directory
+        (<a href="#approver-directory" class="auto internal xref">Section 5.2</a>); it does not, by itself,
+        prove that the holder of that identifier is a particular natural
+        person. Proof of a specific real-world identity -- that
+        <code>ep:approver:jchen-controller</code> is the human Jordan Chen --
+        is out of scope. The Approver Directory trust root
+        (<a href="#approver-directory" class="auto internal xref">Section 5.2</a>) is the explicit slot where
+        an identity-proofing or key-discovery layer binds keys to named
+        persons; the strength of any such binding is a property of that
+        layer, not of the receipt format. A receipt proves that a key
+        enrolled under a given approver identifier signed the exact
+        action; the mapping from identifier to person is established and
+        asserted by the directory authority.<a href="#section-1.2-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+<div id="terminology">
+<section id="section-2">
+      <h2 id="name-terminology">
+<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-terminology" class="section-name selfRef">Terminology</a>
+      </h2>
+<p id="section-2-1">The key words "<span class="bcp14">MUST</span>", "<span class="bcp14">MUST NOT</span>",
+      "<span class="bcp14">REQUIRED</span>", "<span class="bcp14">SHALL</span>",
+      "<span class="bcp14">SHALL NOT</span>", "<span class="bcp14">SHOULD</span>",
+      "<span class="bcp14">SHOULD NOT</span>", "<span class="bcp14">RECOMMENDED</span>",
+      "<span class="bcp14">NOT RECOMMENDED</span>", "<span class="bcp14">MAY</span>", and
+      "<span class="bcp14">OPTIONAL</span>" in this document are to be interpreted as
+      described in BCP 14 <span>[<a href="#RFC2119" class="cite xref">RFC2119</a>]</span> <span>[<a href="#RFC8174" class="cite xref">RFC8174</a>]</span>
+      when, and only when, they appear in all capitals, as shown here.<a href="#section-2-1" class="pilcrow">¶</a></p>
+<p id="section-2-2"><strong>Initiator.</strong> The entity (typically an AI agent or
+      automated process) that proposes a high-risk action. The initiator
+      is identified but never trusted with approval authority over its
+      own actions.<a href="#section-2-2" class="pilcrow">¶</a></p>
+<p id="section-2-3"><strong>Approver.</strong> A named human (or, for lower
+      assurance classes, an organizational role occupied by a named human
+      at decision time) who holds approval authority under policy. The
+      approver controls a private signing key; see
+      <a href="#approver-keys" class="auto internal xref">Section 5</a>.<a href="#section-2-3" class="pilcrow">¶</a></p>
+<p id="section-2-4"><strong>Action.</strong> A single proposed operation with
+      concrete parameters (e.g., one wire transfer to one beneficiary for
+      one amount). Actions are represented by an Action Object and
+      identified by their action hash (<a href="#action-object" class="auto internal xref">Section 3</a>).<a href="#section-2-4" class="pilcrow">¶</a></p>
+<p id="section-2-5"><strong>Policy.</strong> A named, versioned rule set
+      determining, for a class of actions, which approvers are required
+      (including m-of-n thresholds), validity windows, and amount or
+      scope limits.<a href="#section-2-5" class="pilcrow">¶</a></p>
+<p id="section-2-6"><strong>Authorization Context.</strong> The canonical structure
+      an approver signs: action hash, policy reference, initiator
+      identity, nonce, expiry, and chain binding
+      (<a href="#authorization-context" class="auto internal xref">Section 4</a>).<a href="#section-2-6" class="pilcrow">¶</a></p>
+<p id="section-2-7"><strong>Initiator Attestation.</strong> An
+      <span class="bcp14">OPTIONAL</span> claim by the initiator, carried inside the
+      Authorization Context, stating why the initiator escalated the
+      action to a human (<a href="#initiator-attestation" class="auto internal xref">Section 4.1</a>). It is a
+      claim, not proof of the initiator's internal state.<a href="#section-2-7" class="pilcrow">¶</a></p>
+<p id="section-2-8"><strong>Trust Receipt.</strong> The terminal artifact: the
+      Action Object digest, all approver signatures, the consumption
+      record, and a Merkle inclusion proof against a signed log
+      checkpoint (<a href="#consumption" class="auto internal xref">Section 6</a>).<a href="#section-2-8" class="pilcrow">¶</a></p>
+<p id="section-2-9"><strong>Verifying Executor.</strong> A system of record that
+      verifies a Trust Receipt (or a pre-execution Authorization Bundle)
+      before performing the action. See <a href="#conformance" class="auto internal xref">Section 10</a>.<a href="#section-2-9" class="pilcrow">¶</a></p>
+<p id="section-2-10"><strong>EP Operator.</strong> The party running the
+      orchestration service (policy registry, signoff routing, log).
+      Under this protocol the operator is <em>not</em> in the signing
+      trust path for approvals (G2).<a href="#section-2-10" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="action-object">
+<section id="section-3">
+      <h2 id="name-the-action-object-and-actio">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-the-action-object-and-actio" class="section-name selfRef">The Action Object and Action Hash</a>
+      </h2>
+<p id="section-3-1">An Action Object is a JSON document with at minimum:<a href="#section-3-1" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="section-3-2">
+<pre>
+{
+  "ep_version": "1.0",
+  "action_type": "wire.release",
+  "target": { "system": "treasury.example",
+              "resource": "wire/8841" },
+  "parameters": { "amount": "2400000.00", "currency": "USD",
+                  "beneficiary_account_hash": "sha256:..." },
+  "initiator": "ep:entity:agent-recon-7",
+  "policy_id": "ep:policy:wires-over-100k@v12",
+  "requested_at": "2026-06-09T17:21:04Z"
+}
+</pre><a href="#section-3-2" class="pilcrow">¶</a>
+</div>
+<p id="section-3-3">The Action Object <span class="bcp14">MUST</span> be serialized using JSON
+      Canonicalization Scheme (JCS) <span>[<a href="#RFC8785" class="cite xref">RFC8785</a>]</span>. The
+      <strong>action hash</strong> is the SHA-256 digest of the canonical
+      serialization. Implementations <span class="bcp14">MUST</span> reject approval
+      requests whose action hash does not match a locally recomputed hash
+      of the presented Action Object. Sensitive parameter values
+      <span class="bcp14">MAY</span> be carried as salted hashes (as
+      <code>beneficiary_account_hash</code> above) provided the executing
+      system can recompute them; the binding property is preserved
+      because the hash commits to the committed values.<a href="#section-3-3" class="pilcrow">¶</a></p>
+<p id="section-3-4">The action hash is this receipt format's native integrity
+      identifier. It is not assumed to equal an action digest from a
+      different protocol. A composition layer MAY project the verified
+      Action Object into a Canonical Action IDentifier action type
+      as defined by CAID <span>[<a href="#EP-CAID" class="cite xref">EP-CAID</a>]</span> using
+      an exact mapping profile pinned by the relying party. Such mapping
+      occurs only after receipt verification and does not change this
+      document's signature input. A failed, lossy, or unpinned mapping is
+      indeterminate and MUST NOT be treated as an action match.<a href="#section-3-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="authorization-context">
+<section id="section-4">
+      <h2 id="name-the-authorization-context">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-the-authorization-context" class="section-name selfRef">The Authorization Context</a>
+      </h2>
+<p id="section-4-1">For each required approver, the orchestrator constructs an
+      Authorization Context:<a href="#section-4-1" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="section-4-2">
+<pre>
+{
+  "ep_version": "1.0",
+  "context_type": "ep.signoff.v1",
+  "action_hash": "sha256:9f2c...",
+  "policy_id": "ep:policy:wires-over-100k@v12",
+  "policy_hash": "sha256:77ab...",
+  "initiator": "ep:entity:agent-recon-7",
+  "approver": "ep:approver:jchen-controller",
+  "approver_index": 1,
+  "required_approvals": 2,
+  "nonce": "b64u:R9w1...",
+  "issued_at": "2026-06-09T17:21:05Z",
+  "expires_at": "2026-06-09T17:36:05Z",
+  "prev_receipt_hash": "sha256:51d0..."
+}
+</pre><a href="#section-4-2" class="pilcrow">¶</a>
+</div>
+<p id="section-4-3">Rules:<a href="#section-4-3" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-4-4.1">
+          <code>nonce</code> <span class="bcp14">MUST</span> be at least 128 bits of
+        CSPRNG output and <span class="bcp14">MUST</span> be unique within the issuer and
+        consumption domain for each authorization attempt. It is the
+        consumption key for G3, and is
+        the receipt's freshness mechanism in the sense of the Entity
+        Attestation Token (RFC 9711): a verifier-relevant nonce, here held
+        to a 128-bit floor (twice the EAT minimum). EP does not treat a
+        timestamp alone as freshness; absolute time, where a relying party
+        requires it, is asserted by an independent authority rather than by
+        the operator.<a href="#section-4-4.1" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-4-4.2">
+          <code>policy_hash</code> commits to the exact policy version
+        evaluated. A signature over a context with policy_hash X
+        <span class="bcp14">MUST NOT</span> satisfy a requirement evaluated under
+        policy_hash Y, even for the same policy_id.<a href="#section-4-4.2" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-4-4.3">
+          <code>prev_receipt_hash</code> chains this authorization to the
+        issuing log's most recent receipt, contributing to tamper
+        evidence.<a href="#section-4-4.3" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-4-4.4">The context is JCS-canonicalized; the <strong>context
+        hash</strong> is its SHA-256 digest. The approver signs the
+        context hash.<a href="#section-4-4.4" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-4-4.5">The approver <span class="bcp14">MUST</span> be shown, at signing time, a
+        faithful human-readable rendering of the Action Object -- not only
+        the hash. Signing interfaces that display a different action than
+        the one hashed are a presentation attack; see
+        <a href="#presentation-attacks" class="auto internal xref">Section 12.3</a>.<a href="#section-4-4.5" class="pilcrow">¶</a>
+</li>
+      </ul>
+<div id="initiator-attestation">
+<section id="section-4.1">
+        <h3 id="name-initiator-attestation-optio">
+<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-initiator-attestation-optio" class="section-name selfRef">Initiator Attestation (OPTIONAL)</a>
+        </h3>
+<p id="section-4.1-1">A producer <span class="bcp14">MAY</span> include an
+        <code>initiator_attestation</code> member in any
+        <code>ep.signoff.v1</code> Authorization Context. The member carries
+        the initiator's own stated reason for escalating the action to a
+        human. When present it <span class="bcp14">MUST</span> be a JSON object with
+        the following members and no others:<a href="#section-4.1-1" class="pilcrow">¶</a></p>
+<table class="center" id="table-1">
+          <caption><a href="#table-1" class="selfRef">Table 1</a></caption>
+<thead>
+            <tr>
+              <th class="text-left" rowspan="1" colspan="1">Field</th>
+              <th class="text-left" rowspan="1" colspan="1">Required</th>
+              <th class="text-left" rowspan="1" colspan="1">Type</th>
+              <th class="text-left" rowspan="1" colspan="1">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>escalation_trigger</code>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span class="bcp14">REQUIRED</span>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">string (enum)</td>
+              <td class="text-left" rowspan="1" colspan="1">Why the initiator escalated. Exactly one of:
+              <code>irreversibility</code>, <code>magnitude</code>,
+              <code>uncertainty</code>, <code>novelty</code>,
+              <code>authority_gap</code>, <code>policy_rule</code>.</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>policy_basis</code>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span class="bcp14">OPTIONAL</span> (<span class="bcp14">REQUIRED</span>
+              whenever a deterministic policy rule fired, including always
+              when <code>escalation_trigger</code> is
+              <code>policy_rule</code>)</td>
+              <td class="text-left" rowspan="1" colspan="1">string</td>
+              <td class="text-left" rowspan="1" colspan="1">Identifier of the policy or rule that fired, e.g.
+              <code>ep:policy:wires-over-100k@v12/rule:dual-auth</code>.</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>statement</code>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span class="bcp14">OPTIONAL</span>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">string</td>
+              <td class="text-left" rowspan="1" colspan="1">Short free-text reason the initiator gives the approver.
+              <span class="bcp14">MUST NOT</span> exceed 280 characters.</td>
+            </tr>
+          </tbody>
+        </table>
+<p id="section-4.1-3">Enum semantics:<a href="#section-4.1-3" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-4.1-4.1">
+            <code>irreversibility</code> -- the action cannot be undone once
+          executed.<a href="#section-4.1-4.1" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.1-4.2">
+            <code>magnitude</code> -- the amount or scope exceeds what the
+          initiator should act on alone.<a href="#section-4.1-4.2" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.1-4.3">
+            <code>uncertainty</code> -- the initiator's confidence in its own
+          assessment is too low to proceed unaided.<a href="#section-4.1-4.3" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.1-4.4">
+            <code>novelty</code> -- the action or counterparty has no
+          precedent in the initiator's history.<a href="#section-4.1-4.4" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.1-4.5">
+            <code>authority_gap</code> -- the action requires authority the
+          initiator was never granted.<a href="#section-4.1-4.5" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.1-4.6">
+            <code>policy_rule</code> -- a deterministic policy rule required
+          signoff and none of the five substantive categories above
+          captures why; <code>policy_basis</code> names the rule.<a href="#section-4.1-4.6" class="pilcrow">¶</a>
+</li>
+        </ul>
+<p id="section-4.1-5">Example context (fields as above, with the new member):<a href="#section-4.1-5" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="section-4.1-6">
+<pre>
+{
+  "ep_version": "1.0",
+  "context_type": "ep.signoff.v1",
+  "action_hash": "sha256:9f2c...",
+  "policy_id": "ep:policy:wires-over-100k@v12",
+  "policy_hash": "sha256:77ab...",
+  "initiator": "ep:entity:agent-recon-7",
+  "initiator_attestation": {
+    "escalation_trigger": "magnitude",
+    "policy_basis": "ep:policy:wires-over-100k@v12/rule:dual-auth",
+    "statement": "Exceeds my single-action limit; new beneficiary."
+  },
+  "approver": "ep:approver:jchen-controller",
+  "approver_index": 1,
+  "required_approvals": 2,
+  "nonce": "b64u:R9w1...",
+  "issued_at": "2026-06-09T17:21:05Z",
+  "expires_at": "2026-06-09T17:36:05Z"
+}
+</pre><a href="#section-4.1-6" class="pilcrow">¶</a>
+</div>
+<p id="section-4.1-7">Rules:<a href="#section-4.1-7" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-4.1-8.1">
+            <strong>Status.</strong> The member is
+          <span class="bcp14">OPTIONAL</span>. Existing issuers remain conformant; the
+          field can be adopted policy-by-policy.<a href="#section-4.1-8.1" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.1-8.2">
+            <strong>Binding.</strong> No new signature, digest, or
+          verification step is introduced. The context is
+          JCS-canonicalized as already required above; JCS serializes
+          every member present, so <code>initiator_attestation</code> and
+          everything inside it are part of the signed bytes. The
+          approver's signature therefore covers the stated reason: the
+          receipt proves the stated reason was part of what the approver
+          signed. Receipts carrying this member verify under the existing
+          <a href="#offline-verification" class="auto internal xref">Section 6.3</a> verifiers unmodified; a
+          context without the member produces byte-identical canonical
+          material to one produced today.<a href="#section-4.1-8.2" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.1-8.3">
+            <strong>Trigger/basis precedence.</strong>
+            <code>escalation_trigger</code> always carries the substantive
+          reason: when one of the first five enum values applies, the
+          producer <span class="bcp14">MUST</span> use it, whether or not a
+          deterministic rule also fired; <code>policy_rule</code>
+            <span class="bcp14">MUST</span> be used only when no substantive category
+          fits. Independently of which trigger is chosen, whenever a
+          deterministic policy rule fired, <code>policy_basis</code>
+            <span class="bcp14">MUST</span> be populated with that rule's
+          identifier.<a href="#section-4.1-8.3" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.1-8.4">
+            <strong>Cross-context consistency.</strong> When a receipt
+          contains multiple contexts (m-of-n approvals), the
+          <code>initiator_attestation</code> object, if present in any
+          context, <span class="bcp14">MUST</span> be present in every context of that
+          receipt, and its canonical form --
+          <code>canonicalize(initiator_attestation)</code> -- <span class="bcp14">MUST</span>
+          be identical across all of them. Every approver signs the same
+          stated reason.<a href="#section-4.1-8.4" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.1-8.5">Producers <span class="bcp14">MUST NOT</span> add members beyond the
+          three defined above in v1.<a href="#section-4.1-8.5" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.1-8.6">A signing client implementing this member
+          <span class="bcp14">MUST</span> render the attestation to the approver
+          alongside the faithful human-readable rendering of the Action
+          Object that this section already requires, subject to the
+          untrusted-content display rules in
+          <a href="#initiator-attestation-security" class="auto internal xref">Section 12.9</a>.<a href="#section-4.1-8.6" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.1-8.7">A signing client presented with a context whose
+          <code>statement</code> exceeds 280 characters <span class="bcp14">MUST</span>
+          refuse to render it for signing.<a href="#section-4.1-8.7" class="pilcrow">¶</a>
+</li>
+        </ul>
+<p id="section-4.1-9">The attestation is a claim by the initiator, which this
+        document identifies but never trusts
+        (<a href="#terminology" class="auto internal xref">Section 2</a>): it is the initiator's stated
+        reason, not a verified fact, and it is not evidence of the
+        initiator's internal state. Verifiers implementing this member
+        <span class="bcp14">MUST</span> check the cross-context consistency rule above
+        and <span class="bcp14">SHOULD</span> surface the attestation and flag other
+        violations of this section in verification reports; none of these
+        checks affects signature validity, by design, so receipts verify
+        on verifiers that predate this member.<a href="#section-4.1-9" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="agent-binding">
+<section id="section-4.2">
+        <h3 id="name-agent-binding-optional">
+<a href="#section-4.2" class="section-number selfRef">4.2. </a><a href="#name-agent-binding-optional" class="section-name selfRef">Agent Binding (OPTIONAL)</a>
+        </h3>
+<p id="section-4.2-1">A producer <span class="bcp14">MAY</span> include an <code>agent_binding</code>
+        member in any <code>ep.signoff.v1</code> Authorization Context. The
+        member attributes the authorized action to an external <strong>agent
+        identity</strong> and, optionally, the external
+        <strong>delegation</strong> under which that agent was authorized to
+        act. When present it <span class="bcp14">MUST</span> be a JSON object with the
+        following members and no others:<a href="#section-4.2-1" class="pilcrow">¶</a></p>
+<table class="center" id="table-2">
+          <caption><a href="#table-2" class="selfRef">Table 2</a></caption>
+<thead>
+            <tr>
+              <th class="text-left" rowspan="1" colspan="1">Field</th>
+              <th class="text-left" rowspan="1" colspan="1">Required</th>
+              <th class="text-left" rowspan="1" colspan="1">Type</th>
+              <th class="text-left" rowspan="1" colspan="1">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>agent_id</code>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span class="bcp14">REQUIRED</span>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">string</td>
+              <td class="text-left" rowspan="1" colspan="1">Non-empty external agent-identity reference (URI, DID, or
+              opaque id). This document does not constrain its scheme.</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>delegation</code>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span class="bcp14">OPTIONAL</span>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">object</td>
+              <td class="text-left" rowspan="1" colspan="1">The external delegation that authorized the agent; members
+              below, no others.</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>statement</code>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span class="bcp14">OPTIONAL</span>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">string</td>
+              <td class="text-left" rowspan="1" colspan="1">Short free-text note for the approver. <span class="bcp14">MUST NOT</span>
+              exceed 280 characters.</td>
+            </tr>
+          </tbody>
+        </table>
+<p id="section-4.2-3">When <code>delegation</code> is present it <span class="bcp14">MUST</span> be a
+        JSON object with the following members and no others:<a href="#section-4.2-3" class="pilcrow">¶</a></p>
+<table class="center" id="table-3">
+          <caption><a href="#table-3" class="selfRef">Table 3</a></caption>
+<thead>
+            <tr>
+              <th class="text-left" rowspan="1" colspan="1">Field</th>
+              <th class="text-left" rowspan="1" colspan="1">Required</th>
+              <th class="text-left" rowspan="1" colspan="1">Type</th>
+              <th class="text-left" rowspan="1" colspan="1">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>scheme</code>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span class="bcp14">REQUIRED</span>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">string</td>
+              <td class="text-left" rowspan="1" colspan="1">Non-empty name of the external delegation standard, e.g.
+              <code>"WIMSE"</code>, <code>"DRP"</code>.</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>ref</code>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span class="bcp14">REQUIRED</span>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">string</td>
+              <td class="text-left" rowspan="1" colspan="1">Non-empty external receipt/credential identifier.</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>hash</code>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span class="bcp14">OPTIONAL</span>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">string</td>
+              <td class="text-left" rowspan="1" colspan="1">Content hash of the referenced artifact, formatted
+              <code>"sha256:&lt;64-lowercase-hex&gt;"</code>.</td>
+            </tr>
+            <tr>
+              <td class="text-left" rowspan="1" colspan="1">
+                <code>observed_at</code>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">
+                <span class="bcp14">OPTIONAL</span>
+</td>
+              <td class="text-left" rowspan="1" colspan="1">string</td>
+              <td class="text-left" rowspan="1" colspan="1">RFC 3339 timestamp recording when the external delegation
+              evidence was observed or known valid. See L4 evidence freshness
+              below.</td>
+            </tr>
+          </tbody>
+        </table>
+<p id="section-4.2-5">Example context (fields as above, with the new member):<a href="#section-4.2-5" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="section-4.2-6">
+<pre>
+{
+  "ep_version": "1.0",
+  "context_type": "ep.signoff.v1",
+  "action_hash": "sha256:9f2c...",
+  "policy_id": "ep:policy:wires-over-100k@v12",
+  "policy_hash": "sha256:77ab...",
+  "initiator": "ep:entity:agent-recon-7",
+  "agent_binding": {
+    "agent_id": "did:web:agents.example.com:recon-7",
+    "delegation": {
+      "scheme": "WIMSE",
+      "ref": "urn:wimse:cred:9c41ab",
+      "hash": "sha256:2f9a...",
+      "observed_at": "2026-06-09T17:20:48Z"
+    },
+    "statement": "Acting for treasury-ops under wire delegation."
+  },
+  "approver": "ep:approver:jchen-controller",
+  "approver_index": 1,
+  "required_approvals": 2,
+  "nonce": "b64u:R9w1...",
+  "issued_at": "2026-06-09T17:21:05Z",
+  "expires_at": "2026-06-09T17:36:05Z"
+}
+</pre><a href="#section-4.2-6" class="pilcrow">¶</a>
+</div>
+<p id="section-4.2-7">Rules:<a href="#section-4.2-7" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-4.2-8.1">
+            <strong>Status.</strong> The member is <span class="bcp14">OPTIONAL</span>.
+          Existing issuers remain conformant; the field can be adopted
+          policy-by-policy.<a href="#section-4.2-8.1" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.2-8.2">
+            <strong>Claim, not proof.</strong> <code>agent_binding</code>
+          records that the action was <em>presented</em> as being taken by
+          <code>agent_id</code> under delegation <code>ref</code>. This document
+          identifies but never trusts the binding
+          (<a href="#terminology" class="auto internal xref">Section 2</a>): it is neither proof of the agent's
+          identity nor proof of the delegation's validity, both of which
+          remain the responsibility of the referenced external system. A
+          verifier <span class="bcp14">MUST NOT</span> treat <code>agent_binding</code> as
+          proof of either; it <span class="bcp14">MAY</span> surface <code>agent_id</code> and
+          <code>delegation</code> to the relying party as part of the verified
+          context, clearly labeled as a reference to an external system.<a href="#section-4.2-8.2" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.2-8.3">
+            <strong>Binding.</strong> No new signature, digest, or
+          verification step is introduced. The context is JCS-canonicalized as
+          already required above; JCS serializes every member present, so
+          <code>agent_binding</code> and everything inside it are part of the
+          signed bytes. The approver's signature therefore covers the binding.
+          Receipts carrying this member verify under the existing
+          <a href="#offline-verification" class="auto internal xref">Section 6.3</a> verifiers unmodified; a context
+          without it produces byte-identical canonical material to one produced
+          today.<a href="#section-4.2-8.3" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.2-8.4">
+            <strong>Cross-context consistency.</strong> When a receipt
+          contains multiple contexts (m-of-n approvals), the
+          <code>agent_binding</code> object, if present in any context,
+          <span class="bcp14">MUST</span> be present in every context of that receipt, and
+          its canonical form -- <code>canonicalize(agent_binding)</code> --
+          <span class="bcp14">MUST</span> be identical across all of them. Every approver
+          signs the same attribution.<a href="#section-4.2-8.4" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.2-8.5">Producers <span class="bcp14">MUST NOT</span> add members beyond those
+          defined above in v1, in either <code>agent_binding</code> or its
+          <code>delegation</code>.<a href="#section-4.2-8.5" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.2-8.6">A signing client implementing this member <span class="bcp14">SHOULD</span>
+          render <code>agent_id</code> (and <code>delegation</code> if present) to the
+          approver alongside the faithful human-readable rendering of the
+          Action Object that this section already requires, subject to the
+          untrusted-content display rules in
+          <a href="#initiator-attestation-security" class="auto internal xref">Section 12.9</a>. A signing client
+          presented with a context whose <code>statement</code> exceeds 280
+          characters <span class="bcp14">MUST</span> refuse to render it for signing.<a href="#section-4.2-8.6" class="pilcrow">¶</a>
+</li>
+        </ul>
+<p id="section-4.2-9"><strong>L4 evidence freshness (OPTIONAL).</strong> A human
+        authorization decision is only as trustworthy as the upstream
+        agent-identity and delegation evidence it relied on. If a decision is
+        enforced correctly against a delegation claim that was never
+        constrained or has since expired, the failure surfaces at the
+        authorization layer but originates in the identity/delegation layer
+        beneath it. This document makes that dependency explicit and recordable
+        without absorbing the identity layer:<a href="#section-4.2-9" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-4.2-10.1">A producer <span class="bcp14">MAY</span> populate
+          <code>delegation.observed_at</code> with the RFC 3339 time at which the
+          external delegation evidence was observed or known valid. Like the
+          rest of the binding, it is covered by the approver's signature.<a href="#section-4.2-10.1" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-4.2-10.2">A relying party <span class="bcp14">MAY</span> enforce freshness against
+          <code>observed_at</code>. When it does, the evaluation
+          <span class="bcp14">MUST</span> fail closed: a missing <code>observed_at</code>, a
+          timestamp later than the evaluation time, or an age exceeding the
+          relying party's configured maximum <span class="bcp14">MUST</span> be treated as
+          not-fresh. When no maximum age is configured, freshness is not
+          evaluated and the evidence is still surfaced for the audit
+          record.<a href="#section-4.2-10.2" class="pilcrow">¶</a>
+</li>
+        </ul>
+<p id="section-4.2-11">This keeps the receipt agnostic to which external
+        identity/delegation scheme prevails: the relying party binds to and
+        records whatever evidence was presented rather than requiring that
+        layer to converge, and a stale or unconstrained upstream claim becomes
+        detectable after the fact rather than silently absorbed. As with the
+        Initiator Attestation, none of these checks affects signature validity,
+        by design, so receipts verify on verifiers that predate this
+        member.<a href="#section-4.2-11" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="approver-keys">
+<section id="section-5">
+      <h2 id="name-approver-keys-and-the-signo">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-approver-keys-and-the-signo" class="section-name selfRef">Approver Keys and the Signoff Signature</a>
+      </h2>
+<p id="section-5-1">This section is the core upgrade over server-side approval
+      systems.<a href="#section-5-1" class="pilcrow">¶</a></p>
+<div id="key-classes">
+<section id="section-5.1">
+        <h3 id="name-key-classes">
+<a href="#section-5.1" class="section-number selfRef">5.1. </a><a href="#name-key-classes" class="section-name selfRef">Key Classes</a>
+        </h3>
+<p id="section-5.1-1">Key classes classify KEY CUSTODY -- who holds and exercises
+        the approver's signing key -- and nothing else. They are
+        distinct from, and unrelated to, any assurance-level or
+        conformance-class vocabulary used elsewhere. Cross-protocol
+        requirements ought to name verifier-visible properties such as
+        user verification, device binding, initiator exclusion, distinct
+        humans, freshness, and status rather than treating these
+        receipt-local custody labels as universal assurance grades.<a href="#section-5.1-1" class="pilcrow">¶</a></p>
+<p id="section-5.1-2"><strong>Class A -- Device-bound keys
+        (<span class="bcp14">RECOMMENDED</span>).</strong> The approver's key is
+        generated and held in a platform authenticator or security key
+        and exercised via WebAuthn <span>[<a href="#WEBAUTHN" class="cite xref">WEBAUTHN</a>]</span>. The
+        signature algorithm is ES256 (P-256) or Ed25519 where supported.
+        The WebAuthn challenge <span class="bcp14">MUST</span> be the context hash.
+        The authenticator's user-verification flag (biometric or PIN)
+        <span class="bcp14">MUST</span> be required for signoff credentials. This
+        user-verification-gated signature is the native EP human-approval
+        act; it is fully defined by this section and does not rely on any
+        external acquiescence or confirmation mechanism. Attestation
+        <span class="bcp14">SHOULD</span> be captured at enrollment so relying parties
+        can establish that the key is hardware-bound.<a href="#section-5.1-2" class="pilcrow">¶</a></p>
+<p id="section-5.1-3"><strong>Class B -- Software keys.</strong> An Ed25519 keypair
+        held in the approver's client environment (CLI keychain, mobile
+        secure enclave via app). Acceptable where WebAuthn is impractical
+        (headless approval terminals), with the reduced assurance noted
+        in receipts.<a href="#section-5.1-3" class="pilcrow">¶</a></p>
+<p id="section-5.1-4"><strong>Class C -- Operator-custodied keys (LEGACY).</strong>
+        The EP operator signs on the approver's behalf after
+        authenticating them. This class exists only to describe
+        pre-existing deployments. Receipts produced under Class C
+        <span class="bcp14">MUST</span> be labeled <code>key_class: "C"</code> and
+        relying parties <span class="bcp14">SHOULD</span> treat them as evidence of
+        operator assertion, not approver signature. New deployments
+        <span class="bcp14">SHOULD NOT</span> use Class C.<a href="#section-5.1-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="approver-directory">
+<section id="section-5.2">
+        <h3 id="name-enrollment-and-the-approver">
+<a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-enrollment-and-the-approver" class="section-name selfRef">Enrollment and the Approver Directory</a>
+        </h3>
+<p id="section-5.2-1">Approver public keys are enrolled into a signed Approver
+        Directory maintained per organization: a Merkle tree over
+        <code>(approver_id, public_key, key_class, valid_from, valid_to,
+        roles)</code> entries, with signed tree heads published alongside
+        receipt log checkpoints. A receipt's offline verifiability (G5)
+        includes an inclusion proof of the approver's key entry, so a
+        verifier needs no live directory access. Key rotation appends a
+        new entry and terminates the old one; signatures verify against
+        the key entry valid at <code>issued_at</code>.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
+<p id="section-5.2-2">Directory authority is a trust root and <span class="bcp14">MUST NOT</span> default to the EP operator. The directory tree head
+        <span class="bcp14">MUST</span> be signed by an organization-controlled
+        directory key (custody options parallel
+        <a href="#key-classes" class="auto internal xref">Section 5.1</a>; an organization-held hardware key
+        is <span class="bcp14">RECOMMENDED</span>). Where directory
+        <em>operation</em> is delegated to the EP operator, every
+        enrollment entry <span class="bcp14">MUST</span> carry a second-party
+        attestation -- a signature over the new entry by an organization
+        administrator key or by a quorum of already-enrolled approvers --
+        and that attestation <span class="bcp14">MUST</span> be included in the
+        receipt's <code>approver_key_proofs</code>. Verifiers
+        <span class="bcp14">MUST</span> treat a directory head signed only by an
+        operator-held key as operator assertion (Class C-equivalent
+        assurance), regardless of the key class of the individual
+        signoffs. Rationale: an operator that unilaterally controls
+        directory membership cannot forge an enrolled approver's
+        signature, but it can enroll a key it controls under a legitimate
+        approver's name -- relocating the forgery rather than preventing
+        it. See <a href="#directory-authority" class="auto internal xref">Section 12.6</a>.<a href="#section-5.2-2" class="pilcrow">¶</a></p>
+<p id="section-5.2-3">This directory is also the binding point between approver
+        identifiers and real-world persons
+        (<a href="#scope-of-identity" class="auto internal xref">Section 1.2</a>). The strength of that binding
+        -- how an organization proves that an enrolled identifier is the
+        person it names, and how key-discovery layers attach to it -- is a
+        property of the directory authority and any identity layer bound
+        to it, not of the receipt format defined here.<a href="#section-5.2-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<section id="section-5.3">
+        <h3 id="name-the-signoff">
+<a href="#section-5.3" class="section-number selfRef">5.3. </a><a href="#name-the-signoff" class="section-name selfRef">The Signoff</a>
+        </h3>
+<p id="section-5.3-1">A signoff is:<a href="#section-5.3-1" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="section-5.3-2">
+<pre>
+{
+  "context_hash": "sha256:c41e...",
+  "signature": "b64u:MEUCIQ...",
+  "key_class": "A",
+  "approver_key_id": "ep:key:jchen-controller#2026-01",
+  "signed_at": "2026-06-09T17:24:40Z",
+  "webauthn": { "authenticator_data": "b64u:...",
+                "client_data_json": "b64u:..." }
+}
+</pre><a href="#section-5.3-2" class="pilcrow">¶</a>
+</div>
+<p id="section-5.3-3">For Class A, verifiers <span class="bcp14">MUST</span> validate the
+        WebAuthn assertion per <span>[<a href="#WEBAUTHN" class="cite xref">WEBAUTHN</a>]</span> including that
+        <code>clientDataJSON.challenge</code> equals the context hash and
+        that the user-verification bit is set. A denial is also signed
+        (over the context hash with a <code>decision: "denied"</code>
+        envelope) so that refusals are equally attributable,
+        tamper-evident, and terminal. This is a cryptographic statement;
+        legal non-repudiation is out of scope.<a href="#section-5.3-3" class="pilcrow">¶</a></p>
+</section>
+</section>
+</div>
+<div id="consumption">
+<section id="section-6">
+      <h2 id="name-consumption-commitment-and-">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-consumption-commitment-and-" class="section-name selfRef">Consumption, Commitment, and the Trust Receipt</a>
+      </h2>
+<section id="section-6.1">
+        <h3 id="name-state-machine">
+<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-state-machine" class="section-name selfRef">State Machine</a>
+        </h3>
+<p id="section-6.1-1">An authorization attempt proceeds:<a href="#section-6.1-1" class="pilcrow">¶</a></p>
+<div class="alignLeft art-text artwork" id="section-6.1-2">
+<pre>
+REQUESTED -&gt; {PARTIALLY_APPROVED}* -&gt; APPROVED -&gt; COMMITTED
+          \-&gt; DENIED                          \-&gt; EXPIRED
+          \-&gt; EXPIRED
+</pre><a href="#section-6.1-2" class="pilcrow">¶</a>
+</div>
+<p id="section-6.1-3">COMMITTED, DENIED, and EXPIRED are terminal. The protocol
+        invariants -- maintained as machine-checked models and
+        <span class="bcp14">REQUIRED</span> of conforming implementations -- are:<a href="#section-6.1-3" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-6.1-4.1">
+            <strong>ConsumeOnce.</strong> Within one conforming shared,
+          atomic consumption domain, a nonce transitions to a terminal
+          state at most once. Any second presentation to that domain
+          <span class="bcp14">MUST</span> be rejected with a replay error. The model
+          does not assert coordination with an independent store that
+          does not share this state.<a href="#section-6.1-4.1" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-6.1-4.2">
+            <strong>BindingMatch.</strong> A signoff satisfies only the
+          context (and therefore only the action hash) it signs.<a href="#section-6.1-4.2" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-6.1-4.3">
+            <strong>TerminalIrreversibility.</strong> No transition
+          exits a terminal state.<a href="#section-6.1-4.3" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-6.1-4.4">
+            <strong>SelfApprovalImpossible.</strong> For every signoff,
+          <code>approver != initiator</code>; for m-of-n policies, approvers
+          are pairwise distinct and each distinct from the
+          initiator.<a href="#section-6.1-4.4" class="pilcrow">¶</a>
+</li>
+          <li class="normal" id="section-6.1-4.5">
+            <strong>NoBypassWrite.</strong> A COMMITTED state is
+          reachable only through the full sequence; conforming verifying
+          executors <span class="bcp14">MUST NOT</span> execute without verifying it
+          (<a href="#conformance" class="auto internal xref">Section 10</a>).<a href="#section-6.1-4.5" class="pilcrow">¶</a>
+</li>
+        </ul>
+</section>
+<section id="section-6.2">
+        <h3 id="name-the-trust-receipt">
+<a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-the-trust-receipt" class="section-name selfRef">The Trust Receipt</a>
+        </h3>
+<p id="section-6.2-1">Upon commitment the orchestrator assembles and logs the Trust
+        Receipt:<a href="#section-6.2-1" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="section-6.2-2">
+<pre>
+{
+  "receipt_id": "ep:receipt:01J...",
+  "action": { "...": "full Action Object" },
+  "action_hash": "sha256:9f2c...",
+  "contexts": [ { "...": "Authorization Context 1" } ],
+  "signoffs": [ { "...": "Signoff 1" },
+                { "...": "Signoff 2" } ],
+  "consumption": { "nonce": "b64u:R9w1...",
+                   "state": "COMMITTED",
+                   "committed_at": "2026-06-09T17:25:02Z" },
+  "log_proof": { "leaf_index": 88412,
+                 "inclusion_path": ["sha256:...", "..."],
+                 "checkpoint": { "tree_size": 90210,
+                                 "root_hash": "sha256:...",
+                                 "log_signature": "b64u:...",
+                                 "log_key_id": "ep:log:acme#1" } },
+  "approver_key_proofs": [ { "directory_inclusion": "..." } ]
+}
+</pre><a href="#section-6.2-2" class="pilcrow">¶</a>
+</div>
+</section>
+<div id="offline-verification">
+<section id="section-6.3">
+        <h3 id="name-offline-verification-algori">
+<a href="#section-6.3" class="section-number selfRef">6.3. </a><a href="#name-offline-verification-algori" class="section-name selfRef">Offline Verification Algorithm</a>
+        </h3>
+<p id="section-6.3-1">A verifier with (receipt, trusted log public key, trusted
+        directory root or pinned approver keys) and <strong>no network
+        access</strong> <span class="bcp14">MUST</span> be able to establish all of
+        the following; the published verifier package performs exactly
+        these steps:<a href="#section-6.3-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-6.3-2">
+          <li id="section-6.3-2.1">Recompute the action hash from the canonical Action Object;
+          compare.<a href="#section-6.3-2.1" class="pilcrow">¶</a>
+</li>
+          <li id="section-6.3-2.2">For each context: recompute the context hash; confirm it
+          commits to the action hash, the policy hash, and a distinct
+          approver.<a href="#section-6.3-2.2" class="pilcrow">¶</a>
+</li>
+          <li id="section-6.3-2.3">For each signoff: verify the signature (and WebAuthn
+          assertion where present) over the context hash against the
+          approver key entry, checking the key's validity window contains
+          <code>issued_at</code>.<a href="#section-6.3-2.3" class="pilcrow">¶</a>
+</li>
+          <li id="section-6.3-2.4">Confirm SoD: initiator appears in no approver slot;
+          approvers are pairwise distinct; the approval count satisfies
+          <code>required_approvals</code>.<a href="#section-6.3-2.4" class="pilcrow">¶</a>
+</li>
+          <li id="section-6.3-2.5">Verify the Merkle inclusion proof of the receipt leaf
+          against the checkpoint root, and the checkpoint signature
+          against the log key.<a href="#section-6.3-2.5" class="pilcrow">¶</a>
+</li>
+          <li id="section-6.3-2.6">Confirm <code>signed_at</code> and <code>committed_at</code> fall
+          within <code>[issued_at, expires_at]</code>.<a href="#section-6.3-2.6" class="pilcrow">¶</a>
+</li>
+        </ol>
+<p id="section-6.3-3">Degenerate empty-path rule (step 5). An empty
+        <code>inclusion_path</code> <span class="bcp14">MUST</span> be accepted only when
+        the checkpoint's <code>tree_size</code> is exactly 1 and the
+        <code>leaf_index</code>, when present, is 0; an empty path presented
+        with any other tree size (including a missing or non-integer
+        <code>tree_size</code>) <span class="bcp14">MUST</span> be refused, before any
+        Merkle computation. Without this rule an empty path degenerates
+        to "leaf hash equals root hash", which a forged checkpoint can
+        satisfy at any claimed tree size by simply repeating the leaf
+        hash as its root. Two public reject vectors in the EP conformance
+        suite (<code>reject_empty_path_tree_size_not_1</code> and
+        <code>reject_empty_path_nonzero_leaf_index</code>) pin this rule
+        across the cross-language reference verifiers.<a href="#section-6.3-3" class="pilcrow">¶</a></p>
+<p id="section-6.3-4">Step 5 is what distinguishes EP receipts from log-access
+        designs: the checkpoint travels <em>inside</em> the receipt, so
+        verification requires no query to the log. Detecting log
+        equivocation (split-view attacks) additionally benefits from
+        gossip or witness cosigning (<a href="#log-equivocation" class="auto internal xref">Section 12.4</a>),
+        which is an online activity; the offline guarantee is that
+        <em>this receipt is internally consistent, correctly signed by
+        enrolled approver keys, and was included in a log tree whose head
+        the log operator signed</em>.<a href="#section-6.3-4" class="pilcrow">¶</a></p>
+<p id="section-6.3-5">Offline verification establishes authenticity, not currency.
+        Two properties are explicitly NOT established offline: (a)
+        post-issuance revocation -- a receipt whose approver key was
+        revoked an hour after commitment still verifies; the artifact is
+        evidence of validity <em>at commit time</em>; and (b) log honesty
+        against split views (<a href="#log-equivocation" class="auto internal xref">Section 12.4</a>). A
+        relying party with freshness or revocation requirements
+        <span class="bcp14">MUST</span> additionally consult a current directory head
+        and log checkpoint online. Implementations <span class="bcp14">MUST NOT</span> describe offline verification as establishing that a
+        receipt is "currently valid."<a href="#section-6.3-5" class="pilcrow">¶</a></p>
+<p id="section-6.3-6">The Initiator Attestation
+        (<a href="#initiator-attestation" class="auto internal xref">Section 4.1</a>), where present, is
+        covered by the context hash recomputed in step 2 above; no
+        additional verification step is required for it.<a href="#section-6.3-6" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="receipt-extensions">
+<section id="section-7">
+      <h2 id="name-companion-receipt-extension">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-companion-receipt-extension" class="section-name selfRef">Companion Receipt Extensions and Digest Binding</a>
+      </h2>
+<p id="section-7-1">Extensions <span class="bcp14">MUST NOT</span> be inserted into the base Trust
+      Receipt.  The <code>EP-RECEIPT-v1</code> object, its closed schema, its
+      canonical bytes, and the verification procedure in
+      <a href="#offline-verification" class="auto internal xref">Section 6.3</a> remain unchanged.  In particular,
+      a base verifier <span class="bcp14">MUST NOT</span> strip, ignore, or otherwise
+      preprocess an unrecognized receipt member before verification.<a href="#section-7-1" class="pilcrow">¶</a></p>
+<p id="section-7-2">A producer <span class="bcp14">MAY</span> convey lifecycle or composition bindings
+      in a separate companion object whose version is
+      <code>EP-RECEIPT-EXTENSIONS-v1</code>.  The companion is not part of the
+      base Trust Receipt and confers no authority by itself.  It
+      <span class="bcp14">MUST</span> be a closed object with exactly
+      <code>version</code>, <code>base_receipt_digest</code>,
+      <code>base_action_digest</code>, and <code>entries</code>:<a href="#section-7-2" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="section-7-3">
+<pre>
+{
+  "version": "EP-RECEIPT-EXTENSIONS-v1",
+  "base_receipt_digest": "sha256:...",
+  "base_action_digest": "sha256:...",
+  "entries": [
+    {
+      "name": "ai.emiliaprotocol.trust-program.stage-receipts.v1",
+      "operation_id": "provider-stable-operation-id",
+      "consequence_digest": null,
+      "artifact_digest": "sha256:..."
+    }
+  ]
+}
+</pre><a href="#section-7-3" class="pilcrow">¶</a>
+</div>
+<p id="section-7-4">The <code>base_receipt_digest</code> <span class="bcp14">MUST</span> be SHA-256 over
+      the JCS canonicalization of the complete, unchanged base Trust Receipt.
+      No member is removed or added for this calculation.  This value is the
+      identity of the complete portable receipt, not the Merkle leaf hash;
+      implementations <span class="bcp14">MUST NOT</span> substitute a leaf digest that
+      omits <code>log_proof</code> or <code>approver_key_proofs</code>.  The
+      <code>base_action_digest</code> <span class="bcp14">MUST</span> equal that base receipt's
+      <code>action_hash</code>.  Digest values in this companion
+      <span class="bcp14">MUST</span> use the lowercase
+      <code>sha256:</code> prefix followed by exactly 64 lowercase hexadecimal
+      characters.  The <code>entries</code> member <span class="bcp14">MUST</span> contain
+      between 1 and 32 closed objects, each with exactly
+      <code>name</code>, <code>operation_id</code>, <code>consequence_digest</code>, and
+      <code>artifact_digest</code>.<a href="#section-7-4" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-7-5.1">
+          <code>name</code> <span class="bcp14">MUST</span> be an ASCII lowercase,
+        dot-separated extension name.  Each label begins and ends with a
+        lowercase letter or digit and can contain interior hyphens.  A name
+        <span class="bcp14">MUST NOT</span> exceed 255 ASCII characters.  A name
+        allocated outside the document-local namespace
+        <span class="bcp14">SHOULD</span> begin with a reversed DNS name controlled by its
+        allocator.  Control of a name is only collision avoidance; it conveys
+        no trust.  An entries array <span class="bcp14">MUST NOT</span> contain the same
+        name more than once.<a href="#section-7-5.1" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-7-5.2">
+          <code>operation_id</code> is either null or the stable operation
+        identifier selected by the extension profile.  A lifecycle extension
+        governing a material attempt <span class="bcp14">MUST</span> use a non-null value
+        and <span class="bcp14">MUST NOT</span> derive it from presenter-controlled display
+        text.  A non-null value <span class="bcp14">MUST</span> be non-empty, contain no
+        control characters, and contain no more than 512 Unicode scalar
+        values.<a href="#section-7-5.2" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-7-5.3">
+          <code>consequence_digest</code> is either null for a pre-effect
+        extension or the extension profile's digest of the exact observed,
+        claimed, or settled consequence.  A null value conveys no execution
+        or outcome proof.<a href="#section-7-5.3" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-7-5.4">
+          <code>artifact_digest</code> <span class="bcp14">MUST</span> be the SHA-256 digest
+        of the exact companion artifact under the canonicalization rule named
+        by the selected extension definition.<a href="#section-7-5.4" class="pilcrow">¶</a>
+</li>
+      </ul>
+<p id="section-7-6">An extension-aware relying party <span class="bcp14">MUST</span> first verify the
+      unchanged base Trust Receipt using the base verification procedure.  It
+      then separately verifies the companion version, recomputes both base
+      digests, and evaluates the extension names required by its own policy.
+      The companion envelope is an untrusted index, not an authenticated
+      assertion.  Companion artifacts are conveyed separately; this document
+      defines no network retrieval or presenter-supplied locator.  Parsers
+      <span class="bcp14">MUST</span> apply the duplicate-member, surrogate, number, and
+      depth rejection rules in <a href="#canonicalization-robustness" class="auto internal xref">Section 12.11</a>
+      to the companion before using any entry.
+      For each required entry, an extension-specific verifier
+      <span class="bcp14">MUST</span> verify the companion artifact under
+      relying-party-selected trust and <span class="bcp14">MUST</span> require that
+      artifact to bind the same extension name, base action digest, base
+      receipt digest, operation identifier, and consequence digest.  It then
+      recomputes the artifact digest over that exact artifact.  The extension
+      profile <span class="bcp14">MUST</span> define any freshness, replay, revocation,
+      and terminal-state checks needed for its assurance claim.  Merely
+      carrying a digest does not establish the artifact's validity, authority,
+      freshness, non-replay, or execution semantics.<a href="#section-7-6" class="pilcrow">¶</a></p>
+<p id="section-7-7">An extension-aware relying party <span class="bcp14">MAY</span> ignore an unknown
+      sidecar entry only when its policy does not require that extension name.
+      It <span class="bcp14">MUST</span> fail closed when a required entry is absent,
+      unknown, duplicated, malformed, untrusted, or mismatched.  The required
+      extension set is selected independently by relying-party policy; a
+      presenter cannot weaken it by omitting an entry.  A verifier that
+      implements only <code>EP-RECEIPT-v1</code> does not process the companion and
+      gains no additional assurance from its presence.<a href="#section-7-7" class="pilcrow">¶</a></p>
+<div id="provisional-extension-registry">
+<section id="section-7.1">
+        <h3 id="name-provisional-extension-regis">
+<a href="#section-7.1" class="section-number selfRef">7.1. </a><a href="#name-provisional-extension-regis" class="section-name selfRef">Provisional Extension Registry</a>
+        </h3>
+<p id="section-7.1-1">This revision defines the design rules for a provisional,
+        document-local namespace; it does not create an IANA registry.  Names
+        beginning with <code>ep.</code> are reserved for assignments made by a
+        future revision of this document or by a separately versioned public
+        extension index explicitly referenced by such a revision.  This
+        revision makes no <code>ep.</code> assignments.  Other specifications can
+        self-allocate a reversed-DNS name under a domain they control.<a href="#section-7.1-1" class="pilcrow">¶</a></p>
+<p id="section-7.1-2">Every extension definition <span class="bcp14">MUST</span> specify its immutable
+        name, controlling specification and version, companion artifact
+        version, canonicalization rule, artifact-digest rule,
+        operation-identifier semantics, consequence-digest semantics,
+        relying-party trust inputs, freshness and replay behavior, and
+        fail-closed conditions.  An incompatible semantic change
+        <span class="bcp14">MUST</span> allocate a new name.  An extension definition
+        <span class="bcp14">MUST NOT</span> redefine the base Action Object, Authorization
+        Context, signoff, consumption, or log-proof bytes.<a href="#section-7.1-2" class="pilcrow">¶</a></p>
+<p id="section-7.1-3">A relying party <span class="bcp14">MUST</span> pin the exact extension
+        definition it accepts; discovering a syntactically valid name is not
+        authorization to trust it.  A future document could request an IANA
+        registry if interoperable use demonstrates that centralized
+        allocation is needed.  Such a request is outside the scope of this
+        revision.<a href="#section-7.1-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="action-lifecycle-relationship">
+<section id="section-7.2">
+        <h3 id="name-relationship-to-the-action-">
+<a href="#section-7.2" class="section-number selfRef">7.2. </a><a href="#name-relationship-to-the-action-" class="section-name selfRef">Relationship to the Action Lifecycle</a>
+        </h3>
+<p id="section-7.2-1">This subsection is informative.  The companion seam permits a
+        revocation statement to retract future authority without rewriting an
+        executed effect; an outcome-binding artifact to compare approved bytes
+        with an observed effect; an action-remedy receipt to describe a newly
+        authorized compensating action with its own CAID and
+        <code>rollback: false</code>; or an evidence challenge to name evidence
+        missing before execution.  These examples do not soften the base
+        receipt's terminal or consumption semantics.<a href="#section-7.2-1" class="pilcrow">¶</a></p>
+<p id="section-7.2-2">An Authority Program (also described informally as a Trust Program)
+      can use the same companion seam for immutable stage receipts whose sorted
+      predecessor receipt digests bind a relying-party-pinned recursive
+      series/parallel program to one root CAID and action.  An Authorization
+      Evidence Chain composition artifact can bind a separately verified set
+      of evidence nodes to the same receipt and action digests.  A staged DTC
+      settlement profile could likewise bind a receipt or certificate state
+      root.  These are informative, non-exhaustive consumers.  Base receipt
+      verification does not validate any such chain, program, lifecycle, or
+      settlement artifact.  This document does not claim that Authority
+      Program or DTC settlement infrastructure is standardized, independently
+      implemented, deployed, or proved by base receipt or companion-envelope
+      verification.<a href="#section-7.2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<section id="section-8">
+      <h2 id="name-multi-approver-policies-m-o">
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-multi-approver-policies-m-o" class="section-name selfRef">Multi-Approver Policies (m-of-n)</a>
+      </h2>
+<p id="section-8-1">A policy <span class="bcp14">MAY</span> require k distinct approvers from a
+      role set. Each approver receives and signs an individual
+      Authorization Context sharing the same <code>action_hash</code> and
+      <code>nonce</code> family but a distinct <code>approver_index</code>.
+      Commitment occurs only when k valid, distinct signoffs exist before
+      <code>expires_at</code>. Partial approval confers no authority: a
+      verifying executor presented with fewer than k signoffs
+      <span class="bcp14">MUST</span> refuse.<a href="#section-8-1" class="pilcrow">¶</a></p>
+</section>
+<section id="section-9">
+      <h2 id="name-delegation-constraints">
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-delegation-constraints" class="section-name selfRef">Delegation Constraints</a>
+      </h2>
+<p id="section-9-1">Where an approver's authority is itself delegated, the
+      delegation record <span class="bcp14">MUST</span> be presented in the receipt's
+      <code>approver_key_proofs</code>, and the constraint
+      <strong>DelegateCannotExceedPrincipal</strong> applies: the
+      effective scope of a delegate is the intersection of the delegation
+      grant and the principal's authority at signing time. Delegation
+      chains are bounded (<span class="bcp14">RECOMMENDED</span> depth of at most 2)
+      and every link is independently signed.<a href="#section-9-1" class="pilcrow">¶</a></p>
+</section>
+<div id="conformance">
+<section id="section-10">
+      <h2 id="name-conformance-classes-and-exe">
+<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-conformance-classes-and-exe" class="section-name selfRef">Conformance Classes and Execution-Side Enforcement</a>
+      </h2>
+<p id="section-10-1">Honesty about deployment topology is a protocol feature. Three
+      classes:<a href="#section-10-1" class="pilcrow">¶</a></p>
+<p id="section-10-2"><strong>EP-Verified Execution (STRONG).</strong> The system of
+      record (payment switch, registry, deployment controller) verifies
+      the Authorization Bundle (receipt-less pre-execution form: action
+      object, contexts, signoffs, consumption attestation) before
+      executing, and refuses otherwise. The gate cannot be bypassed by
+      any party that does not control the system of record itself.<a href="#section-10-2" class="pilcrow">¶</a></p>
+<p id="section-10-3"><strong>EP-Gated Middleware (STANDARD).</strong> An interception
+      layer between the agent and the executing credential enforces the
+      gate. Provides strong protection against agent error and prompt
+      injection; an operator with code control can bypass. Receipts
+      remain valid evidence of what <em>was</em> approved.<a href="#section-10-3" class="pilcrow">¶</a></p>
+<p id="section-10-4"><strong>EP-Evidence Only (BASIC).</strong> Actions execute
+      independently; receipts are produced for audit. No enforcement
+      claim is made.<a href="#section-10-4" class="pilcrow">¶</a></p>
+<p id="section-10-5">Implementations <span class="bcp14">MUST</span> declare their class in
+      receipts (<code>enforcement_class</code>), and marketing or compliance
+      claims <span class="bcp14">MUST NOT</span> state a stronger class than
+      deployed. This section exists because the difference between "we
+      proved the protocol" and "your deployment is unbypassable" is the
+      most common overclaim in this category.<a href="#section-10-5" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="related-work">
+<section id="section-11">
+      <h2 id="name-relationship-to-other-work">
+<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-relationship-to-other-work" class="section-name selfRef">Relationship to Other Work</a>
+      </h2>
+<p id="section-11-1"><strong>Companion EP documents.</strong> This document is
+      self-contained: a receipt is issued, verified, and consumed under
+      this specification alone. A family of separately published
+      companion documents composes with it without altering its
+      semantics, grouped by function: action identity and comparison
+      across independently issued artifacts as defined by CAID
+      <span>[<a href="#EP-CAID" class="cite xref">EP-CAID</a>]</span>; multi-approver policies as defined by
+      EP-QUORUM <span>[<a href="#EP-QUORUM" class="cite xref">EP-QUORUM</a>]</span> and display
+      binding; enforcement-side ordering and bounded multi-action
+      execution (including <span>[<a href="#EP-BOUNDED-CAP" class="cite xref">EP-BOUNDED-CAP</a>]</span>);
+      post-execution outcome observation, revocation statements, and
+      compensating remedies; and evidence composition, challenge, and
+      reliance records. Each companion consumes this document's digests
+      or supplies relying-party trust inputs; none is required for
+      conformance to this document.<a href="#section-11-1" class="pilcrow">¶</a></p>
+<p id="section-11-2"><strong>DRP</strong>
+      (<span>[<a href="#I-D.nelson-agent-delegation-receipts" class="cite xref">I-D.nelson-agent-delegation-receipts</a>]</span>) binds a
+      <em>user's</em> delegation to an <em>operator's</em> instructions --
+      upstream consumer delegation. EP binds an <em>organizational
+      approver</em> to an <em>exact action</em> -- downstream
+      authorization under its own SoD and m-of-n profiles. The two
+      compose: a DRP delegation can be referenced in
+      an EP Action Object's provenance field.<a href="#section-11-2" class="pilcrow">¶</a></p>
+<p id="section-11-3"><strong>Bounded Capability Receipts</strong>
+        <span>[<a href="#EP-BOUNDED-CAP" class="cite xref">EP-BOUNDED-CAP</a>]</span> authorize a different lifecycle.
+      An EP Authorization Receipt can approve the exact act of issuing a
+      bounded capability, and that issuance receipt is consumed when the
+      capability is registered. It <span class="bcp14">MUST NOT</span> then be reused
+      as though it approved every later capability-funded operation. The
+      capability binds the complete issuance-receipt digest, scope, budget,
+      holder proof, and validity interval; its shared reserve/commit store
+      accounts later operations. A deployment that requires human approval of
+      an individual exercise obtains a new action-bound EP receipt or
+      a quorum receipt set (<span>[<a href="#EP-QUORUM" class="cite xref">EP-QUORUM</a>]</span>) for that
+      exercise.<a href="#section-11-3" class="pilcrow">¶</a></p>
+<p id="section-11-4"><strong>CIBA</strong> <span>[<a href="#CIBA" class="cite xref">CIBA</a>]</span> transports an
+      authentication-time approval to a backchannel device; it does not
+      produce an action-bound, offline-verifiable, one-time-consumable
+      artifact. CIBA <span class="bcp14">MAY</span> serve as the transport by which
+      an approver is reached; the EP signoff is what they produce when
+      they get there.<a href="#section-11-4" class="pilcrow">¶</a></p>
+<p id="section-11-5"><strong>AI Agent Authentication and Authorization</strong>
+      (<span>[<a href="#I-D.klrc-aiagent-auth" class="cite xref">I-D.klrc-aiagent-auth</a>]</span>) keeps the final authorization
+      decision with the authorization server, requires local user
+      confirmation to be bound to a verifiable grant, and identifies
+      mid-execution confirmation as an area where additional work may be
+      needed. An EP Authorization Context is one candidate evidence object
+      for that binding; it does not replace the grant or authorization
+      server decision. The same document requires durable, tamper-evident
+      audit records. An EP Trust Receipt can supply an action, decision, and
+      terminal-consumption record under the selected profile, but does not
+      by itself satisfy deployment monitoring, remediation, retention, or
+      compliance requirements. A profile can carry the Authorization Context
+      or Trust Receipt digest in transaction context without redefining
+      transaction-token semantics.<a href="#section-11-5" class="pilcrow">¶</a></p>
+<p id="section-11-6"><strong>Mastercard Verifiable Intent</strong> <span>[<a href="#FIDO-VI" class="cite xref">FIDO-VI</a>]</span>,
+      co-developed with Google and contributed to the FIDO Alliance,
+      describes portable, verifiable evidence of
+      user intent. The cited page describes a contribution and prospective
+      standardization, not a final FIDO specification. EP does not claim
+      portable human evidence is absent.
+      Its receipt profile separately specifies an enrolled organizational
+      approver directory, exact Authorization Context, initiator exclusion,
+      terminal consumption record, and optional distinct-human quorum.<a href="#section-11-6" class="pilcrow">¶</a></p>
+<p id="section-11-7"><strong>AuthZEN Access Request and Approval Profile</strong>
+        <span>[<a href="#AUTHZEN-AARP" class="cite xref">AUTHZEN-AARP</a>]</span> defines requestable denial,
+      asynchronous approval tasks, an approval object whose optional state
+      carries opaque proof or verifier state, JWS interoperability when that
+      state is carried by value, an exact-match baseline, and PDP re-evaluation
+      at enforcement time. EP
+      does not replace that profile. A deployment can select an EP receipt
+      as an additional evidence profile when it requires a verifier-visible
+      approver-held device ceremony, enrolled-human directory binding,
+      portable initiator exclusion, or one-time executor consumption. The
+      relying party remains responsible for deciding which profile satisfies
+      its requirement.<a href="#section-11-7" class="pilcrow">¶</a></p>
+<p id="section-11-8"><strong>WIMSE / workload identity</strong> authenticates the
+      workload to services; EP supplies action-bound approval evidence that
+      a relying party may require in its local authorization decision.
+      These are complementary layers.<a href="#section-11-8" class="pilcrow">¶</a></p>
+<p id="section-11-9"><strong>Receiver-attested logging (e.g., Sello)</strong> has the
+      receiving service sign what it observed, post-hoc. EP is
+      pre-execution authorization. A complete deployment benefits from
+      both: EP records the pre-execution signing and consumption event under
+      a selected profile; receiver attestation records what the receiver
+      observed afterward. Local policy determines whether the former is
+      sufficient for authorization.<a href="#section-11-9" class="pilcrow">¶</a></p>
+<p id="section-11-10"><strong>AgentROA (draft-nivalto-agentroa-route-authorization),
+      AIIP, and CIRP</strong> define machine-side, per-hop execution and
+      route receipts for agent actions under delegated authority. Their
+      approval-state or approval-reference fields do not by themselves
+      define the EP ceremony and directory profile. EP evidence can fill
+      such a reference where that profile is selected, and its delegation
+      constraints share AgentROA's monotonic ("tighten-only")
+      scope-narrowing discipline.<a href="#section-11-10" class="pilcrow">¶</a></p>
+<p id="section-11-11"><strong>The Entity Attestation Token (RFC 9711, RATS)</strong>
+      attests the <em>agent or platform</em> -- model, keys, posture; EP
+      carries evidence of an enrolled approver key's action-bound decision.
+      The two are orthogonal and
+      composable: an EAT says the machine is what it claims; an EP receipt
+      says a named person approved the exact action.<a href="#section-11-11" class="pilcrow">¶</a></p>
+<p id="section-11-12"><strong>Transaction Tokens
+      (draft-ietf-oauth-transaction-tokens)</strong> propagate workload and
+      agent authorization context across a machine call chain; an EP
+      receipt can be one referenced approval artifact when a relying
+      party requires that profile.<a href="#section-11-12" class="pilcrow">¶</a></p>
+<p id="section-11-13"><strong>Evidence Record Syntax (RFC 4998)</strong> preserves
+      signed evidence across algorithm aging by periodic re-timestamping.
+      EP applies the same approach to long-lived receipts via an
+      evidence-record renewal chain, so a receipt verifiable today remains
+      verifiable after its original algorithms weaken -- a property the
+      10-25+ year retention schedules of government records require.<a href="#section-11-13" class="pilcrow">¶</a></p>
+</section>
+</div>
+<section id="section-12">
+      <h2 id="name-security-considerations">
+<a href="#section-12" class="section-number selfRef">12. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+      </h2>
+<section id="section-12.1">
+        <h3 id="name-operator-compromise">
+<a href="#section-12.1" class="section-number selfRef">12.1. </a><a href="#name-operator-compromise" class="section-name selfRef">Operator Compromise</a>
+        </h3>
+<p id="section-12.1-1">Under key classes A/B, a compromised EP operator can deny
+        service and can fail to route signoff requests, and it cannot
+        <em>forge a signature</em>: it lacks approver keys, and it cannot
+        replay one (nonces are single-consumption and receipts chain).
+        Two operator-compromise paths remain and are stated plainly
+        rather than claimed away. First, an operator that controls the
+        signing client's rendering can harvest a <em>genuine</em>
+        signature over an action the approver misunderstood -- a
+        presentation attack (<a href="#presentation-attacks" class="auto internal xref">Section 12.3</a>); for
+        this reason an independently-authored rendering surface is
+        <span class="bcp14">REQUIRED</span> for high-value policies. Second, an operator
+        that unilaterally controls the Approver Directory can enroll keys
+        it controls (<a href="#approver-directory" class="auto internal xref">Section 5.2</a>,
+        <a href="#directory-authority" class="auto internal xref">Section 12.6</a>). Accordingly, the accurate
+        claim for classes A/B is: "the operator cannot forge an
+        approver's signature." The stronger claim -- "the operator cannot
+        obtain an unauthorized approval" -- additionally requires the
+        directory-authority and independent-rendering controls. Under
+        class C the operator can fabricate outright; hence the labeling
+        requirement.<a href="#section-12.1-1" class="pilcrow">¶</a></p>
+</section>
+<section id="section-12.2">
+        <h3 id="name-approver-device-compromise">
+<a href="#section-12.2" class="section-number selfRef">12.2. </a><a href="#name-approver-device-compromise" class="section-name selfRef">Approver Device Compromise</a>
+        </h3>
+<p id="section-12.2-1">A stolen authenticator with user verification still requires
+        the biometric/PIN. Organizations <span class="bcp14">SHOULD</span> require
+        key class A for high-value policies and <span class="bcp14">SHOULD</span>
+        pair approval with out-of-band action rendering (the approver
+        sees the wire details on a second surface).<a href="#section-12.2-1" class="pilcrow">¶</a></p>
+</section>
+<div id="presentation-attacks">
+<section id="section-12.3">
+        <h3 id="name-presentation-attacks">
+<a href="#section-12.3" class="section-number selfRef">12.3. </a><a href="#name-presentation-attacks" class="section-name selfRef">Presentation Attacks</a>
+        </h3>
+<p id="section-12.3-1">The gravest risk in this protocol, stated without
+        minimization: the approver signs context hash H believing it
+        represents action X when it represents action Y. A signature
+        proves user presence and an act of approval toward <em>whatever
+        was rendered</em>; cryptography cannot prove the rendering was
+        faithful. Required mitigations, in increasing strength: (1) the
+        signing client <span class="bcp14">MUST</span> render the Action Object from
+        the exact bytes that were hashed -- never from a separately
+        supplied description; (2) for high-value policies, render
+        templates <span class="bcp14">MUST</span> be registered with the policy and
+        committed by <code>policy_hash</code>, so the display logic is part
+        of what the approver's signature covers; (3) for policies above
+        an organization-designated threshold, the material action
+        parameters (amount, beneficiary identifiers) <span class="bcp14">MUST</span>
+        additionally be rendered on a second surface not authored by the
+        orchestrating operator -- for example, delivered by the verifying
+        executor or an independent operator to the approver's enrolled
+        device over a separate channel. The residual risk is stated
+        honestly: absent a trusted display path (hardware the operator
+        does not author), rendering fidelity is enforced by controls
+        (2)-(3), by audit, and by consented mismatch drills
+        (<a href="#approver-fatigue" class="auto internal xref">Section 12.8</a>) -- not by mathematics. What
+        the cryptography does guarantee is exactness of evidence: the
+        receipt contains the full Action Object actually signed, so any
+        divergence between what was displayed and what was executed is
+        detectable after the fact with proof rather than testimony.<a href="#section-12.3-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="log-equivocation">
+<section id="section-12.4">
+        <h3 id="name-log-equivocation">
+<a href="#section-12.4" class="section-number selfRef">12.4. </a><a href="#name-log-equivocation" class="section-name selfRef">Log Equivocation</a>
+        </h3>
+<p id="section-12.4-1">A malicious log could show different trees to different
+        parties. Checkpoints <span class="bcp14">SHOULD</span> be witness-cosigned
+        and/or gossiped between independent EP operators; the federation
+        profile makes cross-operator checkpoint exchange mandatory. Before a
+        witness signs a checkpoint or a gossip participant accepts it for
+        comparison, that participant <span class="bcp14">MUST</span> verify the
+        checkpoint's log signature under the pinned log key and
+        <span class="bcp14">MUST</span> verify any required consistency proof from the
+        participant's previously accepted checkpoint. A quorum of witness
+        signatures over a caller-supplied but unauthenticated tuple is not
+        evidence that the named log produced that tuple.<a href="#section-12.4-1" class="pilcrow">¶</a></p>
+<p id="section-12.4-2">For this purpose, independent operators require separate
+        administrative control, key custody, and failure domains; multiple
+        co-located processes under one operator do not provide independent
+        witnessing. Comparing supplied authenticated views can prove that the
+        views conflict. It does not by itself prove freshness, completeness,
+        or that every relying party received the latest checkpoint.<a href="#section-12.4-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<section id="section-12.5">
+        <h3 id="name-what-the-formal-models-do-a">
+<a href="#section-12.5" class="section-number selfRef">12.5. </a><a href="#name-what-the-formal-models-do-a" class="section-name selfRef">What the Formal Models Do and Do Not Prove</a>
+        </h3>
+<p id="section-12.5-1">The TLA+/Alloy models prove safety of the authorization state
+        machine: no replay, no self-approval, no bypass <em>within the
+        modeled system</em>, no partial commitment. They prove nothing
+        about any AI model's behavior, about host compromise, or about
+        deployments in a weaker conformance class. Implementations
+        <span class="bcp14">MUST NOT</span> represent the proofs as covering
+        deployment topologies they do not model. For the same honesty:
+        three normative mechanisms in this document are specified ahead
+        of the reference implementation and are not yet exercised by it
+        or by conformance vectors -- the operator-signed-directory
+        assurance downgrade (Section 5.2), delegation records in
+        approver_key_proofs and the DelegateCannotExceedPrincipal check
+        (Section 8), and enforcement_class emission (Section 9).
+        Implementers MUST treat the text as normative and the reference
+        implementation as incomplete on these three points, not the
+        reverse. The m-of-n quorum flow IS
+        now modeled: a checked Alloy model (formal/ep_quorum.als in the
+        repository) proves SelfApprovalImpossible, NoHumanFillsTwoSlots,
+        NoKeyFillsTwoSlots, TwoPersonRuleHolds, and ordered-chain
+        acyclicity/linearity against the quorum verifier and its
+        conformance vectors. The models additionally
+        do not yet cover the WebAuthn challenge binding, the Approver
+        Directory, log checkpoints, or the Initiator
+        Attestation (<a href="#initiator-attestation" class="auto internal xref">Section 4.1</a>); those sections
+        are specified, not proven, and extending the models to them is
+        tracked work.<a href="#section-12.5-1" class="pilcrow">¶</a></p>
+<p id="section-12.5-2">A separate composed Tamarin model joins signed challenge, CAID,
+        two distinct user-verification-gated approvals, scoped authority
+        under an exact pinned registry view, revocation, receipt-issuer
+        pinning, one-time consumption, and execution in one symbolic trace
+        <span>[<a href="#FORMAL-STATUS" class="cite xref">FORMAL-STATUS</a>]</span>. Ten named obligations verify,
+        including execution_requires_full_composition,
+        initiator_cannot_self_approve, no_issuer_laundering,
+        strict_registry_view_is_exact, and
+        injective_execution_with_consumption. Two deliberately unsafe
+        comparison lemmas are falsified with concrete traces: one omits
+        consumption and admits same-receipt replay; the other omits exact
+        registry-view binding and admits a stale or equivocating view. The
+        model treats signatures as perfect symbolic primitives and does not
+        prove WebAuthn internals, parser correctness, amount arithmetic,
+        policy authorship, clock freshness, transparency-log completeness,
+        collusion resistance, or downstream exactly-once physical effects.<a href="#section-12.5-2" class="pilcrow">¶</a></p>
+<p id="section-12.5-3">The quorum abstraction in the standalone symbolic model is a fixed
+        2-of-2 instance. Its checked result is evidence for that instance, not
+        a proof of the arbitrary k-of-n construction defined by the companion
+        EP-QUORUM document and not a proof of production code. CI regression
+        gating of an existing prover result increases reproducibility; it does
+        not add a lemma or enlarge the model's scope.<a href="#section-12.5-3" class="pilcrow">¶</a></p>
+<p id="section-12.5-4">Independent implementation status, stated precisely: the
+        three reference verifiers (JavaScript, Python, Go) agree on the
+        published conformance vectors but live in one repository -- a
+        cross-language consistency check, not independent
+        implementations. A separately authored Rust verifier was evaluated
+        on 11 July 2026 and passed 16 suites and 164 vectors from a
+        hash-pinned bundle <span>[<a href="#EXTERNAL-RUST-PIN" class="cite xref">EXTERNAL-RUST-PIN</a>]</span>. That result
+        is time-pinned: it does not cover the current larger vector bundle,
+        and the available construction statement predates the evaluated
+        hardening commit. It is therefore evidence of external implementation
+        and execution for that bundle, not yet strict clean-room construction
+        acceptance for the current specification.<a href="#section-12.5-4" class="pilcrow">¶</a></p>
+</section>
+<div id="directory-authority">
+<section id="section-12.6">
+        <h3 id="name-directory-authority">
+<a href="#section-12.6" class="section-number selfRef">12.6. </a><a href="#name-directory-authority" class="section-name selfRef">Directory Authority</a>
+        </h3>
+<p id="section-12.6-1"><a href="#approver-keys" class="auto internal xref">Section 5</a> removes the operator from the
+        signature path; <a href="#approver-directory" class="auto internal xref">Section 5.2</a> must not
+        readmit it as the authority that decides which keys count. If the
+        EP operator alone signs the Approver Directory, a malicious
+        operator can satisfy policy by enrolling a key it controls under
+        a nominally legitimate approver's name. The controls in
+        <a href="#approver-directory" class="auto internal xref">Section 5.2</a> (organization-held directory
+        key; second-party attestation on enrollment; Class C-equivalent
+        treatment otherwise) exist for this reason. Auditors
+        <span class="bcp14">SHOULD</span> verify directory key custody as part of any
+        assessment that relies on receipts.<a href="#section-12.6-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<section id="section-12.7">
+        <h3 id="name-what-separation-of-duties-d">
+<a href="#section-12.7" class="section-number selfRef">12.7. </a><a href="#name-what-separation-of-duties-d" class="section-name selfRef">What Separation of Duties Does and Does Not Provide</a>
+        </h3>
+<p id="section-12.7-1">SelfApprovalImpossible (<a href="#consumption" class="auto internal xref">Section 6</a>) defeats
+        <em>unilateral</em> self-approval: no initiator can approve its
+        own action, and m-of-n approvers are pairwise distinct
+        identities. It does not defeat collusion among distinct enrolled
+        humans, one human who controls multiple enrolled identities (an
+        enrollment control -- <a href="#approver-directory" class="auto internal xref">Section 5.2</a>), or a
+        coerced approver. Receipts make such events <em>attributable</em>
+        -- named, signed, and evidenced -- which raises the cost of insider
+        fraud; they do not make it impossible, and implementations
+        <span class="bcp14">MUST NOT</span> claim otherwise.<a href="#section-12.7-1" class="pilcrow">¶</a></p>
+</section>
+<div id="approver-fatigue">
+<section id="section-12.8">
+        <h3 id="name-approver-fatigue">
+<a href="#section-12.8" class="section-number selfRef">12.8. </a><a href="#name-approver-fatigue" class="section-name selfRef">Approver Fatigue</a>
+        </h3>
+<p id="section-12.8-1">A gate that humans route around protects nothing;
+        rubber-stamping is the empirical failure mode of every
+        human-in-the-loop control under volume. This protocol is
+        therefore not a general approval workflow: deployments
+        <span class="bcp14">MUST</span> scope signoff policies to genuinely
+        high-risk, low-frequency actions and <span class="bcp14">SHOULD</span> handle
+        volume with policy (thresholds, allow-lists, velocity rules)
+        rather than human throughput. Operational countermeasures
+        <span class="bcp14">SHOULD</span> include monitoring time-to-sign
+        distributions (signing latencies near the floor indicate approval
+        without review), tracking deny rates (a gate that never denies is
+        either perfectly upstream-filtered or ceremonial), and consented
+        render-mismatch drills that measure whether approvers read what
+        they sign. Such telemetry is deployment guidance, not protocol;
+        but the protocol's guarantees are only as strong as the attention
+        of the human at its center, and implementations
+        <span class="bcp14">SHOULD</span> say so to their customers.<a href="#section-12.8-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="initiator-attestation-security">
+<section id="section-12.9">
+        <h3 id="name-initiator-attestation-as-an">
+<a href="#section-12.9" class="section-number selfRef">12.9. </a><a href="#name-initiator-attestation-as-an" class="section-name selfRef">Initiator Attestation as an Attack Surface</a>
+        </h3>
+<p id="section-12.9-1">The <code>statement</code> member of an Initiator Attestation
+        (<a href="#initiator-attestation" class="auto internal xref">Section 4.1</a>) is
+        attacker-influenceable free text rendered to a human at the moment
+        of decision -- a social-engineering surface aimed at the approver,
+        adjacent to the presentation attacks of
+        <a href="#presentation-attacks" class="auto internal xref">Section 12.3</a>. A compromised or
+        prompt-injected initiator can state any trigger and any reason;
+        injection can change what the initiator <em>proposes</em>,
+        including this field, but it cannot change what a human
+        <em>approves</em> on their own hardware, because the device-bound
+        signature (<a href="#key-classes" class="auto internal xref">Section 5.1</a>) is outside the model
+        context. Conforming signing clients <span class="bcp14">MUST</span> therefore
+        render the <code>statement</code> as untrusted content: plain text
+        only, with no markup, links, or control characters rendered; the
+        280-character cap enforced; and visually distinct styling that
+        labels it as the initiator's unverified claim, clearly separated
+        from the operator-rendered Action Object. This is consistent with
+        the rendering-faithfulness discipline of
+        <a href="#presentation-attacks" class="auto internal xref">Section 12.3</a>: the approver's decision
+        input is the rendered Action Object; the statement is commentary
+        from a party the protocol never trusts. A related residual vector
+        is divide-and-misinform: because each approver signs their own
+        context, a malicious orchestrator can show different approvers of
+        an m-of-n receipt different attestations, and every individual
+        signature remains valid. The cross-context consistency rule
+        (<a href="#initiator-attestation" class="auto internal xref">Section 4.1</a>) exists for this;
+        verifiers implementing the member <span class="bcp14">MUST</span> flag
+        violations, but on verifiers that predate the member such a
+        receipt still verifies -- the rule is a conformance check, not a
+        signature property.<a href="#section-12.9-1" class="pilcrow">¶</a></p>
+<p id="section-12.9-2">Privacy: statements written by an agent mid-task can leak
+        sensitive operational context -- counterparty details, internal
+        findings, fragments of prompts -- into receipts that are long-lived
+        and portable by design. Deployments <span class="bcp14">SHOULD</span> prefer
+        <code>escalation_trigger</code> plus <code>policy_basis</code> identifiers
+        over free text wherever a rule id captures the reason,
+        <span class="bcp14">SHOULD</span> constrain or template <code>statement</code>
+        generation for regulated data, and <span class="bcp14">MUST</span> apply the
+        same retention and disclosure controls to attestation content as
+        to the rest of the receipt.<a href="#section-12.9-2" class="pilcrow">¶</a></p>
+<p id="section-12.9-3">Absence is not evidence: a receipt without an attestation means
+        only that the issuer did not populate it -- not that the initiator
+        judged the action routine, and not that no escalation reasoning
+        occurred. Verifiers and auditors <span class="bcp14">MUST NOT</span> infer
+        anything from the absence of an attestation alone. (Separately,
+        and unchanged: for an action a policy gates on signoff, the
+        absence of any valid receipt at all remains evidence that the
+        control was bypassed -- that property comes from the gate, not from
+        this member.)<a href="#section-12.9-3" class="pilcrow">¶</a></p>
+<p id="section-12.9-4">No trust feedback: policy engines <span class="bcp14">MUST NOT</span> use
+        <code>initiator_attestation</code> content to relax thresholds, skip
+        approvers, or raise any trust score. The initiator must gain
+        nothing by saying the right words; the attestation is a claim by a
+        party the protocol identifies but never trusts, not proof of its
+        internal state.<a href="#section-12.9-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<section id="section-12.10">
+        <h3 id="name-no-symmetric-key-on-the-ver">
+<a href="#section-12.10" class="section-number selfRef">12.10. </a><a href="#name-no-symmetric-key-on-the-ver" class="section-name selfRef">No symmetric key on the verification trust path</a>
+        </h3>
+<p id="section-12.10-1">Every artifact a relying party verifies offline -- the approver
+        signoff (Class A: ES256/P-256), the operator commit and receipt
+        (Ed25519), the log inclusion proof, and the portable revocation
+        statement (Ed25519) -- is bound by an ASYMMETRIC signature whose
+        verifying key the relying party holds independently of the issuer. No
+        step in offline verification relies on a Message Authentication Code, a
+        shared secret, or any symmetric primitive. This is deliberate and
+        load-bearing: a symmetric construction (for example an HMAC-chained
+        audit log) is verifiable only by a party holding the same secret as the
+        producer, so it does not provide public verification outside that trust
+        domain. An asymmetric issuer can still sign conflicting histories;
+        witness cosigning or gossip is required to detect that equivocation.
+        Conforming verifier
+        implementations <span class="bcp14">MUST NOT</span> introduce a symmetric primitive
+        on the verification path; an implementation that does so does not
+        provide EP's public-verifiability property. (HMAC <span class="bcp14">MAY</span> appear
+        elsewhere in a deployment -- e.g. authenticating an operator's own cron
+        or webhook calls -- provided it is never a link in the chain a third
+        party verifies.)<a href="#section-12.10-1" class="pilcrow">¶</a></p>
+</section>
+<div id="canonicalization-robustness">
+<section id="section-12.11">
+        <h3 id="name-canonicalization-robustness">
+<a href="#section-12.11" class="section-number selfRef">12.11. </a><a href="#name-canonicalization-robustness" class="section-name selfRef">Canonicalization Robustness</a>
+        </h3>
+<p id="section-12.11-1">Every signed EP artifact is verified over its canonical JSON
+        form (<a href="#action-object" class="auto internal xref">Section 3</a>,
+        <a href="#authorization-context" class="auto internal xref">Section 4</a>), so any divergence
+        between two implementations' canonicalization behavior is a
+        signature-verification divergence and therefore a malleability
+        hazard. Implementations <span class="bcp14">MUST</span> reject the known
+        malleability hazard classes, and <span class="bcp14">MUST</span> reject them
+        identically: duplicate object member names (compared after
+        escape decoding), unpaired UTF-16 surrogate escapes, and inputs
+        outside the profile's number and depth bounds (non-integer
+        numbers or integers with magnitude greater than 2^53-1, and
+        container nesting deeper than the profile-pinned bound of 64).
+        The public EP-CANONICALIZATION-v1 vector suite exercises these
+        classes as raw JSON texts, with pinned SHA-256 digests over the
+        canonical bytes of every accepted input, across the
+        cross-language reference verifiers; divergence from the pinned
+        results is a conformance defect, not an implementation choice.
+        (In the reference stack the duplicate-name, surrogate, and depth
+        gates are applied at the parse boundary by the conformance
+        runners, since the verifier packages receive already-parsed
+        values; the profile predicate, canonical serialization, and
+        digests exercise the verifier packages themselves.)<a href="#section-12.11-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+<section id="section-13">
+      <h2 id="name-iana-considerations">
+<a href="#section-13" class="section-number selfRef">13. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+      </h2>
+<p id="section-13-1">This document has no IANA actions.  The extension-name registry in
+      <a href="#provisional-extension-registry" class="auto internal xref">Section 7.1</a> is provisional and
+      document-local.  A future version may request an IANA registry and may
+      register the <code>application/ep-receipt+json</code> media type.<a href="#section-13-1" class="pilcrow">¶</a></p>
+</section>
+<section id="section-14">
+      <h2 id="name-normative-references">
+<a href="#section-14" class="section-number selfRef">14. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+      </h2>
+<dl class="references">
+<dt id="CIBA">[CIBA]</dt>
+      <dd>
+<span class="refAuthor">OpenID Foundation</span>, <span class="refTitle">"OpenID Connect Client-Initiated Backchannel Authentication Flow - Core 1.0"</span>, <time datetime="2021-09" class="refDate">September 2021</time>, <span>&lt;<a href="https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html">https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC2119">[RFC2119]</dt>
+      <dd>
+<span class="refAuthor">Bradner, S.</span>, <span class="refTitle">"Key words for use in RFCs to Indicate Requirement Levels"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 2119</span>, <span class="seriesInfo">DOI 10.17487/RFC2119</span>, <time datetime="1997-03" class="refDate">March 1997</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc2119">https://www.rfc-editor.org/info/rfc2119</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8174">[RFC8174]</dt>
+      <dd>
+<span class="refAuthor">Leiba, B.</span>, <span class="refTitle">"Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 8174</span>, <span class="seriesInfo">DOI 10.17487/RFC8174</span>, <time datetime="2017-05" class="refDate">May 2017</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8174">https://www.rfc-editor.org/info/rfc8174</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8785">[RFC8785]</dt>
+      <dd>
+<span class="refAuthor">Rundgren, A.</span>, <span class="refAuthor">Jordan, B.</span>, and <span class="refAuthor">S. Erdtman</span>, <span class="refTitle">"JSON Canonicalization Scheme (JCS)"</span>, <span class="seriesInfo">RFC 8785</span>, <span class="seriesInfo">DOI 10.17487/RFC8785</span>, <time datetime="2020-06" class="refDate">June 2020</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8785">https://www.rfc-editor.org/info/rfc8785</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="WEBAUTHN">[WEBAUTHN]</dt>
+    <dd>
+<span class="refAuthor">W3C</span>, <span class="refTitle">"Web Authentication: An API for accessing Public Key Credentials, Level 2"</span>, <time datetime="2021-04" class="refDate">April 2021</time>, <span>&lt;<a href="https://www.w3.org/TR/webauthn-2/">https://www.w3.org/TR/webauthn-2/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+</dl>
+</section>
+<section id="section-15">
+      <h2 id="name-informative-references">
+<a href="#section-15" class="section-number selfRef">15. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+      </h2>
+<dl class="references">
+<dt id="AUTHZEN-AARP">[AUTHZEN-AARP]</dt>
+      <dd>
+<span class="refAuthor">OpenID Foundation</span>, <span class="refTitle">"AuthZEN Access Request and Approval Profile - Draft 1"</span>, <time datetime="2026-07" class="refDate">July 2026</time>, <span>&lt;<a href="https://openid.github.io/authzen/authzen-access-request-approval-profile-1_0.html">https://openid.github.io/authzen/authzen-access-request-approval-profile-1_0.html</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="EP-BOUNDED-CAP">[EP-BOUNDED-CAP]</dt>
+      <dd>
+<span class="refAuthor">Schrock, I.</span>, <span class="refTitle">"Bounded Capability Receipts and Durable Spend Control for Agent Actions"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-schrock-ep-bounded-capability-receipts-00</span>, <time datetime="2026-07" class="refDate">July 2026</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/draft-schrock-ep-bounded-capability-receipts/">https://datatracker.ietf.org/doc/draft-schrock-ep-bounded-capability-receipts/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="EP-CAID">[EP-CAID]</dt>
+      <dd>
+<span class="refAuthor">Schrock, I.</span>, <span class="refTitle">"The Canonical Action Identifier (CAID)"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-schrock-canonical-action-identifier-01</span>, <time datetime="2026-07" class="refDate">July 2026</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/draft-schrock-canonical-action-identifier/">https://datatracker.ietf.org/doc/draft-schrock-canonical-action-identifier/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="EP-QUORUM">[EP-QUORUM]</dt>
+      <dd>
+<span class="refAuthor">Schrock, I.</span>, <span class="refTitle">"Multi-Party Quorum Authorization for High-Risk Agent Actions (EP-QUORUM)"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-schrock-ep-quorum-03</span>, <time datetime="2026-07" class="refDate">July 2026</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/draft-schrock-ep-quorum/">https://datatracker.ietf.org/doc/draft-schrock-ep-quorum/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="EXTERNAL-RUST-PIN">[EXTERNAL-RUST-PIN]</dt>
+      <dd>
+<span class="refAuthor">EMILIA Protocol</span>, <span class="refTitle">"Time-Pinned External Rust Verifier Evaluation Record"</span>, <time datetime="2026-07-11" class="refDate">11 July 2026</time>, <span>&lt;<a href="https://github.com/emiliaprotocol/emilia-protocol/blob/main/conformance/external/rust-cleanroom-jdieselny.v1.json">https://github.com/emiliaprotocol/emilia-protocol/blob/main/conformance/external/rust-cleanroom-jdieselny.v1.json</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="FIDO-VI">[FIDO-VI]</dt>
+      <dd>
+<span class="refAuthor">FIDO Alliance</span>, <span class="refTitle">"Building the Trust Layer for Agentic Payments with AP2 and Verifiable Intent"</span>, <time datetime="2026-05-26" class="refDate">26 May 2026</time>, <span>&lt;<a href="https://fidoalliance.org/building-the-trust-layer-for-agentic-payments-with-ap2-and-verifiable-intent/">https://fidoalliance.org/building-the-trust-layer-for-agentic-payments-with-ap2-and-verifiable-intent/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="FORMAL-STATUS">[FORMAL-STATUS]</dt>
+      <dd>
+<span class="refAuthor">EMILIA Protocol</span>, <span class="refTitle">"EMILIA Formal Proof Status and Scope"</span>, <time datetime="2026-07-10" class="refDate">10 July 2026</time>, <span>&lt;<a href="https://github.com/emiliaprotocol/emilia-protocol/blob/main/formal/PROOF_STATUS.md">https://github.com/emiliaprotocol/emilia-protocol/blob/main/formal/PROOF_STATUS.md</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="I-D.klrc-aiagent-auth">[I-D.klrc-aiagent-auth]</dt>
+      <dd>
+<span class="refAuthor">Kasselman, P.</span>, <span class="refAuthor">Lombardo, J.</span>, <span class="refAuthor">Rosomakho, Y.</span>, <span class="refAuthor">Campbell, B.</span>, <span class="refAuthor">Steele, N.</span>, and <span class="refAuthor">A. Parecki</span>, <span class="refTitle">"AI Agent Authentication and Authorization"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-klrc-aiagent-auth-03</span>, <time datetime="2026-07-06" class="refDate">6 July 2026</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/draft-klrc-aiagent-auth/">https://datatracker.ietf.org/doc/draft-klrc-aiagent-auth/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="I-D.nelson-agent-delegation-receipts">[I-D.nelson-agent-delegation-receipts]</dt>
+    <dd>
+<span class="refAuthor">Nelson, R.</span>, <span class="refTitle">"Delegation Receipt Protocol for AI Agent Authorization"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-nelson-agent-delegation-receipts-10</span>, <time datetime="2026-06-13" class="refDate">13 June 2026</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/draft-nelson-agent-delegation-receipts/">https://datatracker.ietf.org/doc/draft-nelson-agent-delegation-receipts/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+</dl>
+</section>
+<div id="changes-since-08">
+<section id="appendix-A">
+      <h2 id="name-changes-since-08">
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-changes-since-08" class="section-name selfRef">Changes since -08</a>
+      </h2>
+<ul class="normal">
+<li class="normal" id="appendix-A-1.1">Changed the intended status from Informational to Standards Track;
+        the wire format, canonicalization, signature inputs, and consumption
+        rules are unchanged.<a href="#appendix-A-1.1" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="appendix-A-1.2">Clarified composition with the authorization-server, human-in-the-
+        loop, transaction-token, and audit requirements in
+        <span>[<a href="#I-D.klrc-aiagent-auth" class="cite xref">I-D.klrc-aiagent-auth</a>]</span> without treating confirmation
+        evidence as authorization.<a href="#appendix-A-1.2" class="pilcrow">¶</a>
+</li>
+      </ul>
+</section>
+</div>
+<div id="changes-since-07">
+<section id="appendix-B">
+      <h2 id="name-changes-since-07">
+<a href="#appendix-B" class="section-number selfRef">Appendix B. </a><a href="#name-changes-since-07" class="section-name selfRef">Changes since -07</a>
+      </h2>
+<ul class="normal">
+<li class="normal" id="appendix-B-1.1">Added the separate <code>EP-RECEIPT-EXTENSIONS-v1</code> companion
+        envelope, a bind-by-digest procedure, and a provisional extension
+        namespace and registry design.  The base Trust Receipt schema, parser,
+        canonical bytes, signature inputs, consumption rules, and log-proof
+        verification remain unchanged; a base verifier never strips or ignores
+        a new receipt member.<a href="#appendix-B-1.1" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="appendix-B-1.2">Defined one common base action, base receipt, operation, and
+        consequence seam for companion artifacts.<a href="#appendix-B-1.2" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="appendix-B-1.3">Added informative, non-exhaustive lifecycle examples including
+        revocation, outcome binding, action remedy, evidence challenge,
+        Authorization Evidence Chain composition, Authority Program stage
+        receipts, and staged DTC settlement binding.  No implementation,
+        deployment, or standards-adoption claim is made for an example merely
+        because it is named here.<a href="#appendix-B-1.3" class="pilcrow">¶</a>
+</li>
+      </ul>
+</section>
+</div>
+<div id="changes-since-06">
+<section id="appendix-C">
+      <h2 id="name-changes-since-06">
+<a href="#appendix-C" class="section-number selfRef">Appendix C. </a><a href="#name-changes-since-06" class="section-name selfRef">Changes since -06</a>
+      </h2>
+<ul class="normal">
+<li class="normal" id="appendix-C-1.1">Narrowed the abstract and introduction from category-wide
+        novelty claims to the guarantees of the selected EP verification
+        profile.<a href="#appendix-C-1.1" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="appendix-C-1.2">Scoped ConsumeOnce to one conforming shared atomic consumption
+        domain and stated that offline evidence cannot prove global
+        non-replay across independent executors.<a href="#appendix-C-1.2" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="appendix-C-1.3">Replaced legal non-repudiation language with cryptographic
+        attribution, tamper evidence, and public verifiability; stated the
+        issuer-equivocation boundary.<a href="#appendix-C-1.3" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="appendix-C-1.4">Added reference entries for the Canonical Action Identifier
+        and EP Quorum companion documents, previously used as terms of
+        art without citations, and a grouped companion-family paragraph
+        in Relationship to Other Work.<a href="#appendix-C-1.4" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="appendix-C-1.5">Added the CAID Action-Mapping composition boundary without
+        changing the EP v1 signature input.<a href="#appendix-C-1.5" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="appendix-C-1.6">Added Mastercard Verifiable Intent and AuthZEN AARP as adjacent,
+        composable work.<a href="#appendix-C-1.6" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="appendix-C-1.7">Clarified that a receipt can authorize and be consumed for
+        capability issuance, but cannot be reused as per-operation approval;
+        the capability protocol binds the full issuance-receipt digest.<a href="#appendix-C-1.7" class="pilcrow">¶</a>
+</li>
+      </ul>
+</section>
+</div>
+<div id="changes-since-04">
+<section id="appendix-D">
+      <h2 id="name-changes-since-04">
+<a href="#appendix-D" class="section-number selfRef">Appendix D. </a><a href="#name-changes-since-04" class="section-name selfRef">Changes since -04</a>
+      </h2>
+<p id="appendix-D-1">-05 adds the human-authorization-receipt composition frame for
+      the SCITT agent-action statement cluster (how a WHO receipt is
+      referenced, by digest, from capsule/record-style statements);
+      updates the SCITT citation to RFC 9943; adds the key-custody
+      disambiguation note in Section 5.1 (key classes classify custody,
+      not assurance levels); corrects the formal-models status (the
+      m-of-n quorum flow is now Alloy-checked) and states plainly which
+      three normative mechanisms the reference implementation does not
+      yet cover.<a href="#appendix-D-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="changes-since-00">
+<section id="appendix-E">
+      <h2 id="name-changes-since-00-through-04">
+<a href="#appendix-E" class="section-number selfRef">Appendix E. </a><a href="#name-changes-since-00-through-04" class="section-name selfRef">Changes since -00 (through -04)</a>
+      </h2>
+<p id="appendix-E-1">This summary covers -00 through -04. Section
+      numbering is stable; all changes are new subsections or in-place
+      additions.<a href="#appendix-E-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="appendix-E-2">
+        <li id="appendix-E-2.1">New <span class="bcp14">OPTIONAL</span> Authorization Context member
+        <code>initiator_attestation</code> (new
+        <a href="#initiator-attestation" class="auto internal xref">Section 4.1</a>): a
+        <span class="bcp14">REQUIRED</span> <code>escalation_trigger</code> enum
+        (<code>irreversibility</code>, <code>magnitude</code>,
+        <code>uncertainty</code>, <code>novelty</code>, <code>authority_gap</code>,
+        <code>policy_rule</code>), an <span class="bcp14">OPTIONAL</span>
+          <code>policy_basis</code> rule identifier, and an
+        <span class="bcp14">OPTIONAL</span> length-capped (&lt;= 280 character)
+        <code>statement</code>. The member is <span class="bcp14">OPTIONAL</span>;
+        it is covered by the context hash via the JCS canonicalization
+        already normative in <a href="#authorization-context" class="auto internal xref">Section 4</a>, so
+        the approver's signature covers the stated reason; receipts
+        carrying it verify under the existing
+        <a href="#offline-verification" class="auto internal xref">Section 6.3</a> verifiers unmodified; and it
+        is a claim by the initiator -- identified but never trusted -- not
+        proof of the initiator's internal state. A terminology entry and a
+        step-2 note in <a href="#offline-verification" class="auto internal xref">Section 6.3</a> were added
+        accordingly.<a href="#appendix-E-2.1" class="pilcrow">¶</a>
+</li>
+        <li id="appendix-E-2.2">Security Considerations additions (new
+        <a href="#initiator-attestation-security" class="auto internal xref">Section 12.9</a>): the
+        <code>statement</code> is attacker-influenceable text presented to a
+        human (prompt-injection -&gt; social-engineering surface); conforming
+        signing clients <span class="bcp14">MUST</span> render it as untrusted content
+        (no markup, length cap, distinct styling), consistent with the
+        <a href="#presentation-attacks" class="auto internal xref">Section 12.3</a> rendering-faithfulness
+        caveat. Adds privacy guidance for free-text statements in
+        long-lived receipts (prefer <code>policy_basis</code> identifiers),
+        the rule that absence of an attestation is not evidence of
+        non-escalation, the cross-context consistency requirement, and the
+        prohibition on using attestation content as a trust input. The
+        formal-models section now lists the Initiator Attestation among
+        the not-yet-modeled areas.<a href="#appendix-E-2.2" class="pilcrow">¶</a>
+</li>
+        <li id="appendix-E-2.3">Introduction/terminology clarifications (new text in the
+        Introduction, new <a href="#scope-of-identity" class="auto internal xref">Section 1.2</a>, and a
+        sentence in <a href="#key-classes" class="auto internal xref">Section 5.1</a> and
+        <a href="#approver-directory" class="auto internal xref">Section 5.2</a>): makes unmistakable that
+        (a) EP's user-verification-gated Class-A signoff is native to this
+        draft and does not depend on any other draft's
+        acquiescence/confirmation mechanism, and (b) proof of a specific
+        natural-person identity is out of scope -- the Approver Directory
+        trust root is the explicit slot where identity/key-discovery
+        layers bind keys to named persons.<a href="#appendix-E-2.3" class="pilcrow">¶</a>
+</li>
+        <li id="appendix-E-2.4">New <span class="bcp14">OPTIONAL</span> Authorization Context member
+        <code>agent_binding</code> (new <a href="#agent-binding" class="auto internal xref">Section 4.2</a>): an
+        external agent-identity reference (<code>agent_id</code>) and an
+        <span class="bcp14">OPTIONAL</span> <code>delegation</code> (<code>scheme</code>,
+        <code>ref</code>, <span class="bcp14">OPTIONAL</span> <code>hash</code>,
+        <span class="bcp14">OPTIONAL</span> <code>observed_at</code>), plus an
+        <span class="bcp14">OPTIONAL</span> length-capped (&lt;= 280 character)
+        <code>statement</code>. Like <code>initiator_attestation</code>, it is
+        <span class="bcp14">OPTIONAL</span>, covered by the context hash via the JCS
+        canonicalization already normative in
+        <a href="#authorization-context" class="auto internal xref">Section 4</a>, verifies under the existing
+        <a href="#offline-verification" class="auto internal xref">Section 6.3</a> verifiers unmodified, and is a
+        claim -- identified but never trusted -- not proof of the agent's
+        identity or the delegation's validity. The <span class="bcp14">OPTIONAL</span>
+          <code>delegation.observed_at</code> records when the upstream
+        identity/delegation (L4) evidence was observed; a relying party
+        <span class="bcp14">MAY</span> enforce freshness against it fail-closed, keeping
+        the receipt agnostic to which external identity scheme prevails while
+        making a stale or unconstrained upstream claim detectable after the
+        fact.<a href="#appendix-E-2.4" class="pilcrow">¶</a>
+</li>
+        <li id="appendix-E-2.5">Housekeeping: version and date bumped in the header; this
+        appendix added; the idnits non-ASCII em-dash / curly-quote cleanup
+        from -00 carried forward as a build step.<a href="#appendix-E-2.5" class="pilcrow">¶</a>
+</li>
+      </ol>
+</section>
+</div>
+<div id="authors-addresses">
+<section id="appendix-F">
+      <h2 id="name-authors-address">
+<a href="#name-authors-address" class="section-name selfRef">Author's Address</a>
+      </h2>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Iman Schrock</span></div>
+<div dir="auto" class="left"><span class="org">EMILIA Protocol, Inc.</span></div>
+<div dir="auto" class="left"><span class="country-name">United States of America</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:team@emiliaprotocol.ai" class="email">team@emiliaprotocol.ai</a>
+</div>
+</address>
+</section>
+</div>
+<script>const toc = document.getElementById("toc");
+toc.querySelector("h2").addEventListener("click", e => {
+  toc.classList.toggle("active");
+});
+toc.querySelector("nav").addEventListener("click", e => {
+  toc.classList.remove("active");
+});
+</script>
+</body>
+</html>

--- a/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/RENDERS/draft-schrock-ep-authorization-receipts-09.txt
+++ b/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/RENDERS/draft-schrock-ep-authorization-receipts-09.txt
@@ -1,0 +1,2128 @@
+
+
+
+
+Network Working Group                                         I. Schrock
+Internet-Draft                                     EMILIA Protocol, Inc.
+Intended status: Standards Track                           3 August 2026
+Expires: 4 February 2027
+
+
+           Authorization Receipts for High-Risk Agent Actions
+               draft-schrock-ep-authorization-receipts-09
+
+Abstract
+
+   This document defines the EMILIA Protocol (EP) authorization receipt,
+   an evidence artifact binding an enrolled approver key to one
+   canonical action before execution.  An approver-held key signs an
+   Authorization Context containing the action hash, policy reference,
+   nonce, audience, and validity window.  A Trust Receipt carries the
+   signed contexts, terminal consumption record, and Merkle inclusion
+   material so a relying party can verify the recorded event offline
+   under independently selected log, directory, policy, and approver
+   trust inputs.
+
+   The receipt establishes only the guarantees of the selected
+   verification profile.  The mapping from an enrolled approver
+   identifier to a natural person is asserted by the directory
+   authority.  Offline verification does not establish current
+   revocation status, global non-replay, comprehension, legality,
+   safety, or execution.  Replay prevention requires an online atomic
+   consumption store at the executor.  The state-machine invariants are
+   machine-checked under the assumptions stated in this document.
+
+   A receipt is evidence, not authorization.  This document does not
+   treat a local user interaction as an authorization decision.
+   Section 10.7 of [I-D.klrc-aiagent-auth] states that an agent MUST NOT
+   treat local UI confirmation alone as sufficient authorization, and
+   notes that additional specification or design work may be needed for
+   user confirmation occurring mid-execution, since CIBA accounts only
+   for client initiation.  This document defines one evidence artifact
+   that an authorization architecture can use in such a flow: the signed
+   Authorization Context is action-bound confirmation evidence an
+   authorization server MAY validate and bind to the grant it issues.
+   The resulting Trust Receipt records terminal consumption and remains
+   evidence; neither object makes the authorization decision.  That
+   decision remains with the authorization server.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+
+
+Schrock                  Expires 4 February 2027                [Page 1]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on 4 February 2027.
+
+Copyright Notice
+
+   Copyright (c) 2026 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents (https://trustee.ietf.org/
+   license-info) in effect on the date of publication of this document.
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.  Code Components
+   extracted from this document must include Revised BSD License text as
+   described in Section 4.e of the Trust Legal Provisions and are
+   provided without warranty as described in the Revised BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+     1.1.  Design Goals  . . . . . . . . . . . . . . . . . . . . . .   5
+     1.2.  Scope of Identity . . . . . . . . . . . . . . . . . . . .   6
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   6
+   3.  The Action Object and Action Hash . . . . . . . . . . . . . .   7
+   4.  The Authorization Context . . . . . . . . . . . . . . . . . .   8
+     4.1.  Initiator Attestation (OPTIONAL)  . . . . . . . . . . . .  10
+     4.2.  Agent Binding (OPTIONAL)  . . . . . . . . . . . . . . . .  12
+   5.  Approver Keys and the Signoff Signature . . . . . . . . . . .  16
+     5.1.  Key Classes . . . . . . . . . . . . . . . . . . . . . . .  16
+     5.2.  Enrollment and the Approver Directory . . . . . . . . . .  16
+     5.3.  The Signoff . . . . . . . . . . . . . . . . . . . . . . .  17
+   6.  Consumption, Commitment, and the Trust Receipt  . . . . . . .  18
+     6.1.  State Machine . . . . . . . . . . . . . . . . . . . . . .  18
+     6.2.  The Trust Receipt . . . . . . . . . . . . . . . . . . . .  18
+     6.3.  Offline Verification Algorithm  . . . . . . . . . . . . .  19
+   7.  Companion Receipt Extensions and Digest Binding . . . . . . .  20
+     7.1.  Provisional Extension Registry  . . . . . . . . . . . . .  22
+     7.2.  Relationship to the Action Lifecycle  . . . . . . . . . .  23
+   8.  Multi-Approver Policies (m-of-n)  . . . . . . . . . . . . . .  23
+
+
+
+Schrock                  Expires 4 February 2027                [Page 2]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   9.  Delegation Constraints  . . . . . . . . . . . . . . . . . . .  24
+   10. Conformance Classes and Execution-Side Enforcement  . . . . .  24
+   11. Relationship to Other Work  . . . . . . . . . . . . . . . . .  24
+   12. Security Considerations . . . . . . . . . . . . . . . . . . .  27
+     12.1.  Operator Compromise  . . . . . . . . . . . . . . . . . .  27
+     12.2.  Approver Device Compromise . . . . . . . . . . . . . . .  27
+     12.3.  Presentation Attacks . . . . . . . . . . . . . . . . . .  28
+     12.4.  Log Equivocation . . . . . . . . . . . . . . . . . . . .  28
+     12.5.  What the Formal Models Do and Do Not Prove . . . . . . .  29
+     12.6.  Directory Authority  . . . . . . . . . . . . . . . . . .  30
+     12.7.  What Separation of Duties Does and Does Not Provide  . .  30
+     12.8.  Approver Fatigue . . . . . . . . . . . . . . . . . . . .  31
+     12.9.  Initiator Attestation as an Attack Surface . . . . . . .  31
+     12.10. No symmetric key on the verification trust path  . . . .  32
+     12.11. Canonicalization Robustness  . . . . . . . . . . . . . .  33
+   13. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  33
+   14. Normative References  . . . . . . . . . . . . . . . . . . . .  33
+   15. Informative References  . . . . . . . . . . . . . . . . . . .  34
+   Appendix A.  Changes since -08  . . . . . . . . . . . . . . . . .  35
+   Appendix B.  Changes since -07  . . . . . . . . . . . . . . . . .  35
+   Appendix C.  Changes since -06  . . . . . . . . . . . . . . . . .  36
+   Appendix D.  Changes since -04  . . . . . . . . . . . . . . . . .  36
+   Appendix E.  Changes since -00 (through -04)  . . . . . . . . . .  37
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  38
+
+1.  Introduction
+
+   Agentic AI systems increasingly hold credentials sufficient to
+   perform irreversible operations: releasing payments, modifying
+   beneficiary records, rotating production credentials, deleting data.
+   Session-level authentication and authorization alone answer whether
+   an actor may operate within a scope.  A deployment can separately
+   require evidence that an enrolled approver key signed one exact
+   proposed action before execution.
+
+   Three structural gaps follow:
+
+   1.  *The action gap.* Identity and access management authorizes
+       _sessions and scopes_, not individual actions.  Fraud that occurs
+       inside a valid session through approved channels (e.g., business
+       email compromise leading to a beneficiary change) is invisible to
+       session-level controls.
+
+   2.  *The accountability gap.* Where human approval exists, it is
+       typically a click in a workflow tool, recorded in a mutable
+       application database controlled by the operator of the approval
+       system.  A deployment can instead require portable evidence
+       binding an enrolled approver key to the specific action.
+
+
+
+Schrock                  Expires 4 February 2027                [Page 3]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   3.  *The verification gap.* Auditors, counterparties, and regulators
+       may need to evaluate evidence outside the operator that produced
+       it, including after the live service is unavailable or the
+       operators disagree.
+
+   This document addresses those deployment requirements with a receipt
+   profile: before an irreversible action executes, an enrolled approver
+   signs the exact action with an approver-held key; an executor records
+   terminal consumption through an atomic state transition; and the
+   resulting receipt remains independently verifiable offline for as
+   long as its algorithms and trust material remain acceptable or are
+   renewed.
+
+   Adjacent mechanisms answer related but non-identical questions.  The
+   distinctions below are profile boundaries, not claims that portable
+   approval or intent evidence exists nowhere else.
+
+   *  OAuth 2.0 with Rich Authorization Requests (RFC 9396) and GNAP
+      (RFC 9635) authorize a client's _requested scope_; they do not
+      produce a named human's offline-verifiable signature over the
+      exact action that executed.
+
+   *  The OAuth Step-Up Authentication Challenge (RFC 9470) can _demand_
+      fresh human authentication for a sensitive operation, but yields
+      no durable, portable artifact of that approval.
+
+   *  Transaction Tokens (draft-ietf-oauth-transaction-tokens) propagate
+      call context across workloads within a trust domain; they are
+      short-lived, online-validated, and assert _workload_ identity, not
+      a human's authorization of an action.
+
+   *  The Security Event Token (RFC 8417) and CAEP convey, as issuer
+      assertions, that an event _occurred_; they are not a human's pre-
+      execution approval bound to one exact action.
+
+   *  RATS (RFC 9334) and the Entity Attestation Token (RFC 9711) attest
+      the trustworthiness of a _platform or workload_, not that a named
+      human authorized an action -- a different trust root.
+
+   *  SCITT (RFC 9943) provides an append-only transparency log and
+      inclusion receipts, but is deliberately agnostic about the
+      application semantics and authority behind a statement.  An EP
+      receipt can be carried as one such application statement.
+
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027                [Page 4]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   *  The agent-action evidence work now emerging around that
+      architecture -- per-action receipt envelopes, action capsules,
+      post-execution profiles, pre-execution permits, and refusal events
+      -- makes agent actions transparent, logged, and policy-checked.
+      Some define approval or intent evidence with different ceremony,
+      identity, freshness, or consumption guarantees.
+
+   The use case for this receipt is narrower than agent logging in
+   general: a relying party needs an action-bound approval event under a
+   named verification profile, portable outside the operator, agent
+   runtime, and transparency service.  EP is one such artifact and is
+   not a replacement for any of the above: it composes with them
+   (Section 11) and can be carried in their formats -- for example, an
+   EP receipt expressed as a COSE Signed Statement and logged by a SCITT
+   Transparency Service, or referenced by digest from an action receipt,
+   capsule, or permit.
+
+   The human-approval mechanism this document specifies -- a user-
+   verification-gated signature over the exact Authorization Context
+   (Section 5.1, Class A) -- is native to EP and self-contained.  It
+   does not depend on, and is not a profile of, any other draft's
+   acquiescence, consent, or confirmation mechanism; a conforming EP
+   signoff is produced entirely by the controls defined here.  Where EP
+   composes with adjacent work (Section 11), that composition is by
+   reference, not dependency.
+
+1.1.  Design Goals
+
+   *  *G1 -- Action binding.* An approval is cryptographically bound to
+      one exact action.  It cannot authorize anything else.
+
+   *  *G2 -- Approver-held keys.* The approver's signature is produced
+      by a key the EP operator does not possess.  The operator
+      orchestrates; it cannot forge.
+
+   *  *G3 -- One-time consumption.* An authorization reaches a terminal
+      state at most once within the executor's shared atomic consumption
+      domain.  Replay presented to that domain MUST be rejected.  An
+      offline receipt alone cannot prove that no independent executor
+      consumed the same authorization.
+
+   *  *G4 -- Separation of duties.* The initiator of an action MUST NOT
+      be an approver of that action.  Policies MAY require m-of-n
+      distinct approvers.
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027                [Page 5]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   *  *G5 -- Offline verifiability.* A receipt is verifiable with no
+      network access, using only the receipt, the approver's public key
+      material, and a published log checkpoint.  Offline verification
+      establishes authenticity and log inclusion as of commit time, not
+      current revocation status (Section 6.3).
+
+   *  *G6 -- Execution-side enforcement.* The strongest deployment
+      places verification at the system of record: the executing service
+      verifies the receipt before performing the action.  Middleware-
+      only deployments are explicitly defined as a weaker conformance
+      class (Section 10).
+
+   *  *G7 -- Machine-checked safety.* The protocol state machine's
+      safety properties are maintained as formal models (TLA+, Alloy,
+      and Tamarin) and checked in continuous integration.
+      Implementations can be tested against a published conformance
+      suite.
+
+1.2.  Scope of Identity
+
+   This document binds an approval to an _approver identifier_ whose key
+   is enrolled in the Approver Directory (Section 5.2); it does not, by
+   itself, prove that the holder of that identifier is a particular
+   natural person.  Proof of a specific real-world identity -- that
+   ep:approver:jchen-controller is the human Jordan Chen -- is out of
+   scope.  The Approver Directory trust root (Section 5.2) is the
+   explicit slot where an identity-proofing or key-discovery layer binds
+   keys to named persons; the strength of any such binding is a property
+   of that layer, not of the receipt format.  A receipt proves that a
+   key enrolled under a given approver identifier signed the exact
+   action; the mapping from identifier to person is established and
+   asserted by the directory authority.
+
+2.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+   *Initiator.* The entity (typically an AI agent or automated process)
+   that proposes a high-risk action.  The initiator is identified but
+   never trusted with approval authority over its own actions.
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027                [Page 6]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   *Approver.* A named human (or, for lower assurance classes, an
+   organizational role occupied by a named human at decision time) who
+   holds approval authority under policy.  The approver controls a
+   private signing key; see Section 5.
+
+   *Action.* A single proposed operation with concrete parameters (e.g.,
+   one wire transfer to one beneficiary for one amount).  Actions are
+   represented by an Action Object and identified by their action hash
+   (Section 3).
+
+   *Policy.* A named, versioned rule set determining, for a class of
+   actions, which approvers are required (including m-of-n thresholds),
+   validity windows, and amount or scope limits.
+
+   *Authorization Context.* The canonical structure an approver signs:
+   action hash, policy reference, initiator identity, nonce, expiry, and
+   chain binding (Section 4).
+
+   *Initiator Attestation.* An OPTIONAL claim by the initiator, carried
+   inside the Authorization Context, stating why the initiator escalated
+   the action to a human (Section 4.1).  It is a claim, not proof of the
+   initiator's internal state.
+
+   *Trust Receipt.* The terminal artifact: the Action Object digest, all
+   approver signatures, the consumption record, and a Merkle inclusion
+   proof against a signed log checkpoint (Section 6).
+
+   *Verifying Executor.* A system of record that verifies a Trust
+   Receipt (or a pre-execution Authorization Bundle) before performing
+   the action.  See Section 10.
+
+   *EP Operator.* The party running the orchestration service (policy
+   registry, signoff routing, log).  Under this protocol the operator is
+   _not_ in the signing trust path for approvals (G2).
+
+3.  The Action Object and Action Hash
+
+   An Action Object is a JSON document with at minimum:
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027                [Page 7]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   {
+     "ep_version": "1.0",
+     "action_type": "wire.release",
+     "target": { "system": "treasury.example",
+                 "resource": "wire/8841" },
+     "parameters": { "amount": "2400000.00", "currency": "USD",
+                     "beneficiary_account_hash": "sha256:..." },
+     "initiator": "ep:entity:agent-recon-7",
+     "policy_id": "ep:policy:wires-over-100k@v12",
+     "requested_at": "2026-06-09T17:21:04Z"
+   }
+
+   The Action Object MUST be serialized using JSON Canonicalization
+   Scheme (JCS) [RFC8785].  The *action hash* is the SHA-256 digest of
+   the canonical serialization.  Implementations MUST reject approval
+   requests whose action hash does not match a locally recomputed hash
+   of the presented Action Object.  Sensitive parameter values MAY be
+   carried as salted hashes (as beneficiary_account_hash above) provided
+   the executing system can recompute them; the binding property is
+   preserved because the hash commits to the committed values.
+
+   The action hash is this receipt format's native integrity identifier.
+   It is not assumed to equal an action digest from a different
+   protocol.  A composition layer MAY project the verified Action Object
+   into a Canonical Action IDentifier action type ([EP-CAID]) using an
+   exact mapping profile pinned by the relying party.  Such mapping
+   occurs only after receipt verification and does not change this
+   document's signature input.  A failed, lossy, or unpinned mapping is
+   indeterminate and MUST NOT be treated as an action match.
+
+4.  The Authorization Context
+
+   For each required approver, the orchestrator constructs an
+   Authorization Context:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027                [Page 8]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   {
+     "ep_version": "1.0",
+     "context_type": "ep.signoff.v1",
+     "action_hash": "sha256:9f2c...",
+     "policy_id": "ep:policy:wires-over-100k@v12",
+     "policy_hash": "sha256:77ab...",
+     "initiator": "ep:entity:agent-recon-7",
+     "approver": "ep:approver:jchen-controller",
+     "approver_index": 1,
+     "required_approvals": 2,
+     "nonce": "b64u:R9w1...",
+     "issued_at": "2026-06-09T17:21:05Z",
+     "expires_at": "2026-06-09T17:36:05Z",
+     "prev_receipt_hash": "sha256:51d0..."
+   }
+
+   Rules:
+
+   *  nonce MUST be at least 128 bits of CSPRNG output and MUST be
+      unique within the issuer and consumption domain for each
+      authorization attempt.  It is the consumption key for G3, and is
+      the receipt's freshness mechanism in the sense of the Entity
+      Attestation Token (RFC 9711): a verifier-relevant nonce, here held
+      to a 128-bit floor (twice the EAT minimum).  EP does not treat a
+      timestamp alone as freshness; absolute time, where a relying party
+      requires it, is asserted by an independent authority rather than
+      by the operator.
+
+   *  policy_hash commits to the exact policy version evaluated.  A
+      signature over a context with policy_hash X MUST NOT satisfy a
+      requirement evaluated under policy_hash Y, even for the same
+      policy_id.
+
+   *  prev_receipt_hash chains this authorization to the issuing log's
+      most recent receipt, contributing to tamper evidence.
+
+   *  The context is JCS-canonicalized; the *context hash* is its
+      SHA-256 digest.  The approver signs the context hash.
+
+   *  The approver MUST be shown, at signing time, a faithful human-
+      readable rendering of the Action Object -- not only the hash.
+      Signing interfaces that display a different action than the one
+      hashed are a presentation attack; see Section 12.3.
+
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027                [Page 9]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+4.1.  Initiator Attestation (OPTIONAL)
+
+   A producer MAY include an initiator_attestation member in any
+   ep.signoff.v1 Authorization Context.  The member carries the
+   initiator's own stated reason for escalating the action to a human.
+   When present it MUST be a JSON object with the following members and
+   no others:
+
+   +==================+==================+======+=====================+
+   |Field             |Required          |Type  |Description          |
+   +==================+==================+======+=====================+
+   |escalation_trigger|REQUIRED          |string|Why the initiator    |
+   |                  |                  |(enum)|escalated.  Exactly  |
+   |                  |                  |      |one of:              |
+   |                  |                  |      |irreversibility,     |
+   |                  |                  |      |magnitude,           |
+   |                  |                  |      |uncertainty, novelty,|
+   |                  |                  |      |authority_gap,       |
+   |                  |                  |      |policy_rule.         |
+   +------------------+------------------+------+---------------------+
+   |policy_basis      |OPTIONAL (REQUIRED|string|Identifier of the    |
+   |                  |whenever a        |      |policy or rule that  |
+   |                  |deterministic     |      |fired, e.g.          |
+   |                  |policy rule fired,|      |ep:policy:wires-over-|
+   |                  |including always  |      |100k@v12/rule:dual-  |
+   |                  |when              |      |auth.                |
+   |                  |escalation_trigger|      |                     |
+   |                  |is policy_rule)   |      |                     |
+   +------------------+------------------+------+---------------------+
+   |statement         |OPTIONAL          |string|Short free-text      |
+   |                  |                  |      |reason the initiator |
+   |                  |                  |      |gives the approver.  |
+   |                  |                  |      |MUST NOT exceed 280  |
+   |                  |                  |      |characters.          |
+   +------------------+------------------+------+---------------------+
+
+                                 Table 1
+
+   Enum semantics:
+
+   *  irreversibility -- the action cannot be undone once executed.
+
+   *  magnitude -- the amount or scope exceeds what the initiator should
+      act on alone.
+
+   *  uncertainty -- the initiator's confidence in its own assessment is
+      too low to proceed unaided.
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 10]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   *  novelty -- the action or counterparty has no precedent in the
+      initiator's history.
+
+   *  authority_gap -- the action requires authority the initiator was
+      never granted.
+
+   *  policy_rule -- a deterministic policy rule required signoff and
+      none of the five substantive categories above captures why;
+      policy_basis names the rule.
+
+   Example context (fields as above, with the new member):
+
+   {
+     "ep_version": "1.0",
+     "context_type": "ep.signoff.v1",
+     "action_hash": "sha256:9f2c...",
+     "policy_id": "ep:policy:wires-over-100k@v12",
+     "policy_hash": "sha256:77ab...",
+     "initiator": "ep:entity:agent-recon-7",
+     "initiator_attestation": {
+       "escalation_trigger": "magnitude",
+       "policy_basis": "ep:policy:wires-over-100k@v12/rule:dual-auth",
+       "statement": "Exceeds my single-action limit; new beneficiary."
+     },
+     "approver": "ep:approver:jchen-controller",
+     "approver_index": 1,
+     "required_approvals": 2,
+     "nonce": "b64u:R9w1...",
+     "issued_at": "2026-06-09T17:21:05Z",
+     "expires_at": "2026-06-09T17:36:05Z"
+   }
+
+   Rules:
+
+   *  *Status.* The member is OPTIONAL.  Existing issuers remain
+      conformant; the field can be adopted policy-by-policy.
+
+   *  *Binding.* No new signature, digest, or verification step is
+      introduced.  The context is JCS-canonicalized as already required
+      above; JCS serializes every member present, so
+      initiator_attestation and everything inside it are part of the
+      signed bytes.  The approver's signature therefore covers the
+      stated reason: the receipt proves the stated reason was part of
+      what the approver signed.  Receipts carrying this member verify
+      under the existing Section 6.3 verifiers unmodified; a context
+      without the member produces byte-identical canonical material to
+      one produced today.
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 11]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   *  *Trigger/basis precedence.* escalation_trigger always carries the
+      substantive reason: when one of the first five enum values
+      applies, the producer MUST use it, whether or not a deterministic
+      rule also fired; policy_rule MUST be used only when no substantive
+      category fits.  Independently of which trigger is chosen, whenever
+      a deterministic policy rule fired, policy_basis MUST be populated
+      with that rule's identifier.
+
+   *  *Cross-context consistency.* When a receipt contains multiple
+      contexts (m-of-n approvals), the initiator_attestation object, if
+      present in any context, MUST be present in every context of that
+      receipt, and its canonical form --
+      canonicalize(initiator_attestation) -- MUST be identical across
+      all of them.  Every approver signs the same stated reason.
+
+   *  Producers MUST NOT add members beyond the three defined above in
+      v1.
+
+   *  A signing client implementing this member MUST render the
+      attestation to the approver alongside the faithful human-readable
+      rendering of the Action Object that this section already requires,
+      subject to the untrusted-content display rules in Section 12.9.
+
+   *  A signing client presented with a context whose statement exceeds
+      280 characters MUST refuse to render it for signing.
+
+   The attestation is a claim by the initiator, which this document
+   identifies but never trusts (Section 2): it is the initiator's stated
+   reason, not a verified fact, and it is not evidence of the
+   initiator's internal state.  Verifiers implementing this member MUST
+   check the cross-context consistency rule above and SHOULD surface the
+   attestation and flag other violations of this section in verification
+   reports; none of these checks affects signature validity, by design,
+   so receipts verify on verifiers that predate this member.
+
+4.2.  Agent Binding (OPTIONAL)
+
+   A producer MAY include an agent_binding member in any ep.signoff.v1
+   Authorization Context.  The member attributes the authorized action
+   to an external *agent identity* and, optionally, the external
+   *delegation* under which that agent was authorized to act.  When
+   present it MUST be a JSON object with the following members and no
+   others:
+
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 12]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+    +============+==========+========+================================+
+    | Field      | Required | Type   | Description                    |
+    +============+==========+========+================================+
+    | agent_id   | REQUIRED | string | Non-empty external agent-      |
+    |            |          |        | identity reference (URI, DID,  |
+    |            |          |        | or opaque id).  This document  |
+    |            |          |        | does not constrain its scheme. |
+    +------------+----------+--------+--------------------------------+
+    | delegation | OPTIONAL | object | The external delegation that   |
+    |            |          |        | authorized the agent; members  |
+    |            |          |        | below, no others.              |
+    +------------+----------+--------+--------------------------------+
+    | statement  | OPTIONAL | string | Short free-text note for the   |
+    |            |          |        | approver.  MUST NOT exceed 280 |
+    |            |          |        | characters.                    |
+    +------------+----------+--------+--------------------------------+
+
+                                  Table 2
+
+   When delegation is present it MUST be a JSON object with the
+   following members and no others:
+
+    +=============+==========+========+==============================+
+    | Field       | Required | Type   | Description                  |
+    +=============+==========+========+==============================+
+    | scheme      | REQUIRED | string | Non-empty name of the        |
+    |             |          |        | external delegation          |
+    |             |          |        | standard, e.g.  "WIMSE",     |
+    |             |          |        | "DRP".                       |
+    +-------------+----------+--------+------------------------------+
+    | ref         | REQUIRED | string | Non-empty external receipt/  |
+    |             |          |        | credential identifier.       |
+    +-------------+----------+--------+------------------------------+
+    | hash        | OPTIONAL | string | Content hash of the          |
+    |             |          |        | referenced artifact,         |
+    |             |          |        | formatted "sha256:<64-       |
+    |             |          |        | lowercase-hex>".             |
+    +-------------+----------+--------+------------------------------+
+    | observed_at | OPTIONAL | string | RFC 3339 timestamp recording |
+    |             |          |        | when the external delegation |
+    |             |          |        | evidence was observed or     |
+    |             |          |        | known valid.  See L4         |
+    |             |          |        | evidence freshness below.    |
+    +-------------+----------+--------+------------------------------+
+
+                                 Table 3
+
+   Example context (fields as above, with the new member):
+
+
+
+Schrock                  Expires 4 February 2027               [Page 13]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   {
+     "ep_version": "1.0",
+     "context_type": "ep.signoff.v1",
+     "action_hash": "sha256:9f2c...",
+     "policy_id": "ep:policy:wires-over-100k@v12",
+     "policy_hash": "sha256:77ab...",
+     "initiator": "ep:entity:agent-recon-7",
+     "agent_binding": {
+       "agent_id": "did:web:agents.example.com:recon-7",
+       "delegation": {
+         "scheme": "WIMSE",
+         "ref": "urn:wimse:cred:9c41ab",
+         "hash": "sha256:2f9a...",
+         "observed_at": "2026-06-09T17:20:48Z"
+       },
+       "statement": "Acting for treasury-ops under wire delegation."
+     },
+     "approver": "ep:approver:jchen-controller",
+     "approver_index": 1,
+     "required_approvals": 2,
+     "nonce": "b64u:R9w1...",
+     "issued_at": "2026-06-09T17:21:05Z",
+     "expires_at": "2026-06-09T17:36:05Z"
+   }
+
+   Rules:
+
+   *  *Status.* The member is OPTIONAL.  Existing issuers remain
+      conformant; the field can be adopted policy-by-policy.
+
+   *  *Claim, not proof.* agent_binding records that the action was
+      _presented_ as being taken by agent_id under delegation ref.  This
+      document identifies but never trusts the binding (Section 2): it
+      is neither proof of the agent's identity nor proof of the
+      delegation's validity, both of which remain the responsibility of
+      the referenced external system.  A verifier MUST NOT treat
+      agent_binding as proof of either; it MAY surface agent_id and
+      delegation to the relying party as part of the verified context,
+      clearly labeled as a reference to an external system.
+
+   *  *Binding.* No new signature, digest, or verification step is
+      introduced.  The context is JCS-canonicalized as already required
+      above; JCS serializes every member present, so agent_binding and
+      everything inside it are part of the signed bytes.  The approver's
+      signature therefore covers the binding.  Receipts carrying this
+      member verify under the existing Section 6.3 verifiers unmodified;
+      a context without it produces byte-identical canonical material to
+      one produced today.
+
+
+
+Schrock                  Expires 4 February 2027               [Page 14]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   *  *Cross-context consistency.* When a receipt contains multiple
+      contexts (m-of-n approvals), the agent_binding object, if present
+      in any context, MUST be present in every context of that receipt,
+      and its canonical form -- canonicalize(agent_binding) -- MUST be
+      identical across all of them.  Every approver signs the same
+      attribution.
+
+   *  Producers MUST NOT add members beyond those defined above in v1,
+      in either agent_binding or its delegation.
+
+   *  A signing client implementing this member SHOULD render agent_id
+      (and delegation if present) to the approver alongside the faithful
+      human-readable rendering of the Action Object that this section
+      already requires, subject to the untrusted-content display rules
+      in Section 12.9.  A signing client presented with a context whose
+      statement exceeds 280 characters MUST refuse to render it for
+      signing.
+
+   *L4 evidence freshness (OPTIONAL).* A human authorization decision is
+   only as trustworthy as the upstream agent-identity and delegation
+   evidence it relied on.  If a decision is enforced correctly against a
+   delegation claim that was never constrained or has since expired, the
+   failure surfaces at the authorization layer but originates in the
+   identity/delegation layer beneath it.  This document makes that
+   dependency explicit and recordable without absorbing the identity
+   layer:
+
+   *  A producer MAY populate delegation.observed_at with the RFC 3339
+      time at which the external delegation evidence was observed or
+      known valid.  Like the rest of the binding, it is covered by the
+      approver's signature.
+
+   *  A relying party MAY enforce freshness against observed_at.  When
+      it does, the evaluation MUST fail closed: a missing observed_at, a
+      timestamp later than the evaluation time, or an age exceeding the
+      relying party's configured maximum MUST be treated as not-fresh.
+      When no maximum age is configured, freshness is not evaluated and
+      the evidence is still surfaced for the audit record.
+
+   This keeps the receipt agnostic to which external identity/delegation
+   scheme prevails: the relying party binds to and records whatever
+   evidence was presented rather than requiring that layer to converge,
+   and a stale or unconstrained upstream claim becomes detectable after
+   the fact rather than silently absorbed.  As with the Initiator
+   Attestation, none of these checks affects signature validity, by
+   design, so receipts verify on verifiers that predate this member.
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 15]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+5.  Approver Keys and the Signoff Signature
+
+   This section is the core upgrade over server-side approval systems.
+
+5.1.  Key Classes
+
+   Key classes classify KEY CUSTODY -- who holds and exercises the
+   approver's signing key -- and nothing else.  They are distinct from,
+   and unrelated to, any assurance-level or conformance-class vocabulary
+   used elsewhere.  Cross-protocol requirements ought to name verifier-
+   visible properties such as user verification, device binding,
+   initiator exclusion, distinct humans, freshness, and status rather
+   than treating these receipt-local custody labels as universal
+   assurance grades.
+
+   *Class A -- Device-bound keys (RECOMMENDED).* The approver's key is
+   generated and held in a platform authenticator or security key and
+   exercised via WebAuthn [WEBAUTHN].  The signature algorithm is ES256
+   (P-256) or Ed25519 where supported.  The WebAuthn challenge MUST be
+   the context hash.  The authenticator's user-verification flag
+   (biometric or PIN) MUST be required for signoff credentials.  This
+   user-verification-gated signature is the native EP human-approval
+   act; it is fully defined by this section and does not rely on any
+   external acquiescence or confirmation mechanism.  Attestation SHOULD
+   be captured at enrollment so relying parties can establish that the
+   key is hardware-bound.
+
+   *Class B -- Software keys.* An Ed25519 keypair held in the approver's
+   client environment (CLI keychain, mobile secure enclave via app).
+   Acceptable where WebAuthn is impractical (headless approval
+   terminals), with the reduced assurance noted in receipts.
+
+   *Class C -- Operator-custodied keys (LEGACY).* The EP operator signs
+   on the approver's behalf after authenticating them.  This class
+   exists only to describe pre-existing deployments.  Receipts produced
+   under Class C MUST be labeled key_class: "C" and relying parties
+   SHOULD treat them as evidence of operator assertion, not approver
+   signature.  New deployments SHOULD NOT use Class C.
+
+5.2.  Enrollment and the Approver Directory
+
+   Approver public keys are enrolled into a signed Approver Directory
+   maintained per organization: a Merkle tree over (approver_id,
+   public_key, key_class, valid_from, valid_to, roles) entries, with
+   signed tree heads published alongside receipt log checkpoints.  A
+   receipt's offline verifiability (G5) includes an inclusion proof of
+   the approver's key entry, so a verifier needs no live directory
+   access.  Key rotation appends a new entry and terminates the old one;
+
+
+
+Schrock                  Expires 4 February 2027               [Page 16]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   signatures verify against the key entry valid at issued_at.
+
+   Directory authority is a trust root and MUST NOT default to the EP
+   operator.  The directory tree head MUST be signed by an organization-
+   controlled directory key (custody options parallel Section 5.1; an
+   organization-held hardware key is RECOMMENDED).  Where directory
+   _operation_ is delegated to the EP operator, every enrollment entry
+   MUST carry a second-party attestation -- a signature over the new
+   entry by an organization administrator key or by a quorum of already-
+   enrolled approvers -- and that attestation MUST be included in the
+   receipt's approver_key_proofs.  Verifiers MUST treat a directory head
+   signed only by an operator-held key as operator assertion (Class
+   C-equivalent assurance), regardless of the key class of the
+   individual signoffs.  Rationale: an operator that unilaterally
+   controls directory membership cannot forge an enrolled approver's
+   signature, but it can enroll a key it controls under a legitimate
+   approver's name -- relocating the forgery rather than preventing it.
+   See Section 12.6.
+
+   This directory is also the binding point between approver identifiers
+   and real-world persons (Section 1.2).  The strength of that binding
+   -- how an organization proves that an enrolled identifier is the
+   person it names, and how key-discovery layers attach to it -- is a
+   property of the directory authority and any identity layer bound to
+   it, not of the receipt format defined here.
+
+5.3.  The Signoff
+
+   A signoff is:
+
+   {
+     "context_hash": "sha256:c41e...",
+     "signature": "b64u:MEUCIQ...",
+     "key_class": "A",
+     "approver_key_id": "ep:key:jchen-controller#2026-01",
+     "signed_at": "2026-06-09T17:24:40Z",
+     "webauthn": { "authenticator_data": "b64u:...",
+                   "client_data_json": "b64u:..." }
+   }
+
+   For Class A, verifiers MUST validate the WebAuthn assertion per
+   [WEBAUTHN] including that clientDataJSON.challenge equals the context
+   hash and that the user-verification bit is set.  A denial is also
+   signed (over the context hash with a decision: "denied" envelope) so
+   that refusals are equally attributable, tamper-evident, and terminal.
+   This is a cryptographic statement; legal non-repudiation is out of
+   scope.
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 17]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+6.  Consumption, Commitment, and the Trust Receipt
+
+6.1.  State Machine
+
+   An authorization attempt proceeds:
+
+   REQUESTED -> {PARTIALLY_APPROVED}* -> APPROVED -> COMMITTED
+             \-> DENIED                          \-> EXPIRED
+             \-> EXPIRED
+
+   COMMITTED, DENIED, and EXPIRED are terminal.  The protocol invariants
+   -- maintained as machine-checked models and REQUIRED of conforming
+   implementations -- are:
+
+   *  *ConsumeOnce.* Within one conforming shared, atomic consumption
+      domain, a nonce transitions to a terminal state at most once.  Any
+      second presentation to that domain MUST be rejected with a replay
+      error.  The model does not assert coordination with an independent
+      store that does not share this state.
+
+   *  *BindingMatch.* A signoff satisfies only the context (and
+      therefore only the action hash) it signs.
+
+   *  *TerminalIrreversibility.* No transition exits a terminal state.
+
+   *  *SelfApprovalImpossible.* For every signoff, approver !=
+      initiator; for m-of-n policies, approvers are pairwise distinct
+      and each distinct from the initiator.
+
+   *  *NoBypassWrite.* A COMMITTED state is reachable only through the
+      full sequence; conforming verifying executors MUST NOT execute
+      without verifying it (Section 10).
+
+6.2.  The Trust Receipt
+
+   Upon commitment the orchestrator assembles and logs the Trust
+   Receipt:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 18]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   {
+     "receipt_id": "ep:receipt:01J...",
+     "action": { "...": "full Action Object" },
+     "action_hash": "sha256:9f2c...",
+     "contexts": [ { "...": "Authorization Context 1" } ],
+     "signoffs": [ { "...": "Signoff 1" },
+                   { "...": "Signoff 2" } ],
+     "consumption": { "nonce": "b64u:R9w1...",
+                      "state": "COMMITTED",
+                      "committed_at": "2026-06-09T17:25:02Z" },
+     "log_proof": { "leaf_index": 88412,
+                    "inclusion_path": ["sha256:...", "..."],
+                    "checkpoint": { "tree_size": 90210,
+                                    "root_hash": "sha256:...",
+                                    "log_signature": "b64u:...",
+                                    "log_key_id": "ep:log:acme#1" } },
+     "approver_key_proofs": [ { "directory_inclusion": "..." } ]
+   }
+
+6.3.  Offline Verification Algorithm
+
+   A verifier with (receipt, trusted log public key, trusted directory
+   root or pinned approver keys) and *no network access* MUST be able to
+   establish all of the following; the published verifier package
+   performs exactly these steps:
+
+   1.  Recompute the action hash from the canonical Action Object;
+       compare.
+
+   2.  For each context: recompute the context hash; confirm it commits
+       to the action hash, the policy hash, and a distinct approver.
+
+   3.  For each signoff: verify the signature (and WebAuthn assertion
+       where present) over the context hash against the approver key
+       entry, checking the key's validity window contains issued_at.
+
+   4.  Confirm SoD: initiator appears in no approver slot; approvers are
+       pairwise distinct; the approval count satisfies
+       required_approvals.
+
+   5.  Verify the Merkle inclusion proof of the receipt leaf against the
+       checkpoint root, and the checkpoint signature against the log
+       key.
+
+   6.  Confirm signed_at and committed_at fall within [issued_at,
+       expires_at].
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 19]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   Degenerate empty-path rule (step 5).  An empty inclusion_path MUST be
+   accepted only when the checkpoint's tree_size is exactly 1 and the
+   leaf_index, when present, is 0; an empty path presented with any
+   other tree size (including a missing or non-integer tree_size) MUST
+   be refused, before any Merkle computation.  Without this rule an
+   empty path degenerates to "leaf hash equals root hash", which a
+   forged checkpoint can satisfy at any claimed tree size by simply
+   repeating the leaf hash as its root.  Two public reject vectors in
+   the EP conformance suite (reject_empty_path_tree_size_not_1 and
+   reject_empty_path_nonzero_leaf_index) pin this rule across the cross-
+   language reference verifiers.
+
+   Step 5 is what distinguishes EP receipts from log-access designs: the
+   checkpoint travels _inside_ the receipt, so verification requires no
+   query to the log.  Detecting log equivocation (split-view attacks)
+   additionally benefits from gossip or witness cosigning
+   (Section 12.4), which is an online activity; the offline guarantee is
+   that _this receipt is internally consistent, correctly signed by
+   enrolled approver keys, and was included in a log tree whose head the
+   log operator signed_.
+
+   Offline verification establishes authenticity, not currency.  Two
+   properties are explicitly NOT established offline: (a) post-issuance
+   revocation -- a receipt whose approver key was revoked an hour after
+   commitment still verifies; the artifact is evidence of validity _at
+   commit time_; and (b) log honesty against split views (Section 12.4).
+   A relying party with freshness or revocation requirements MUST
+   additionally consult a current directory head and log checkpoint
+   online.  Implementations MUST NOT describe offline verification as
+   establishing that a receipt is "currently valid."
+
+   The Initiator Attestation (Section 4.1), where present, is covered by
+   the context hash recomputed in step 2 above; no additional
+   verification step is required for it.
+
+7.  Companion Receipt Extensions and Digest Binding
+
+   Extensions MUST NOT be inserted into the base Trust Receipt.  The EP-
+   RECEIPT-v1 object, its closed schema, its canonical bytes, and the
+   verification procedure in Section 6.3 remain unchanged.  In
+   particular, a base verifier MUST NOT strip, ignore, or otherwise
+   preprocess an unrecognized receipt member before verification.
+
+   A producer MAY convey lifecycle or composition bindings in a separate
+   companion object whose version is EP-RECEIPT-EXTENSIONS-v1.  The
+   companion is not part of the base Trust Receipt and confers no
+   authority by itself.  It MUST be a closed object with exactly
+   version, base_receipt_digest, base_action_digest, and entries:
+
+
+
+Schrock                  Expires 4 February 2027               [Page 20]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   {
+     "version": "EP-RECEIPT-EXTENSIONS-v1",
+     "base_receipt_digest": "sha256:...",
+     "base_action_digest": "sha256:...",
+     "entries": [
+       {
+         "name": "ai.emiliaprotocol.trust-program.stage-receipts.v1",
+         "operation_id": "provider-stable-operation-id",
+         "consequence_digest": null,
+         "artifact_digest": "sha256:..."
+       }
+     ]
+   }
+
+   The base_receipt_digest MUST be SHA-256 over the JCS canonicalization
+   of the complete, unchanged base Trust Receipt.  No member is removed
+   or added for this calculation.  This value is the identity of the
+   complete portable receipt, not the Merkle leaf hash; implementations
+   MUST NOT substitute a leaf digest that omits log_proof or
+   approver_key_proofs.  The base_action_digest MUST equal that base
+   receipt's action_hash.  Digest values in this companion MUST use the
+   lowercase sha256: prefix followed by exactly 64 lowercase hexadecimal
+   characters.  The entries member MUST contain between 1 and 32 closed
+   objects, each with exactly name, operation_id, consequence_digest,
+   and artifact_digest.
+
+   *  name MUST be an ASCII lowercase, dot-separated extension name.
+      Each label begins and ends with a lowercase letter or digit and
+      can contain interior hyphens.  A name MUST NOT exceed 255 ASCII
+      characters.  A name allocated outside the document-local namespace
+      SHOULD begin with a reversed DNS name controlled by its allocator.
+      Control of a name is only collision avoidance; it conveys no
+      trust.  An entries array MUST NOT contain the same name more than
+      once.
+
+   *  operation_id is either null or the stable operation identifier
+      selected by the extension profile.  A lifecycle extension
+      governing a material attempt MUST use a non-null value and MUST
+      NOT derive it from presenter-controlled display text.  A non-null
+      value MUST be non-empty, contain no control characters, and
+      contain no more than 512 Unicode scalar values.
+
+   *  consequence_digest is either null for a pre-effect extension or
+      the extension profile's digest of the exact observed, claimed, or
+      settled consequence.  A null value conveys no execution or outcome
+      proof.
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 21]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   *  artifact_digest MUST be the SHA-256 digest of the exact companion
+      artifact under the canonicalization rule named by the selected
+      extension definition.
+
+   An extension-aware relying party MUST first verify the unchanged base
+   Trust Receipt using the base verification procedure.  It then
+   separately verifies the companion version, recomputes both base
+   digests, and evaluates the extension names required by its own
+   policy.  The companion envelope is an untrusted index, not an
+   authenticated assertion.  Companion artifacts are conveyed
+   separately; this document defines no network retrieval or presenter-
+   supplied locator.  Parsers MUST apply the duplicate-member,
+   surrogate, number, and depth rejection rules in Section 12.11 to the
+   companion before using any entry.  For each required entry, an
+   extension-specific verifier MUST verify the companion artifact under
+   relying-party-selected trust and MUST require that artifact to bind
+   the same extension name, base action digest, base receipt digest,
+   operation identifier, and consequence digest.  It then recomputes the
+   artifact digest over that exact artifact.  The extension profile MUST
+   define any freshness, replay, revocation, and terminal-state checks
+   needed for its assurance claim.  Merely carrying a digest does not
+   establish the artifact's validity, authority, freshness, non-replay,
+   or execution semantics.
+
+   An extension-aware relying party MAY ignore an unknown sidecar entry
+   only when its policy does not require that extension name.  It MUST
+   fail closed when a required entry is absent, unknown, duplicated,
+   malformed, untrusted, or mismatched.  The required extension set is
+   selected independently by relying-party policy; a presenter cannot
+   weaken it by omitting an entry.  A verifier that implements only EP-
+   RECEIPT-v1 does not process the companion and gains no additional
+   assurance from its presence.
+
+7.1.  Provisional Extension Registry
+
+   This revision defines the design rules for a provisional, document-
+   local namespace; it does not create an IANA registry.  Names
+   beginning with ep. are reserved for assignments made by a future
+   revision of this document or by a separately versioned public
+   extension index explicitly referenced by such a revision.  This
+   revision makes no ep. assignments.  Other specifications can self-
+   allocate a reversed-DNS name under a domain they control.
+
+   Every extension definition MUST specify its immutable name,
+   controlling specification and version, companion artifact version,
+   canonicalization rule, artifact-digest rule, operation-identifier
+   semantics, consequence-digest semantics, relying-party trust inputs,
+   freshness and replay behavior, and fail-closed conditions.  An
+
+
+
+Schrock                  Expires 4 February 2027               [Page 22]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   incompatible semantic change MUST allocate a new name.  An extension
+   definition MUST NOT redefine the base Action Object, Authorization
+   Context, signoff, consumption, or log-proof bytes.
+
+   A relying party MUST pin the exact extension definition it accepts;
+   discovering a syntactically valid name is not authorization to trust
+   it.  A future document could request an IANA registry if
+   interoperable use demonstrates that centralized allocation is needed.
+   Such a request is outside the scope of this revision.
+
+7.2.  Relationship to the Action Lifecycle
+
+   This subsection is informative.  The companion seam permits a
+   revocation statement to retract future authority without rewriting an
+   executed effect; an outcome-binding artifact to compare approved
+   bytes with an observed effect; an action-remedy receipt to describe a
+   newly authorized compensating action with its own CAID and rollback:
+   false; or an evidence challenge to name evidence missing before
+   execution.  These examples do not soften the base receipt's terminal
+   or consumption semantics.
+
+   An Authority Program (also described informally as a Trust Program)
+   can use the same companion seam for immutable stage receipts whose
+   sorted predecessor receipt digests bind a relying-party-pinned
+   recursive series/parallel program to one root CAID and action.  An
+   Authorization Evidence Chain composition artifact can bind a
+   separately verified set of evidence nodes to the same receipt and
+   action digests.  A staged DTC settlement profile could likewise bind
+   a receipt or certificate state root.  These are informative, non-
+   exhaustive consumers.  Base receipt verification does not validate
+   any such chain, program, lifecycle, or settlement artifact.  This
+   document does not claim that Authority Program or DTC settlement
+   infrastructure is standardized, independently implemented, deployed,
+   or proved by base receipt or companion-envelope verification.
+
+8.  Multi-Approver Policies (m-of-n)
+
+   A policy MAY require k distinct approvers from a role set.  Each
+   approver receives and signs an individual Authorization Context
+   sharing the same action_hash and nonce family but a distinct
+   approver_index.  Commitment occurs only when k valid, distinct
+   signoffs exist before expires_at.  Partial approval confers no
+   authority: a verifying executor presented with fewer than k signoffs
+   MUST refuse.
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 23]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+9.  Delegation Constraints
+
+   Where an approver's authority is itself delegated, the delegation
+   record MUST be presented in the receipt's approver_key_proofs, and
+   the constraint *DelegateCannotExceedPrincipal* applies: the effective
+   scope of a delegate is the intersection of the delegation grant and
+   the principal's authority at signing time.  Delegation chains are
+   bounded (RECOMMENDED depth of at most 2) and every link is
+   independently signed.
+
+10.  Conformance Classes and Execution-Side Enforcement
+
+   Honesty about deployment topology is a protocol feature.  Three
+   classes:
+
+   *EP-Verified Execution (STRONG).* The system of record (payment
+   switch, registry, deployment controller) verifies the Authorization
+   Bundle (receipt-less pre-execution form: action object, contexts,
+   signoffs, consumption attestation) before executing, and refuses
+   otherwise.  The gate cannot be bypassed by any party that does not
+   control the system of record itself.
+
+   *EP-Gated Middleware (STANDARD).* An interception layer between the
+   agent and the executing credential enforces the gate.  Provides
+   strong protection against agent error and prompt injection; an
+   operator with code control can bypass.  Receipts remain valid
+   evidence of what _was_ approved.
+
+   *EP-Evidence Only (BASIC).* Actions execute independently; receipts
+   are produced for audit.  No enforcement claim is made.
+
+   Implementations MUST declare their class in receipts
+   (enforcement_class), and marketing or compliance claims MUST NOT
+   state a stronger class than deployed.  This section exists because
+   the difference between "we proved the protocol" and "your deployment
+   is unbypassable" is the most common overclaim in this category.
+
+11.  Relationship to Other Work
+
+   *Companion EP documents.* This document is self-contained: a receipt
+   is issued, verified, and consumed under this specification alone.  A
+   family of separately published companion documents composes with it
+   without altering its semantics, grouped by function: action identity
+   and comparison across independently issued artifacts ([EP-CAID]);
+   multi-approver policies ([EP-QUORUM]) and display binding;
+   enforcement-side ordering and bounded multi-action execution
+   (including [EP-BOUNDED-CAP]); post-execution outcome observation,
+   revocation statements, and compensating remedies; and evidence
+
+
+
+Schrock                  Expires 4 February 2027               [Page 24]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   composition, challenge, and reliance records.  Each companion
+   consumes this document's digests or supplies relying-party trust
+   inputs; none is required for conformance to this document.
+
+   *DRP* ([I-D.nelson-agent-delegation-receipts]) binds a _user's_
+   delegation to an _operator's_ instructions -- upstream consumer
+   delegation.  EP binds an _organizational approver_ to an _exact
+   action_ -- downstream authorization under its own SoD and m-of-n
+   profiles.  The two compose: a DRP delegation can be referenced in an
+   EP Action Object's provenance field.
+
+   *Bounded Capability Receipts* [EP-BOUNDED-CAP] authorize a different
+   lifecycle.  An EP Authorization Receipt can approve the exact act of
+   issuing a bounded capability, and that issuance receipt is consumed
+   when the capability is registered.  It MUST NOT then be reused as
+   though it approved every later capability-funded operation.  The
+   capability binds the complete issuance-receipt digest, scope, budget,
+   holder proof, and validity interval; its shared reserve/commit store
+   accounts later operations.  A deployment that requires human approval
+   of an individual exercise obtains a new action-bound EP receipt or a
+   quorum receipt set ([EP-QUORUM]) for that exercise.
+
+   *CIBA* [CIBA] transports an authentication-time approval to a
+   backchannel device; it does not produce an action-bound, offline-
+   verifiable, one-time-consumable artifact.  CIBA MAY serve as the
+   transport by which an approver is reached; the EP signoff is what
+   they produce when they get there.
+
+   *AI Agent Authentication and Authorization* ([I-D.klrc-aiagent-auth])
+   keeps the final authorization decision with the authorization server,
+   requires local user confirmation to be bound to a verifiable grant,
+   and identifies mid-execution confirmation as an area where additional
+   work may be needed.  An EP Authorization Context is one candidate
+   evidence object for that binding; it does not replace the grant or
+   authorization server decision.  The same document requires durable,
+   tamper-evident audit records.  An EP Trust Receipt can supply an
+   action, decision, and terminal-consumption record under the selected
+   profile, but does not by itself satisfy deployment monitoring,
+   remediation, retention, or compliance requirements.  A profile can
+   carry the Authorization Context or Trust Receipt digest in
+   transaction context without redefining transaction-token semantics.
+
+
+
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 25]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   *Mastercard Verifiable Intent* [FIDO-VI], co-developed with Google
+   and contributed to the FIDO Alliance, describes portable, verifiable
+   evidence of user intent.  The cited page describes a contribution and
+   prospective standardization, not a final FIDO specification.  EP does
+   not claim portable human evidence is absent.  Its receipt profile
+   separately specifies an enrolled organizational approver directory,
+   exact Authorization Context, initiator exclusion, terminal
+   consumption record, and optional distinct-human quorum.
+
+   *AuthZEN Access Request and Approval Profile* [AUTHZEN-AARP] defines
+   requestable denial, asynchronous approval tasks, an approval object
+   whose optional state carries opaque proof or verifier state, JWS
+   interoperability when that state is carried by value, an exact-match
+   baseline, and PDP re-evaluation at enforcement time.  EP does not
+   replace that profile.  A deployment can select an EP receipt as an
+   additional evidence profile when it requires a verifier-visible
+   approver-held device ceremony, enrolled-human directory binding,
+   portable initiator exclusion, or one-time executor consumption.  The
+   relying party remains responsible for deciding which profile
+   satisfies its requirement.
+
+   *WIMSE / workload identity* authenticates the workload to services;
+   EP supplies action-bound approval evidence that a relying party may
+   require in its local authorization decision.  These are complementary
+   layers.
+
+   *Receiver-attested logging (e.g., Sello)* has the receiving service
+   sign what it observed, post-hoc.  EP is pre-execution authorization.
+   A complete deployment benefits from both: EP records the pre-
+   execution signing and consumption event under a selected profile;
+   receiver attestation records what the receiver observed afterward.
+   Local policy determines whether the former is sufficient for
+   authorization.
+
+   *AgentROA (draft-nivalto-agentroa-route-authorization), AIIP, and
+   CIRP* define machine-side, per-hop execution and route receipts for
+   agent actions under delegated authority.  Their approval-state or
+   approval-reference fields do not by themselves define the EP ceremony
+   and directory profile.  EP evidence can fill such a reference where
+   that profile is selected, and its delegation constraints share
+   AgentROA's monotonic ("tighten-only") scope-narrowing discipline.
+
+   *The Entity Attestation Token (RFC 9711, RATS)* attests the _agent or
+   platform_ -- model, keys, posture; EP carries evidence of an enrolled
+   approver key's action-bound decision.  The two are orthogonal and
+   composable: an EAT says the machine is what it claims; an EP receipt
+   says a named person approved the exact action.
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 26]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   *Transaction Tokens (draft-ietf-oauth-transaction-tokens)* propagate
+   workload and agent authorization context across a machine call chain;
+   an EP receipt can be one referenced approval artifact when a relying
+   party requires that profile.
+
+   *Evidence Record Syntax (RFC 4998)* preserves signed evidence across
+   algorithm aging by periodic re-timestamping.  EP applies the same
+   approach to long-lived receipts via an evidence-record renewal chain,
+   so a receipt verifiable today remains verifiable after its original
+   algorithms weaken -- a property the 10-25+ year retention schedules
+   of government records require.
+
+12.  Security Considerations
+
+12.1.  Operator Compromise
+
+   Under key classes A/B, a compromised EP operator can deny service and
+   can fail to route signoff requests, and it cannot _forge a
+   signature_: it lacks approver keys, and it cannot replay one (nonces
+   are single-consumption and receipts chain).  Two operator-compromise
+   paths remain and are stated plainly rather than claimed away.  First,
+   an operator that controls the signing client's rendering can harvest
+   a _genuine_ signature over an action the approver misunderstood -- a
+   presentation attack (Section 12.3); for this reason an independently-
+   authored rendering surface is REQUIRED for high-value policies.
+   Second, an operator that unilaterally controls the Approver Directory
+   can enroll keys it controls (Section 5.2, Section 12.6).
+   Accordingly, the accurate claim for classes A/B is: "the operator
+   cannot forge an approver's signature."  The stronger claim -- "the
+   operator cannot obtain an unauthorized approval" -- additionally
+   requires the directory-authority and independent-rendering controls.
+   Under class C the operator can fabricate outright; hence the labeling
+   requirement.
+
+12.2.  Approver Device Compromise
+
+   A stolen authenticator with user verification still requires the
+   biometric/PIN.  Organizations SHOULD require key class A for high-
+   value policies and SHOULD pair approval with out-of-band action
+   rendering (the approver sees the wire details on a second surface).
+
+
+
+
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 27]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+12.3.  Presentation Attacks
+
+   The gravest risk in this protocol, stated without minimization: the
+   approver signs context hash H believing it represents action X when
+   it represents action Y.  A signature proves user presence and an act
+   of approval toward _whatever was rendered_; cryptography cannot prove
+   the rendering was faithful.  Required mitigations, in increasing
+   strength: (1) the signing client MUST render the Action Object from
+   the exact bytes that were hashed -- never from a separately supplied
+   description; (2) for high-value policies, render templates MUST be
+   registered with the policy and committed by policy_hash, so the
+   display logic is part of what the approver's signature covers; (3)
+   for policies above an organization-designated threshold, the material
+   action parameters (amount, beneficiary identifiers) MUST additionally
+   be rendered on a second surface not authored by the orchestrating
+   operator -- for example, delivered by the verifying executor or an
+   independent operator to the approver's enrolled device over a
+   separate channel.  The residual risk is stated honestly: absent a
+   trusted display path (hardware the operator does not author),
+   rendering fidelity is enforced by controls (2)-(3), by audit, and by
+   consented mismatch drills (Section 12.8) -- not by mathematics.  What
+   the cryptography does guarantee is exactness of evidence: the receipt
+   contains the full Action Object actually signed, so any divergence
+   between what was displayed and what was executed is detectable after
+   the fact with proof rather than testimony.
+
+12.4.  Log Equivocation
+
+   A malicious log could show different trees to different parties.
+   Checkpoints SHOULD be witness-cosigned and/or gossiped between
+   independent EP operators; the federation profile makes cross-operator
+   checkpoint exchange mandatory.  Before a witness signs a checkpoint
+   or a gossip participant accepts it for comparison, that participant
+   MUST verify the checkpoint's log signature under the pinned log key
+   and MUST verify any required consistency proof from the participant's
+   previously accepted checkpoint.  A quorum of witness signatures over
+   a caller-supplied but unauthenticated tuple is not evidence that the
+   named log produced that tuple.
+
+   For this purpose, independent operators require separate
+   administrative control, key custody, and failure domains; multiple
+   co-located processes under one operator do not provide independent
+   witnessing.  Comparing supplied authenticated views can prove that
+   the views conflict.  It does not by itself prove freshness,
+   completeness, or that every relying party received the latest
+   checkpoint.
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 28]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+12.5.  What the Formal Models Do and Do Not Prove
+
+   The TLA+/Alloy models prove safety of the authorization state
+   machine: no replay, no self-approval, no bypass _within the modeled
+   system_, no partial commitment.  They prove nothing about any AI
+   model's behavior, about host compromise, or about deployments in a
+   weaker conformance class.  Implementations MUST NOT represent the
+   proofs as covering deployment topologies they do not model.  For the
+   same honesty: three normative mechanisms in this document are
+   specified ahead of the reference implementation and are not yet
+   exercised by it or by conformance vectors -- the operator-signed-
+   directory assurance downgrade (Section 5.2), delegation records in
+   approver_key_proofs and the DelegateCannotExceedPrincipal check
+   (Section 8), and enforcement_class emission (Section 9).
+   Implementers MUST treat the text as normative and the reference
+   implementation as incomplete on these three points, not the reverse.
+   The m-of-n quorum flow IS now modeled: a checked Alloy model (formal/
+   ep_quorum.als in the repository) proves SelfApprovalImpossible,
+   NoHumanFillsTwoSlots, NoKeyFillsTwoSlots, TwoPersonRuleHolds, and
+   ordered-chain acyclicity/linearity against the quorum verifier and
+   its conformance vectors.  The models additionally do not yet cover
+   the WebAuthn challenge binding, the Approver Directory, log
+   checkpoints, or the Initiator Attestation (Section 4.1); those
+   sections are specified, not proven, and extending the models to them
+   is tracked work.
+
+   A separate composed Tamarin model joins signed challenge, CAID, two
+   distinct user-verification-gated approvals, scoped authority under an
+   exact pinned registry view, revocation, receipt-issuer pinning, one-
+   time consumption, and execution in one symbolic trace
+   [FORMAL-STATUS].  Ten named obligations verify, including
+   execution_requires_full_composition, initiator_cannot_self_approve,
+   no_issuer_laundering, strict_registry_view_is_exact, and
+   injective_execution_with_consumption.  Two deliberately unsafe
+   comparison lemmas are falsified with concrete traces: one omits
+   consumption and admits same-receipt replay; the other omits exact
+   registry-view binding and admits a stale or equivocating view.  The
+   model treats signatures as perfect symbolic primitives and does not
+   prove WebAuthn internals, parser correctness, amount arithmetic,
+   policy authorship, clock freshness, transparency-log completeness,
+   collusion resistance, or downstream exactly-once physical effects.
+
+
+
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 29]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   The quorum abstraction in the standalone symbolic model is a fixed
+   2-of-2 instance.  Its checked result is evidence for that instance,
+   not a proof of the arbitrary k-of-n construction defined by the
+   companion EP-QUORUM document and not a proof of production code.  CI
+   regression gating of an existing prover result increases
+   reproducibility; it does not add a lemma or enlarge the model's
+   scope.
+
+   Independent implementation status, stated precisely: the three
+   reference verifiers (JavaScript, Python, Go) agree on the published
+   conformance vectors but live in one repository -- a cross-language
+   consistency check, not independent implementations.  A separately
+   authored Rust verifier was evaluated on 11 July 2026 and passed 16
+   suites and 164 vectors from a hash-pinned bundle [EXTERNAL-RUST-PIN].
+   That result is time-pinned: it does not cover the current larger
+   vector bundle, and the available construction statement predates the
+   evaluated hardening commit.  It is therefore evidence of external
+   implementation and execution for that bundle, not yet strict clean-
+   room construction acceptance for the current specification.
+
+12.6.  Directory Authority
+
+   Section 5 removes the operator from the signature path; Section 5.2
+   must not readmit it as the authority that decides which keys count.
+   If the EP operator alone signs the Approver Directory, a malicious
+   operator can satisfy policy by enrolling a key it controls under a
+   nominally legitimate approver's name.  The controls in Section 5.2
+   (organization-held directory key; second-party attestation on
+   enrollment; Class C-equivalent treatment otherwise) exist for this
+   reason.  Auditors SHOULD verify directory key custody as part of any
+   assessment that relies on receipts.
+
+12.7.  What Separation of Duties Does and Does Not Provide
+
+   SelfApprovalImpossible (Section 6) defeats _unilateral_ self-
+   approval: no initiator can approve its own action, and m-of-n
+   approvers are pairwise distinct identities.  It does not defeat
+   collusion among distinct enrolled humans, one human who controls
+   multiple enrolled identities (an enrollment control -- Section 5.2),
+   or a coerced approver.  Receipts make such events _attributable_ --
+   named, signed, and evidenced -- which raises the cost of insider
+   fraud; they do not make it impossible, and implementations MUST NOT
+   claim otherwise.
+
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 30]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+12.8.  Approver Fatigue
+
+   A gate that humans route around protects nothing; rubber-stamping is
+   the empirical failure mode of every human-in-the-loop control under
+   volume.  This protocol is therefore not a general approval workflow:
+   deployments MUST scope signoff policies to genuinely high-risk, low-
+   frequency actions and SHOULD handle volume with policy (thresholds,
+   allow-lists, velocity rules) rather than human throughput.
+   Operational countermeasures SHOULD include monitoring time-to-sign
+   distributions (signing latencies near the floor indicate approval
+   without review), tracking deny rates (a gate that never denies is
+   either perfectly upstream-filtered or ceremonial), and consented
+   render-mismatch drills that measure whether approvers read what they
+   sign.  Such telemetry is deployment guidance, not protocol; but the
+   protocol's guarantees are only as strong as the attention of the
+   human at its center, and implementations SHOULD say so to their
+   customers.
+
+12.9.  Initiator Attestation as an Attack Surface
+
+   The statement member of an Initiator Attestation (Section 4.1) is
+   attacker-influenceable free text rendered to a human at the moment of
+   decision -- a social-engineering surface aimed at the approver,
+   adjacent to the presentation attacks of Section 12.3.  A compromised
+   or prompt-injected initiator can state any trigger and any reason;
+   injection can change what the initiator _proposes_, including this
+   field, but it cannot change what a human _approves_ on their own
+   hardware, because the device-bound signature (Section 5.1) is outside
+   the model context.  Conforming signing clients MUST therefore render
+   the statement as untrusted content: plain text only, with no markup,
+   links, or control characters rendered; the 280-character cap
+   enforced; and visually distinct styling that labels it as the
+   initiator's unverified claim, clearly separated from the operator-
+   rendered Action Object.  This is consistent with the rendering-
+   faithfulness discipline of Section 12.3: the approver's decision
+   input is the rendered Action Object; the statement is commentary from
+   a party the protocol never trusts.  A related residual vector is
+   divide-and-misinform: because each approver signs their own context,
+   a malicious orchestrator can show different approvers of an m-of-n
+   receipt different attestations, and every individual signature
+   remains valid.  The cross-context consistency rule (Section 4.1)
+   exists for this; verifiers implementing the member MUST flag
+   violations, but on verifiers that predate the member such a receipt
+   still verifies -- the rule is a conformance check, not a signature
+   property.
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 31]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   Privacy: statements written by an agent mid-task can leak sensitive
+   operational context -- counterparty details, internal findings,
+   fragments of prompts -- into receipts that are long-lived and
+   portable by design.  Deployments SHOULD prefer escalation_trigger
+   plus policy_basis identifiers over free text wherever a rule id
+   captures the reason, SHOULD constrain or template statement
+   generation for regulated data, and MUST apply the same retention and
+   disclosure controls to attestation content as to the rest of the
+   receipt.
+
+   Absence is not evidence: a receipt without an attestation means only
+   that the issuer did not populate it -- not that the initiator judged
+   the action routine, and not that no escalation reasoning occurred.
+   Verifiers and auditors MUST NOT infer anything from the absence of an
+   attestation alone.  (Separately, and unchanged: for an action a
+   policy gates on signoff, the absence of any valid receipt at all
+   remains evidence that the control was bypassed -- that property comes
+   from the gate, not from this member.)
+
+   No trust feedback: policy engines MUST NOT use initiator_attestation
+   content to relax thresholds, skip approvers, or raise any trust
+   score.  The initiator must gain nothing by saying the right words;
+   the attestation is a claim by a party the protocol identifies but
+   never trusts, not proof of its internal state.
+
+12.10.  No symmetric key on the verification trust path
+
+   Every artifact a relying party verifies offline -- the approver
+   signoff (Class A: ES256/P-256), the operator commit and receipt
+   (Ed25519), the log inclusion proof, and the portable revocation
+   statement (Ed25519) -- is bound by an ASYMMETRIC signature whose
+   verifying key the relying party holds independently of the issuer.
+   No step in offline verification relies on a Message Authentication
+   Code, a shared secret, or any symmetric primitive.  This is
+   deliberate and load-bearing: a symmetric construction (for example an
+   HMAC-chained audit log) is verifiable only by a party holding the
+   same secret as the producer, so it does not provide public
+   verification outside that trust domain.  An asymmetric issuer can
+   still sign conflicting histories; witness cosigning or gossip is
+   required to detect that equivocation.  Conforming verifier
+   implementations MUST NOT introduce a symmetric primitive on the
+   verification path; an implementation that does so does not provide
+   EP's public-verifiability property.  (HMAC MAY appear elsewhere in a
+   deployment -- e.g. authenticating an operator's own cron or webhook
+   calls -- provided it is never a link in the chain a third party
+   verifies.)
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 32]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+12.11.  Canonicalization Robustness
+
+   Every signed EP artifact is verified over its canonical JSON form
+   (Section 3, Section 4), so any divergence between two
+   implementations' canonicalization behavior is a signature-
+   verification divergence and therefore a malleability hazard.
+   Implementations MUST reject the known malleability hazard classes,
+   and MUST reject them identically: duplicate object member names
+   (compared after escape decoding), unpaired UTF-16 surrogate escapes,
+   and inputs outside the profile's number and depth bounds (non-integer
+   numbers or integers with magnitude greater than 2^53-1, and container
+   nesting deeper than the profile-pinned bound of 64).  The public EP-
+   CANONICALIZATION-v1 vector suite exercises these classes as raw JSON
+   texts, with pinned SHA-256 digests over the canonical bytes of every
+   accepted input, across the cross-language reference verifiers;
+   divergence from the pinned results is a conformance defect, not an
+   implementation choice.  (In the reference stack the duplicate-name,
+   surrogate, and depth gates are applied at the parse boundary by the
+   conformance runners, since the verifier packages receive already-
+   parsed values; the profile predicate, canonical serialization, and
+   digests exercise the verifier packages themselves.)
+
+13.  IANA Considerations
+
+   This document has no IANA actions.  The extension-name registry in
+   Section 7.1 is provisional and document-local.  A future version may
+   request an IANA registry and may register the application/ep-
+   receipt+json media type.
+
+14.  Normative References
+
+   [CIBA]     OpenID Foundation, "OpenID Connect Client-Initiated
+              Backchannel Authentication Flow - Core 1.0", September
+              2021, <https://openid.net/specs/openid-client-initiated-
+              backchannel-authentication-core-1_0.html>.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 33]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   [RFC8785]  Rundgren, A., Jordan, B., and S. Erdtman, "JSON
+              Canonicalization Scheme (JCS)", RFC 8785,
+              DOI 10.17487/RFC8785, June 2020,
+              <https://www.rfc-editor.org/info/rfc8785>.
+
+   [WEBAUTHN] W3C, "Web Authentication: An API for accessing Public Key
+              Credentials, Level 2", April 2021,
+              <https://www.w3.org/TR/webauthn-2/>.
+
+15.  Informative References
+
+   [AUTHZEN-AARP]
+              OpenID Foundation, "AuthZEN Access Request and Approval
+              Profile - Draft 1", July 2026,
+              <https://openid.github.io/authzen/authzen-access-request-
+              approval-profile-1_0.html>.
+
+   [EP-BOUNDED-CAP]
+              Schrock, I., "Bounded Capability Receipts and Durable
+              Spend Control for Agent Actions", Work in Progress,
+              Internet-Draft, draft-schrock-ep-bounded-capability-
+              receipts-00, July 2026, <https://datatracker.ietf.org/doc/
+              draft-schrock-ep-bounded-capability-receipts/>.
+
+   [EP-CAID]  Schrock, I., "The Canonical Action Identifier (CAID)",
+              Work in Progress, Internet-Draft, draft-schrock-canonical-
+              action-identifier-01, July 2026,
+              <https://datatracker.ietf.org/doc/draft-schrock-canonical-
+              action-identifier/>.
+
+   [EP-QUORUM]
+              Schrock, I., "Multi-Party Quorum Authorization for High-
+              Risk Agent Actions (EP-QUORUM)", Work in Progress,
+              Internet-Draft, draft-schrock-ep-quorum-03, July 2026,
+              <https://datatracker.ietf.org/doc/draft-schrock-ep-
+              quorum/>.
+
+   [EXTERNAL-RUST-PIN]
+              EMILIA Protocol, "Time-Pinned External Rust Verifier
+              Evaluation Record", 11 July 2026,
+              <https://github.com/emiliaprotocol/emilia-
+              protocol/blob/main/conformance/external/rust-cleanroom-
+              jdieselny.v1.json>.
+
+   [FIDO-VI]  FIDO Alliance, "Building the Trust Layer for Agentic
+              Payments with AP2 and Verifiable Intent", 26 May 2026,
+              <https://fidoalliance.org/building-the-trust-layer-for-
+              agentic-payments-with-ap2-and-verifiable-intent/>.
+
+
+
+Schrock                  Expires 4 February 2027               [Page 34]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   [FORMAL-STATUS]
+              EMILIA Protocol, "EMILIA Formal Proof Status and Scope",
+              10 July 2026, <https://github.com/emiliaprotocol/emilia-
+              protocol/blob/main/formal/PROOF_STATUS.md>.
+
+   [I-D.klrc-aiagent-auth]
+              Kasselman, P., Lombardo, J., Rosomakho, Y., Campbell, B.,
+              Steele, N., and A. Parecki, "AI Agent Authentication and
+              Authorization", Work in Progress, Internet-Draft, draft-
+              klrc-aiagent-auth-03, 6 July 2026,
+              <https://datatracker.ietf.org/doc/draft-klrc-aiagent-
+              auth/>.
+
+   [I-D.nelson-agent-delegation-receipts]
+              Nelson, R., "Delegation Receipt Protocol for AI Agent
+              Authorization", Work in Progress, Internet-Draft, draft-
+              nelson-agent-delegation-receipts-10, 13 June 2026,
+              <https://datatracker.ietf.org/doc/draft-nelson-agent-
+              delegation-receipts/>.
+
+Appendix A.  Changes since -08
+
+   *  Changed the intended status from Informational to Standards Track;
+      the wire format, canonicalization, signature inputs, and
+      consumption rules are unchanged.
+
+   *  Clarified composition with the authorization-server, human-in-the-
+      loop, transaction-token, and audit requirements in
+      [I-D.klrc-aiagent-auth] without treating confirmation evidence as
+      authorization.
+
+Appendix B.  Changes since -07
+
+   *  Added the separate EP-RECEIPT-EXTENSIONS-v1 companion envelope, a
+      bind-by-digest procedure, and a provisional extension namespace
+      and registry design.  The base Trust Receipt schema, parser,
+      canonical bytes, signature inputs, consumption rules, and log-
+      proof verification remain unchanged; a base verifier never strips
+      or ignores a new receipt member.
+
+   *  Defined one common base action, base receipt, operation, and
+      consequence seam for companion artifacts.
+
+
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 35]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+   *  Added informative, non-exhaustive lifecycle examples including
+      revocation, outcome binding, action remedy, evidence challenge,
+      Authorization Evidence Chain composition, Authority Program stage
+      receipts, and staged DTC settlement binding.  No implementation,
+      deployment, or standards-adoption claim is made for an example
+      merely because it is named here.
+
+Appendix C.  Changes since -06
+
+   *  Narrowed the abstract and introduction from category-wide novelty
+      claims to the guarantees of the selected EP verification profile.
+
+   *  Scoped ConsumeOnce to one conforming shared atomic consumption
+      domain and stated that offline evidence cannot prove global non-
+      replay across independent executors.
+
+   *  Replaced legal non-repudiation language with cryptographic
+      attribution, tamper evidence, and public verifiability; stated the
+      issuer-equivocation boundary.
+
+   *  Added reference entries for the Canonical Action Identifier and EP
+      Quorum companion documents, previously used as terms of art
+      without citations, and a grouped companion-family paragraph in
+      Relationship to Other Work.
+
+   *  Added the CAID Action-Mapping composition boundary without
+      changing the EP v1 signature input.
+
+   *  Added Mastercard Verifiable Intent and AuthZEN AARP as adjacent,
+      composable work.
+
+   *  Clarified that a receipt can authorize and be consumed for
+      capability issuance, but cannot be reused as per-operation
+      approval; the capability protocol binds the full issuance-receipt
+      digest.
+
+Appendix D.  Changes since -04
+
+   -05 adds the human-authorization-receipt composition frame for the
+   SCITT agent-action statement cluster (how a WHO receipt is
+   referenced, by digest, from capsule/record-style statements); updates
+   the SCITT citation to RFC 9943; adds the key-custody disambiguation
+   note in Section 5.1 (key classes classify custody, not assurance
+   levels); corrects the formal-models status (the m-of-n quorum flow is
+   now Alloy-checked) and states plainly which three normative
+   mechanisms the reference implementation does not yet cover.
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 36]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+Appendix E.  Changes since -00 (through -04)
+
+   This summary covers -00 through -04.  Section numbering is stable;
+   all changes are new subsections or in-place additions.
+
+   1.  New OPTIONAL Authorization Context member initiator_attestation
+       (new Section 4.1): a REQUIRED escalation_trigger enum
+       (irreversibility, magnitude, uncertainty, novelty, authority_gap,
+       policy_rule), an OPTIONAL policy_basis rule identifier, and an
+       OPTIONAL length-capped (<= 280 character) statement.  The member
+       is OPTIONAL; it is covered by the context hash via the JCS
+       canonicalization already normative in Section 4, so the
+       approver's signature covers the stated reason; receipts carrying
+       it verify under the existing Section 6.3 verifiers unmodified;
+       and it is a claim by the initiator -- identified but never
+       trusted -- not proof of the initiator's internal state.  A
+       terminology entry and a step-2 note in Section 6.3 were added
+       accordingly.
+
+   2.  Security Considerations additions (new Section 12.9): the
+       statement is attacker-influenceable text presented to a human
+       (prompt-injection -> social-engineering surface); conforming
+       signing clients MUST render it as untrusted content (no markup,
+       length cap, distinct styling), consistent with the Section 12.3
+       rendering-faithfulness caveat.  Adds privacy guidance for free-
+       text statements in long-lived receipts (prefer policy_basis
+       identifiers), the rule that absence of an attestation is not
+       evidence of non-escalation, the cross-context consistency
+       requirement, and the prohibition on using attestation content as
+       a trust input.  The formal-models section now lists the Initiator
+       Attestation among the not-yet-modeled areas.
+
+   3.  Introduction/terminology clarifications (new text in the
+       Introduction, new Section 1.2, and a sentence in Section 5.1 and
+       Section 5.2): makes unmistakable that (a) EP's user-verification-
+       gated Class-A signoff is native to this draft and does not depend
+       on any other draft's acquiescence/confirmation mechanism, and (b)
+       proof of a specific natural-person identity is out of scope --
+       the Approver Directory trust root is the explicit slot where
+       identity/key-discovery layers bind keys to named persons.
+
+   4.  New OPTIONAL Authorization Context member agent_binding (new
+       Section 4.2): an external agent-identity reference (agent_id) and
+       an OPTIONAL delegation (scheme, ref, OPTIONAL hash, OPTIONAL
+       observed_at), plus an OPTIONAL length-capped (<= 280 character)
+       statement.  Like initiator_attestation, it is OPTIONAL, covered
+       by the context hash via the JCS canonicalization already
+       normative in Section 4, verifies under the existing Section 6.3
+
+
+
+Schrock                  Expires 4 February 2027               [Page 37]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
+       verifiers unmodified, and is a claim -- identified but never
+       trusted -- not proof of the agent's identity or the delegation's
+       validity.  The OPTIONAL delegation.observed_at records when the
+       upstream identity/delegation (L4) evidence was observed; a
+       relying party MAY enforce freshness against it fail-closed,
+       keeping the receipt agnostic to which external identity scheme
+       prevails while making a stale or unconstrained upstream claim
+       detectable after the fact.
+
+   5.  Housekeeping: version and date bumped in the header; this
+       appendix added; the idnits non-ASCII em-dash / curly-quote
+       cleanup from -00 carried forward as a build step.
+
+Author's Address
+
+   Iman Schrock
+   EMILIA Protocol, Inc.
+   United States of America
+   Email: team@emiliaprotocol.ai
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 38]

--- a/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/RENDERS/draft-schrock-ep-authorization-receipts-09.txt
+++ b/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/RENDERS/draft-schrock-ep-authorization-receipts-09.txt
@@ -120,24 +120,24 @@ Internet-Draft          EP Authorization Receipts            August 2026
    12. Security Considerations . . . . . . . . . . . . . . . . . . .  27
      12.1.  Operator Compromise  . . . . . . . . . . . . . . . . . .  27
      12.2.  Approver Device Compromise . . . . . . . . . . . . . . .  27
-     12.3.  Presentation Attacks . . . . . . . . . . . . . . . . . .  28
+     12.3.  Presentation Attacks . . . . . . . . . . . . . . . . . .  27
      12.4.  Log Equivocation . . . . . . . . . . . . . . . . . . . .  28
-     12.5.  What the Formal Models Do and Do Not Prove . . . . . . .  29
+     12.5.  What the Formal Models Do and Do Not Prove . . . . . . .  28
      12.6.  Directory Authority  . . . . . . . . . . . . . . . . . .  30
      12.7.  What Separation of Duties Does and Does Not Provide  . .  30
-     12.8.  Approver Fatigue . . . . . . . . . . . . . . . . . . . .  31
+     12.8.  Approver Fatigue . . . . . . . . . . . . . . . . . . . .  30
      12.9.  Initiator Attestation as an Attack Surface . . . . . . .  31
      12.10. No symmetric key on the verification trust path  . . . .  32
-     12.11. Canonicalization Robustness  . . . . . . . . . . . . . .  33
+     12.11. Canonicalization Robustness  . . . . . . . . . . . . . .  32
    13. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  33
    14. Normative References  . . . . . . . . . . . . . . . . . . . .  33
-   15. Informative References  . . . . . . . . . . . . . . . . . . .  34
-   Appendix A.  Changes since -08  . . . . . . . . . . . . . . . . .  35
+   15. Informative References  . . . . . . . . . . . . . . . . . . .  33
+   Appendix A.  Changes since -08  . . . . . . . . . . . . . . . . .  34
    Appendix B.  Changes since -07  . . . . . . . . . . . . . . . . .  35
-   Appendix C.  Changes since -06  . . . . . . . . . . . . . . . . .  36
+   Appendix C.  Changes since -06  . . . . . . . . . . . . . . . . .  35
    Appendix D.  Changes since -04  . . . . . . . . . . . . . . . . .  36
-   Appendix E.  Changes since -00 (through -04)  . . . . . . . . . .  37
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  38
+   Appendix E.  Changes since -00 (through -04)  . . . . . . . . . .  36
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  37
 
 1.  Introduction
 
@@ -418,11 +418,11 @@ Internet-Draft          EP Authorization Receipts            August 2026
    The action hash is this receipt format's native integrity identifier.
    It is not assumed to equal an action digest from a different
    protocol.  A composition layer MAY project the verified Action Object
-   into a Canonical Action IDentifier action type ([EP-CAID]) using an
-   exact mapping profile pinned by the relying party.  Such mapping
-   occurs only after receipt verification and does not change this
-   document's signature input.  A failed, lossy, or unpinned mapping is
-   indeterminate and MUST NOT be treated as an action match.
+   into a Canonical Action IDentifier action type as defined by CAID
+   [EP-CAID] using an exact mapping profile pinned by the relying party.
+   Such mapping occurs only after receipt verification and does not
+   change this document's signature input.  A failed, lossy, or unpinned
+   mapping is indeterminate and MUST NOT be treated as an action match.
 
 4.  The Authorization Context
 
@@ -1333,11 +1333,11 @@ Internet-Draft          EP Authorization Receipts            August 2026
    is issued, verified, and consumed under this specification alone.  A
    family of separately published companion documents composes with it
    without altering its semantics, grouped by function: action identity
-   and comparison across independently issued artifacts ([EP-CAID]);
-   multi-approver policies ([EP-QUORUM]) and display binding;
-   enforcement-side ordering and bounded multi-action execution
-   (including [EP-BOUNDED-CAP]); post-execution outcome observation,
-   revocation statements, and compensating remedies; and evidence
+   and comparison across independently issued artifacts as defined by
+   CAID [EP-CAID]; multi-approver policies as defined by EP-QUORUM
+   [EP-QUORUM] and display binding; enforcement-side ordering and
+   bounded multi-action execution (including [EP-BOUNDED-CAP]); post-
+   execution outcome observation, revocation statements, and
 
 
 
@@ -1346,9 +1346,10 @@ Schrock                  Expires 4 February 2027               [Page 24]
 Internet-Draft          EP Authorization Receipts            August 2026
 
 
-   composition, challenge, and reliance records.  Each companion
-   consumes this document's digests or supplies relying-party trust
-   inputs; none is required for conformance to this document.
+   compensating remedies; and evidence composition, challenge, and
+   reliance records.  Each companion consumes this document's digests or
+   supplies relying-party trust inputs; none is required for conformance
+   to this document.
 
    *DRP* ([I-D.nelson-agent-delegation-receipts]) binds a _user's_
    delegation to an _operator's_ instructions -- upstream consumer
@@ -1388,12 +1389,11 @@ Internet-Draft          EP Authorization Receipts            August 2026
    carry the Authorization Context or Trust Receipt digest in
    transaction context without redefining transaction-token semantics.
 
-
-
-
-
-
-
+   *Mastercard Verifiable Intent* [FIDO-VI], co-developed with Google
+   and contributed to the FIDO Alliance, describes portable, verifiable
+   evidence of user intent.  The cited page describes a contribution and
+   prospective standardization, not a final FIDO specification.  EP does
+   not claim portable human evidence is absent.  Its receipt profile
 
 
 
@@ -1402,11 +1402,6 @@ Schrock                  Expires 4 February 2027               [Page 25]
 Internet-Draft          EP Authorization Receipts            August 2026
 
 
-   *Mastercard Verifiable Intent* [FIDO-VI], co-developed with Google
-   and contributed to the FIDO Alliance, describes portable, verifiable
-   evidence of user intent.  The cited page describes a contribution and
-   prospective standardization, not a final FIDO specification.  EP does
-   not claim portable human evidence is absent.  Its receipt profile
    separately specifies an enrolled organizational approver directory,
    exact Authorization Context, initiator exclusion, terminal
    consumption record, and optional distinct-human quorum.
@@ -1450,6 +1445,11 @@ Internet-Draft          EP Authorization Receipts            August 2026
    composable: an EAT says the machine is what it claims; an EP receipt
    says a named person approved the exact action.
 
+   *Transaction Tokens (draft-ietf-oauth-transaction-tokens)* propagate
+   workload and agent authorization context across a machine call chain;
+   an EP receipt can be one referenced approval artifact when a relying
+   party requires that profile.
+
 
 
 
@@ -1457,11 +1457,6 @@ Schrock                  Expires 4 February 2027               [Page 26]
 
 Internet-Draft          EP Authorization Receipts            August 2026
 
-
-   *Transaction Tokens (draft-ietf-oauth-transaction-tokens)* propagate
-   workload and agent authorization context across a machine call chain;
-   an EP receipt can be one referenced approval artifact when a relying
-   party requires that profile.
 
    *Evidence Record Syntax (RFC 4998)* preserves signed evidence across
    algorithm aging by periodic re-timestamping.  EP applies the same
@@ -1499,21 +1494,6 @@ Internet-Draft          EP Authorization Receipts            August 2026
    value policies and SHOULD pair approval with out-of-band action
    rendering (the approver sees the wire details on a second surface).
 
-
-
-
-
-
-
-
-
-
-
-Schrock                  Expires 4 February 2027               [Page 27]
-
-Internet-Draft          EP Authorization Receipts            August 2026
-
-
 12.3.  Presentation Attacks
 
    The gravest risk in this protocol, stated without minimization: the
@@ -1526,6 +1506,14 @@ Internet-Draft          EP Authorization Receipts            August 2026
    description; (2) for high-value policies, render templates MUST be
    registered with the policy and committed by policy_hash, so the
    display logic is part of what the approver's signature covers; (3)
+
+
+
+Schrock                  Expires 4 February 2027               [Page 27]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
    for policies above an organization-designated threshold, the material
    action parameters (amount, beneficiary identifiers) MUST additionally
    be rendered on a second surface not authored by the orchestrating
@@ -1561,15 +1549,6 @@ Internet-Draft          EP Authorization Receipts            August 2026
    completeness, or that every relying party received the latest
    checkpoint.
 
-
-
-
-
-Schrock                  Expires 4 February 2027               [Page 28]
-
-Internet-Draft          EP Authorization Receipts            August 2026
-
-
 12.5.  What the Formal Models Do and Do Not Prove
 
    The TLA+/Alloy models prove safety of the authorization state
@@ -1583,6 +1562,14 @@ Internet-Draft          EP Authorization Receipts            August 2026
    exercised by it or by conformance vectors -- the operator-signed-
    directory assurance downgrade (Section 5.2), delegation records in
    approver_key_proofs and the DelegateCannotExceedPrincipal check
+
+
+
+Schrock                  Expires 4 February 2027               [Page 28]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
    (Section 8), and enforcement_class emission (Section 9).
    Implementers MUST treat the text as normative and the reference
    implementation as incomplete on these three points, not the reverse.
@@ -1612,20 +1599,6 @@ Internet-Draft          EP Authorization Receipts            August 2026
    policy authorship, clock freshness, transparency-log completeness,
    collusion resistance, or downstream exactly-once physical effects.
 
-
-
-
-
-
-
-
-
-
-Schrock                  Expires 4 February 2027               [Page 29]
-
-Internet-Draft          EP Authorization Receipts            August 2026
-
-
    The quorum abstraction in the standalone symbolic model is a fixed
    2-of-2 instance.  Its checked result is evidence for that instance,
    not a proof of the arbitrary k-of-n construction defined by the
@@ -1645,6 +1618,13 @@ Internet-Draft          EP Authorization Receipts            August 2026
    evaluated hardening commit.  It is therefore evidence of external
    implementation and execution for that bundle, not yet strict clean-
    room construction acceptance for the current specification.
+
+
+
+Schrock                  Expires 4 February 2027               [Page 29]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
 
 12.6.  Directory Authority
 
@@ -1670,18 +1650,6 @@ Internet-Draft          EP Authorization Receipts            August 2026
    fraud; they do not make it impossible, and implementations MUST NOT
    claim otherwise.
 
-
-
-
-
-
-
-
-Schrock                  Expires 4 February 2027               [Page 30]
-
-Internet-Draft          EP Authorization Receipts            August 2026
-
-
 12.8.  Approver Fatigue
 
    A gate that humans route around protects nothing; rubber-stamping is
@@ -1699,6 +1667,20 @@ Internet-Draft          EP Authorization Receipts            August 2026
    protocol's guarantees are only as strong as the attention of the
    human at its center, and implementations SHOULD say so to their
    customers.
+
+
+
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 30]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
 
 12.9.  Initiator Attestation as an Attack Surface
 
@@ -1728,16 +1710,6 @@ Internet-Draft          EP Authorization Receipts            August 2026
    still verifies -- the rule is a conformance check, not a signature
    property.
 
-
-
-
-
-
-Schrock                  Expires 4 February 2027               [Page 31]
-
-Internet-Draft          EP Authorization Receipts            August 2026
-
-
    Privacy: statements written by an agent mid-task can leak sensitive
    operational context -- counterparty details, internal findings,
    fragments of prompts -- into receipts that are long-lived and
@@ -1756,6 +1728,15 @@ Internet-Draft          EP Authorization Receipts            August 2026
    policy gates on signoff, the absence of any valid receipt at all
    remains evidence that the control was bypassed -- that property comes
    from the gate, not from this member.)
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 31]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
 
    No trust feedback: policy engines MUST NOT use initiator_attestation
    content to relax thresholds, skip approvers, or raise any trust
@@ -1785,15 +1766,6 @@ Internet-Draft          EP Authorization Receipts            August 2026
    calls -- provided it is never a link in the chain a third party
    verifies.)
 
-
-
-
-
-Schrock                  Expires 4 February 2027               [Page 32]
-
-Internet-Draft          EP Authorization Receipts            August 2026
-
-
 12.11.  Canonicalization Robustness
 
    Every signed EP artifact is verified over its canonical JSON form
@@ -1814,6 +1786,14 @@ Internet-Draft          EP Authorization Receipts            August 2026
    surrogate, and depth gates are applied at the parse boundary by the
    conformance runners, since the verifier packages receive already-
    parsed values; the profile predicate, canonical serialization, and
+
+
+
+Schrock                  Expires 4 February 2027               [Page 32]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
    digests exercise the verifier packages themselves.)
 
 13.  IANA Considerations
@@ -1839,17 +1819,6 @@ Internet-Draft          EP Authorization Receipts            August 2026
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
-
-
-
-
-
-
-Schrock                  Expires 4 February 2027               [Page 33]
-
-Internet-Draft          EP Authorization Receipts            August 2026
-
-
    [RFC8785]  Rundgren, A., Jordan, B., and S. Erdtman, "JSON
               Canonicalization Scheme (JCS)", RFC 8785,
               DOI 10.17487/RFC8785, June 2020,
@@ -1873,6 +1842,13 @@ Internet-Draft          EP Authorization Receipts            August 2026
               Internet-Draft, draft-schrock-ep-bounded-capability-
               receipts-00, July 2026, <https://datatracker.ietf.org/doc/
               draft-schrock-ep-bounded-capability-receipts/>.
+
+
+
+Schrock                  Expires 4 February 2027               [Page 33]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
 
    [EP-CAID]  Schrock, I., "The Canonical Action Identifier (CAID)",
               Work in Progress, Internet-Draft, draft-schrock-canonical-
@@ -1899,13 +1875,6 @@ Internet-Draft          EP Authorization Receipts            August 2026
               <https://fidoalliance.org/building-the-trust-layer-for-
               agentic-payments-with-ap2-and-verifiable-intent/>.
 
-
-
-Schrock                  Expires 4 February 2027               [Page 34]
-
-Internet-Draft          EP Authorization Receipts            August 2026
-
-
    [FORMAL-STATUS]
               EMILIA Protocol, "EMILIA Formal Proof Status and Scope",
               10 July 2026, <https://github.com/emiliaprotocol/emilia-
@@ -1928,6 +1897,15 @@ Internet-Draft          EP Authorization Receipts            August 2026
 
 Appendix A.  Changes since -08
 
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 34]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
    *  Changed the intended status from Informational to Standards Track;
       the wire format, canonicalization, signature inputs, and
       consumption rules are unchanged.
@@ -1948,19 +1926,6 @@ Appendix B.  Changes since -07
 
    *  Defined one common base action, base receipt, operation, and
       consequence seam for companion artifacts.
-
-
-
-
-
-
-
-
-
-Schrock                  Expires 4 February 2027               [Page 35]
-
-Internet-Draft          EP Authorization Receipts            August 2026
-
 
    *  Added informative, non-exhaustive lifecycle examples including
       revocation, outcome binding, action remedy, evidence challenge,
@@ -1990,6 +1955,13 @@ Appendix C.  Changes since -06
    *  Added the CAID Action-Mapping composition boundary without
       changing the EP v1 signature input.
 
+
+
+Schrock                  Expires 4 February 2027               [Page 35]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
+
    *  Added Mastercard Verifiable Intent and AuthZEN AARP as adjacent,
       composable work.
 
@@ -2009,15 +1981,6 @@ Appendix D.  Changes since -04
    now Alloy-checked) and states plainly which three normative
    mechanisms the reference implementation does not yet cover.
 
-
-
-
-
-Schrock                  Expires 4 February 2027               [Page 36]
-
-Internet-Draft          EP Authorization Receipts            August 2026
-
-
 Appendix E.  Changes since -00 (through -04)
 
    This summary covers -00 through -04.  Section numbering is stable;
@@ -2036,6 +1999,24 @@ Appendix E.  Changes since -00 (through -04)
        trusted -- not proof of the initiator's internal state.  A
        terminology entry and a step-2 note in Section 6.3 were added
        accordingly.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schrock                  Expires 4 February 2027               [Page 36]
+
+Internet-Draft          EP Authorization Receipts            August 2026
+
 
    2.  Security Considerations additions (new Section 12.9): the
        statement is attacker-influenceable text presented to a human
@@ -2066,14 +2047,6 @@ Appendix E.  Changes since -00 (through -04)
        statement.  Like initiator_attestation, it is OPTIONAL, covered
        by the context hash via the JCS canonicalization already
        normative in Section 4, verifies under the existing Section 6.3
-
-
-
-Schrock                  Expires 4 February 2027               [Page 37]
-
-Internet-Draft          EP Authorization Receipts            August 2026
-
-
        verifiers unmodified, and is a claim -- identified but never
        trusted -- not proof of the agent's identity or the delegation's
        validity.  The OPTIONAL delegation.observed_at records when the
@@ -2096,33 +2069,4 @@ Author's Address
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Schrock                  Expires 4 February 2027               [Page 38]
+Schrock                  Expires 4 February 2027               [Page 37]

--- a/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/SHA256SUMS.txt
+++ b/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/SHA256SUMS.txt
@@ -1,0 +1,3 @@
+c144f185861b3cf3e9fe99a79314c9c153f629c91e621416e07046b0ad234b46  UPLOAD-THIS/draft-schrock-ep-authorization-receipts-09.xml
+5dadcefdb1771be209a03972fd0a9d07adee9b9b591ae715bb821278a340b132  RENDERS/draft-schrock-ep-authorization-receipts-09.html
+e1baa9a07609f3337a0e7823231cf84ac4a2c203c89f3b1b41bbd0ae7fb3bf43  RENDERS/draft-schrock-ep-authorization-receipts-09.txt

--- a/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/SHA256SUMS.txt
+++ b/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/SHA256SUMS.txt
@@ -1,3 +1,3 @@
-c144f185861b3cf3e9fe99a79314c9c153f629c91e621416e07046b0ad234b46  UPLOAD-THIS/draft-schrock-ep-authorization-receipts-09.xml
+c4d430e4257fc6ff8a77d7eb8b6a40de3a3159f6eefa83f7df439ebbe42008b9  UPLOAD-THIS/draft-schrock-ep-authorization-receipts-09.xml
 5dadcefdb1771be209a03972fd0a9d07adee9b9b591ae715bb821278a340b132  RENDERS/draft-schrock-ep-authorization-receipts-09.html
 e1baa9a07609f3337a0e7823231cf84ac4a2c203c89f3b1b41bbd0ae7fb3bf43  RENDERS/draft-schrock-ep-authorization-receipts-09.txt

--- a/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/UPLOAD-THIS/draft-schrock-ep-authorization-receipts-09.xml
+++ b/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/UPLOAD-THIS/draft-schrock-ep-authorization-receipts-09.xml
@@ -279,7 +279,8 @@
       <t>The action hash is this receipt format's native integrity
       identifier. It is not assumed to equal an action digest from a
       different protocol. A composition layer MAY project the verified
-      Action Object into a Canonical Action IDentifier action type using
+      Action Object into a Canonical Action IDentifier action type
+      (<xref target="EP-CAID"/>) using
       an exact mapping profile pinned by the relying party. Such mapping
       occurs only after receipt verification and does not change this
       document's signature input. A failed, lossy, or unpinned mapping is
@@ -1071,6 +1072,20 @@ REQUESTED -> {PARTIALLY_APPROVED}* -> APPROVED -> COMMITTED
     </section>
     <section anchor="related-work">
       <name>Relationship to Other Work</name>
+      <t><strong>Companion EP documents.</strong> This document is
+      self-contained: a receipt is issued, verified, and consumed under
+      this specification alone. A family of separately published
+      companion documents composes with it without altering its
+      semantics, grouped by function: action identity and comparison
+      across independently issued artifacts (<xref target="EP-CAID"/>);
+      multi-approver policies (<xref target="EP-QUORUM"/>) and display
+      binding; enforcement-side ordering and bounded multi-action
+      execution (including <xref target="EP-BOUNDED-CAP"/>);
+      post-execution outcome observation, revocation statements, and
+      compensating remedies; and evidence composition, challenge, and
+      reliance records. Each companion consumes this document's digests
+      or supplies relying-party trust inputs; none is required for
+      conformance to this document.</t>
       <t><strong>DRP</strong>
       (<xref target="I-D.nelson-agent-delegation-receipts"/>) binds a
       <em>user's</em> delegation to an <em>operator's</em> instructions --
@@ -1089,7 +1104,8 @@ REQUESTED -> {PARTIALLY_APPROVED}* -> APPROVED -> COMMITTED
       holder proof, and validity interval; its shared reserve/commit store
       accounts later operations. A deployment that requires human approval of
       an individual exercise obtains a new action-bound EP receipt or
-      EP-QUORUM for that exercise.</t>
+      a quorum receipt set (<xref target="EP-QUORUM"/>) for that
+      exercise.</t>
       <t><strong>CIBA</strong> <xref target="CIBA"/> transports an
       authentication-time approval to a backchannel device; it does not
       produce an action-bound, offline-verifiable, one-time-consumable
@@ -1540,6 +1556,22 @@ REQUESTED -> {PARTIALLY_APPROVED}* -> APPROVED -> COMMITTED
         </front>
         <seriesInfo name="Internet-Draft" value="draft-schrock-ep-bounded-capability-receipts-00"/>
       </reference>
+      <reference anchor="EP-CAID" target="https://datatracker.ietf.org/doc/draft-schrock-canonical-action-identifier/">
+        <front>
+          <title>The Canonical Action Identifier (CAID)</title>
+          <author fullname="Iman Schrock"/>
+          <date year="2026" month="July"/>
+        </front>
+        <seriesInfo name="Internet-Draft" value="draft-schrock-canonical-action-identifier-01"/>
+      </reference>
+      <reference anchor="EP-QUORUM" target="https://datatracker.ietf.org/doc/draft-schrock-ep-quorum/">
+        <front>
+          <title>Multi-Party Quorum Authorization for High-Risk Agent Actions (EP-QUORUM)</title>
+          <author fullname="Iman Schrock"/>
+          <date year="2026" month="July"/>
+        </front>
+        <seriesInfo name="Internet-Draft" value="draft-schrock-ep-quorum-03"/>
+      </reference>
       <reference anchor="FORMAL-STATUS" target="https://github.com/emiliaprotocol/emilia-protocol/blob/main/formal/PROOF_STATUS.md">
         <front>
           <title>EMILIA Formal Proof Status and Scope</title>
@@ -1598,6 +1630,10 @@ REQUESTED -> {PARTIALLY_APPROVED}* -> APPROVED -> COMMITTED
         <li>Replaced legal non-repudiation language with cryptographic
         attribution, tamper evidence, and public verifiability; stated the
         issuer-equivocation boundary.</li>
+        <li>Added reference entries for the Canonical Action Identifier
+        and EP Quorum companion documents, previously used as terms of
+        art without citations, and a grouped companion-family paragraph
+        in Relationship to Other Work.</li>
         <li>Added the CAID Action-Mapping composition boundary without
         changing the EP v1 signature input.</li>
         <li>Added Mastercard Verifiable Intent and AuthZEN AARP as adjacent,

--- a/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/UPLOAD-THIS/draft-schrock-ep-authorization-receipts-09.xml
+++ b/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/UPLOAD-THIS/draft-schrock-ep-authorization-receipts-09.xml
@@ -280,7 +280,7 @@
       identifier. It is not assumed to equal an action digest from a
       different protocol. A composition layer MAY project the verified
       Action Object into a Canonical Action IDentifier action type
-      (<xref target="EP-CAID"/>) using
+      as defined by CAID <xref target="EP-CAID"/> using
       an exact mapping profile pinned by the relying party. Such mapping
       occurs only after receipt verification and does not change this
       document's signature input. A failed, lossy, or unpinned mapping is
@@ -1077,8 +1077,9 @@ REQUESTED -> {PARTIALLY_APPROVED}* -> APPROVED -> COMMITTED
       this specification alone. A family of separately published
       companion documents composes with it without altering its
       semantics, grouped by function: action identity and comparison
-      across independently issued artifacts (<xref target="EP-CAID"/>);
-      multi-approver policies (<xref target="EP-QUORUM"/>) and display
+      across independently issued artifacts as defined by CAID
+      <xref target="EP-CAID"/>; multi-approver policies as defined by
+      EP-QUORUM <xref target="EP-QUORUM"/> and display
       binding; enforcement-side ordering and bounded multi-action
       execution (including <xref target="EP-BOUNDED-CAP"/>);
       post-execution outcome observation, revocation statements, and

--- a/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/UPLOAD-THIS/draft-schrock-ep-authorization-receipts-09.xml
+++ b/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/UPLOAD-THIS/draft-schrock-ep-authorization-receipts-09.xml
@@ -2,7 +2,7 @@
 <rfc xmlns:xi="http://www.w3.org/2001/XInclude"
      docName="draft-schrock-ep-authorization-receipts-09"
      category="std" ipr="trust200902"
-     submissionType="IETF" version="3" tocInclude="true" sortRefs="true" symRefs="true">
+     version="3" tocInclude="true" sortRefs="true" symRefs="true">
   <front>
     <title abbrev="EP Authorization Receipts">Authorization Receipts for High-Risk Agent Actions</title>
     <seriesInfo name="Internet-Draft" value="draft-schrock-ep-authorization-receipts-09"/>

--- a/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/VALIDATION.md
+++ b/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/VALIDATION.md
@@ -1,0 +1,14 @@
+# Validation record
+
+Validated on 2026-08-03:
+
+- `xml2rfc 3.34.0` generated the TXT and HTML renderings.
+- `idnits 3.1.0 -m submission` reported `PASS - No nit found`.
+- The source renders as `Intended status: Standards Track`.
+- The governed August 3 six-draft packet still passes
+  `node scripts/check-standards-staged.mjs` unchanged.
+- `node scripts/check-authorization-receipts-09.mjs` verifies the isolated
+  source, renderings, metadata, and checksums.
+
+`xml2rfc` emits its expected informational warning that Standards Track IETF
+documents use `consensus="true"`; this is the permitted value for the category.

--- a/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/VALIDATION.md
+++ b/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-09/VALIDATION.md
@@ -3,12 +3,14 @@
 Validated on 2026-08-03:
 
 - `xml2rfc 3.34.0` generated the TXT and HTML renderings.
-- `idnits 3.1.0 -m submission` reported `PASS - No nit found`.
+- `idnits 3.1.0 -m submission` reported `PASS - No nit found` for both
+  the authoritative XML source and the TXT rendering.
 - The source renders as `Intended status: Standards Track`.
 - The governed August 3 six-draft packet still passes
   `node scripts/check-standards-staged.mjs` unchanged.
 - `node scripts/check-authorization-receipts-09.mjs` verifies the isolated
   source, renderings, metadata, and checksums.
 
-`xml2rfc` emits its expected informational warning that Standards Track IETF
-documents use `consensus="true"`; this is the permitted value for the category.
+The draft remains an individual submission and therefore does not assert an
+adopted document stream. `xml2rfc` emits informational stream and consensus
+default warnings; neither changes the rendered Standards Track status.

--- a/standards/staged/UPLOAD-THIS/draft-schrock-ep-authorization-receipts-09.xml
+++ b/standards/staged/UPLOAD-THIS/draft-schrock-ep-authorization-receipts-09.xml
@@ -1,0 +1,1697 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude"
+     docName="draft-schrock-ep-authorization-receipts-09"
+     category="std" ipr="trust200902"
+     submissionType="IETF" version="3" tocInclude="true" sortRefs="true" symRefs="true">
+  <front>
+    <title abbrev="EP Authorization Receipts">Authorization Receipts for High-Risk Agent Actions</title>
+    <seriesInfo name="Internet-Draft" value="draft-schrock-ep-authorization-receipts-09"/>
+    <author fullname="Iman Schrock">
+      <organization>EMILIA Protocol, Inc.</organization>
+      <address>
+        <postal>
+          <country>US</country>
+        </postal>
+        <email>team@emiliaprotocol.ai</email>
+      </address>
+    </author>
+    <date year="2026" month="August" day="3"/>
+    <area>sec</area>
+    <keyword>AI agents</keyword>
+    <keyword>authorization</keyword>
+    <keyword>receipts</keyword>
+    <keyword>WebAuthn</keyword>
+    <keyword>separation of duties</keyword>
+    <abstract>
+      <t>This document defines the EMILIA Protocol (EP) authorization
+      receipt, an evidence artifact binding an enrolled approver key to
+      one canonical action before execution. An approver-held key signs an
+      Authorization Context containing the action hash, policy reference,
+      nonce, audience, and validity window. A Trust Receipt carries the
+      signed contexts, terminal consumption record, and Merkle inclusion
+      material so a relying party can verify the recorded event offline
+      under independently selected log, directory, policy, and approver
+      trust inputs.</t>
+      <t>The receipt establishes only the guarantees of the selected
+      verification profile. The mapping from an enrolled approver
+      identifier to a natural person is asserted by the directory
+      authority. Offline verification does not establish current
+      revocation status, global non-replay, comprehension, legality,
+      safety, or execution. Replay prevention requires an online atomic
+      consumption store at the executor. The state-machine invariants are
+      machine-checked under the assumptions stated in this document.</t>
+      <t>A receipt is evidence, not authorization. This document does not
+      treat a local user interaction as an authorization decision. Section
+      10.7 of <xref target="I-D.klrc-aiagent-auth"/> states that an agent
+      MUST NOT treat local UI confirmation alone as sufficient
+      authorization, and notes that additional specification or design work
+      may be needed for user confirmation occurring mid-execution, since CIBA accounts
+      only for client initiation. This document defines one evidence
+      artifact that an authorization architecture can use in such a flow:
+      the signed Authorization Context is action-bound confirmation evidence
+      an authorization server MAY validate and bind to the grant it issues.
+      The resulting Trust Receipt records terminal consumption and remains
+      evidence; neither object makes the authorization decision. That
+      decision remains with the authorization server.</t>
+    </abstract>
+  </front>
+  <middle>
+    <section>
+      <name>Introduction</name>
+      <t>Agentic AI systems increasingly hold credentials sufficient to
+      perform irreversible operations: releasing payments, modifying
+      beneficiary records, rotating production credentials, deleting
+      data. Session-level authentication and authorization alone answer
+      whether an actor may operate within a scope. A deployment can
+      separately require evidence that an enrolled approver key signed one
+      exact proposed action before execution.</t>
+      <t>Three structural gaps follow:</t>
+      <ol>
+        <li><strong>The action gap.</strong> Identity and access
+        management authorizes <em>sessions and scopes</em>, not
+        individual actions. Fraud that occurs inside a valid session
+        through approved channels (e.g., business email compromise
+        leading to a beneficiary change) is invisible to session-level
+        controls.</li>
+        <li><strong>The accountability gap.</strong> Where human approval
+        exists, it is typically a click in a workflow tool, recorded in a
+        mutable application database controlled by the operator of the
+        approval system. A deployment can instead require portable
+        evidence binding an enrolled approver key to the specific
+        action.</li>
+        <li><strong>The verification gap.</strong> Auditors,
+        counterparties, and regulators may need to evaluate evidence
+        outside the operator that produced it, including after the live
+        service is unavailable or the operators disagree.</li>
+      </ol>
+      <t>This document addresses those deployment requirements with a
+      receipt profile: before an
+      irreversible action executes, an enrolled approver signs the exact
+      action with an approver-held key; an executor records terminal
+      consumption through an atomic state transition; and the resulting
+      receipt remains independently verifiable offline for as long as its
+      algorithms and trust material remain acceptable or are renewed.</t>
+      <t>Adjacent mechanisms answer related but non-identical questions.
+      The distinctions below are profile boundaries, not claims that
+      portable approval or intent evidence exists nowhere else.</t>
+      <ul>
+        <li>OAuth 2.0 with Rich Authorization Requests (RFC 9396) and
+        GNAP (RFC 9635) authorize a client's <em>requested scope</em>;
+        they do not produce a named human's offline-verifiable signature
+        over the exact action that executed.</li>
+        <li>The OAuth Step-Up Authentication Challenge (RFC 9470) can
+        <em>demand</em> fresh human authentication for a sensitive
+        operation, but yields no durable, portable artifact of that
+        approval.</li>
+        <li>Transaction Tokens (draft-ietf-oauth-transaction-tokens)
+        propagate call context across workloads within a trust domain;
+        they are short-lived, online-validated, and assert
+        <em>workload</em> identity, not a human's authorization of an
+        action.</li>
+        <li>The Security Event Token (RFC 8417) and CAEP convey, as
+        issuer assertions, that an event <em>occurred</em>; they are not
+        a human's pre-execution approval bound to one exact action.</li>
+        <li>RATS (RFC 9334) and the Entity Attestation Token (RFC 9711)
+        attest the trustworthiness of a <em>platform or workload</em>,
+        not that a named human authorized an action -- a different trust
+        root.</li>
+        <li>SCITT (RFC 9943) provides an append-only transparency log
+        and inclusion receipts, but is deliberately agnostic about the
+        application semantics and authority behind a statement. An EP
+        receipt can be carried as one such application statement.</li>
+        <li>The agent-action evidence work now emerging around that
+        architecture -- per-action receipt envelopes, action capsules,
+        post-execution profiles, pre-execution permits, and refusal
+        events -- makes agent actions transparent, logged, and
+        policy-checked. Some define approval or intent evidence with
+        different ceremony, identity, freshness, or consumption
+        guarantees.</li>
+      </ul>
+      <t>The use case for this receipt is narrower than agent logging in
+      general: a relying party needs an action-bound approval event under
+      a named verification profile, portable outside the operator, agent
+      runtime, and transparency service. EP is one such artifact and is
+      not a replacement for any of the above: it composes with them
+      (<xref target="related-work"/>) and can be carried in their
+      formats -- for example, an EP receipt expressed as a COSE Signed
+      Statement and logged by a SCITT Transparency Service, or
+      referenced by digest from an action receipt, capsule, or
+      permit.</t>
+      <t>The human-approval mechanism this document specifies -- a
+      user-verification-gated signature over the exact Authorization
+      Context (<xref target="key-classes"/>, Class A) -- is native to EP
+      and self-contained. It does not depend on, and is not a profile of,
+      any other draft's acquiescence, consent, or confirmation mechanism;
+      a conforming EP signoff is produced entirely by the controls defined
+      here. Where EP composes with adjacent work
+      (<xref target="related-work"/>), that composition is by reference,
+      not dependency.</t>
+      <section>
+        <name>Design Goals</name>
+        <ul>
+          <li><strong>G1 -- Action binding.</strong> An approval is
+          cryptographically bound to one exact action. It cannot
+          authorize anything else.</li>
+          <li><strong>G2 -- Approver-held keys.</strong> The approver's
+          signature is produced by a key the EP operator does not
+          possess. The operator orchestrates; it cannot forge.</li>
+          <li><strong>G3 -- One-time consumption.</strong> An
+          authorization reaches a terminal state at most once within the
+          executor's shared atomic consumption domain. Replay presented to
+          that domain <bcp14>MUST</bcp14> be rejected. An offline receipt
+          alone cannot prove that no independent executor consumed the same
+          authorization.</li>
+          <li><strong>G4 -- Separation of duties.</strong> The initiator
+          of an action <bcp14>MUST NOT</bcp14> be an approver of that
+          action. Policies <bcp14>MAY</bcp14> require m-of-n distinct
+          approvers.</li>
+          <li><strong>G5 -- Offline verifiability.</strong> A receipt is
+          verifiable with no network access, using only the receipt, the
+          approver's public key material, and a published log checkpoint.
+          Offline verification establishes authenticity and log inclusion
+          as of commit time, not current revocation status
+          (<xref target="offline-verification"/>).</li>
+          <li><strong>G6 -- Execution-side enforcement.</strong> The
+          strongest deployment places verification at the system of
+          record: the executing service verifies the receipt before
+          performing the action. Middleware-only deployments are
+          explicitly defined as a weaker conformance class
+          (<xref target="conformance"/>).</li>
+          <li><strong>G7 -- Machine-checked safety.</strong> The protocol
+          state machine's safety properties are maintained as formal
+          models (TLA+, Alloy, and Tamarin) and checked in continuous integration.
+          Implementations can be tested against a published conformance
+          suite.</li>
+        </ul>
+      </section>
+      <section anchor="scope-of-identity">
+        <name>Scope of Identity</name>
+        <t>This document binds an approval to an <em>approver
+        identifier</em> whose key is enrolled in the Approver Directory
+        (<xref target="approver-directory"/>); it does not, by itself,
+        prove that the holder of that identifier is a particular natural
+        person. Proof of a specific real-world identity -- that
+        <tt>ep:approver:jchen-controller</tt> is the human Jordan Chen --
+        is out of scope. The Approver Directory trust root
+        (<xref target="approver-directory"/>) is the explicit slot where
+        an identity-proofing or key-discovery layer binds keys to named
+        persons; the strength of any such binding is a property of that
+        layer, not of the receipt format. A receipt proves that a key
+        enrolled under a given approver identifier signed the exact
+        action; the mapping from identifier to person is established and
+        asserted by the directory authority.</t>
+      </section>
+    </section>
+    <section anchor="terminology">
+      <name>Terminology</name>
+      <t>The key words "<bcp14>MUST</bcp14>", "<bcp14>MUST NOT</bcp14>",
+      "<bcp14>REQUIRED</bcp14>", "<bcp14>SHALL</bcp14>",
+      "<bcp14>SHALL NOT</bcp14>", "<bcp14>SHOULD</bcp14>",
+      "<bcp14>SHOULD NOT</bcp14>", "<bcp14>RECOMMENDED</bcp14>",
+      "<bcp14>NOT RECOMMENDED</bcp14>", "<bcp14>MAY</bcp14>", and
+      "<bcp14>OPTIONAL</bcp14>" in this document are to be interpreted as
+      described in BCP 14 <xref target="RFC2119"/> <xref target="RFC8174"/>
+      when, and only when, they appear in all capitals, as shown here.</t>
+      <t><strong>Initiator.</strong> The entity (typically an AI agent or
+      automated process) that proposes a high-risk action. The initiator
+      is identified but never trusted with approval authority over its
+      own actions.</t>
+      <t><strong>Approver.</strong> A named human (or, for lower
+      assurance classes, an organizational role occupied by a named human
+      at decision time) who holds approval authority under policy. The
+      approver controls a private signing key; see
+      <xref target="approver-keys"/>.</t>
+      <t><strong>Action.</strong> A single proposed operation with
+      concrete parameters (e.g., one wire transfer to one beneficiary for
+      one amount). Actions are represented by an Action Object and
+      identified by their action hash (<xref target="action-object"/>).</t>
+      <t><strong>Policy.</strong> A named, versioned rule set
+      determining, for a class of actions, which approvers are required
+      (including m-of-n thresholds), validity windows, and amount or
+      scope limits.</t>
+      <t><strong>Authorization Context.</strong> The canonical structure
+      an approver signs: action hash, policy reference, initiator
+      identity, nonce, expiry, and chain binding
+      (<xref target="authorization-context"/>).</t>
+      <t><strong>Initiator Attestation.</strong> An
+      <bcp14>OPTIONAL</bcp14> claim by the initiator, carried inside the
+      Authorization Context, stating why the initiator escalated the
+      action to a human (<xref target="initiator-attestation"/>). It is a
+      claim, not proof of the initiator's internal state.</t>
+      <t><strong>Trust Receipt.</strong> The terminal artifact: the
+      Action Object digest, all approver signatures, the consumption
+      record, and a Merkle inclusion proof against a signed log
+      checkpoint (<xref target="consumption"/>).</t>
+      <t><strong>Verifying Executor.</strong> A system of record that
+      verifies a Trust Receipt (or a pre-execution Authorization Bundle)
+      before performing the action. See <xref target="conformance"/>.</t>
+      <t><strong>EP Operator.</strong> The party running the
+      orchestration service (policy registry, signoff routing, log).
+      Under this protocol the operator is <em>not</em> in the signing
+      trust path for approvals (G2).</t>
+    </section>
+    <section anchor="action-object">
+      <name>The Action Object and Action Hash</name>
+      <t>An Action Object is a JSON document with at minimum:</t>
+      <sourcecode type="json"><![CDATA[
+{
+  "ep_version": "1.0",
+  "action_type": "wire.release",
+  "target": { "system": "treasury.example",
+              "resource": "wire/8841" },
+  "parameters": { "amount": "2400000.00", "currency": "USD",
+                  "beneficiary_account_hash": "sha256:..." },
+  "initiator": "ep:entity:agent-recon-7",
+  "policy_id": "ep:policy:wires-over-100k@v12",
+  "requested_at": "2026-06-09T17:21:04Z"
+}
+]]></sourcecode>
+      <t>The Action Object <bcp14>MUST</bcp14> be serialized using JSON
+      Canonicalization Scheme (JCS) <xref target="RFC8785"/>. The
+      <strong>action hash</strong> is the SHA-256 digest of the canonical
+      serialization. Implementations <bcp14>MUST</bcp14> reject approval
+      requests whose action hash does not match a locally recomputed hash
+      of the presented Action Object. Sensitive parameter values
+      <bcp14>MAY</bcp14> be carried as salted hashes (as
+      <tt>beneficiary_account_hash</tt> above) provided the executing
+      system can recompute them; the binding property is preserved
+      because the hash commits to the committed values.</t>
+      <t>The action hash is this receipt format's native integrity
+      identifier. It is not assumed to equal an action digest from a
+      different protocol. A composition layer MAY project the verified
+      Action Object into a Canonical Action IDentifier action type using
+      an exact mapping profile pinned by the relying party. Such mapping
+      occurs only after receipt verification and does not change this
+      document's signature input. A failed, lossy, or unpinned mapping is
+      indeterminate and MUST NOT be treated as an action match.</t>
+    </section>
+    <section anchor="authorization-context">
+      <name>The Authorization Context</name>
+      <t>For each required approver, the orchestrator constructs an
+      Authorization Context:</t>
+      <sourcecode type="json"><![CDATA[
+{
+  "ep_version": "1.0",
+  "context_type": "ep.signoff.v1",
+  "action_hash": "sha256:9f2c...",
+  "policy_id": "ep:policy:wires-over-100k@v12",
+  "policy_hash": "sha256:77ab...",
+  "initiator": "ep:entity:agent-recon-7",
+  "approver": "ep:approver:jchen-controller",
+  "approver_index": 1,
+  "required_approvals": 2,
+  "nonce": "b64u:R9w1...",
+  "issued_at": "2026-06-09T17:21:05Z",
+  "expires_at": "2026-06-09T17:36:05Z",
+  "prev_receipt_hash": "sha256:51d0..."
+}
+]]></sourcecode>
+      <t>Rules:</t>
+      <ul>
+        <li><tt>nonce</tt> <bcp14>MUST</bcp14> be at least 128 bits of
+        CSPRNG output and <bcp14>MUST</bcp14> be unique within the issuer and
+        consumption domain for each authorization attempt. It is the
+        consumption key for G3, and is
+        the receipt's freshness mechanism in the sense of the Entity
+        Attestation Token (RFC 9711): a verifier-relevant nonce, here held
+        to a 128-bit floor (twice the EAT minimum). EP does not treat a
+        timestamp alone as freshness; absolute time, where a relying party
+        requires it, is asserted by an independent authority rather than by
+        the operator.</li>
+        <li><tt>policy_hash</tt> commits to the exact policy version
+        evaluated. A signature over a context with policy_hash X
+        <bcp14>MUST NOT</bcp14> satisfy a requirement evaluated under
+        policy_hash Y, even for the same policy_id.</li>
+        <li><tt>prev_receipt_hash</tt> chains this authorization to the
+        issuing log's most recent receipt, contributing to tamper
+        evidence.</li>
+        <li>The context is JCS-canonicalized; the <strong>context
+        hash</strong> is its SHA-256 digest. The approver signs the
+        context hash.</li>
+        <li>The approver <bcp14>MUST</bcp14> be shown, at signing time, a
+        faithful human-readable rendering of the Action Object -- not only
+        the hash. Signing interfaces that display a different action than
+        the one hashed are a presentation attack; see
+        <xref target="presentation-attacks"/>.</li>
+      </ul>
+      <section anchor="initiator-attestation">
+        <name>Initiator Attestation (OPTIONAL)</name>
+        <t>A producer <bcp14>MAY</bcp14> include an
+        <tt>initiator_attestation</tt> member in any
+        <tt>ep.signoff.v1</tt> Authorization Context. The member carries
+        the initiator's own stated reason for escalating the action to a
+        human. When present it <bcp14>MUST</bcp14> be a JSON object with
+        the following members and no others:</t>
+        <table>
+          <thead>
+            <tr><th>Field</th><th>Required</th><th>Type</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><tt>escalation_trigger</tt></td>
+              <td><bcp14>REQUIRED</bcp14></td>
+              <td>string (enum)</td>
+              <td>Why the initiator escalated. Exactly one of:
+              <tt>irreversibility</tt>, <tt>magnitude</tt>,
+              <tt>uncertainty</tt>, <tt>novelty</tt>,
+              <tt>authority_gap</tt>, <tt>policy_rule</tt>.</td>
+            </tr>
+            <tr>
+              <td><tt>policy_basis</tt></td>
+              <td><bcp14>OPTIONAL</bcp14> (<bcp14>REQUIRED</bcp14>
+              whenever a deterministic policy rule fired, including always
+              when <tt>escalation_trigger</tt> is
+              <tt>policy_rule</tt>)</td>
+              <td>string</td>
+              <td>Identifier of the policy or rule that fired, e.g.
+              <tt>ep:policy:wires-over-100k@v12/rule:dual-auth</tt>.</td>
+            </tr>
+            <tr>
+              <td><tt>statement</tt></td>
+              <td><bcp14>OPTIONAL</bcp14></td>
+              <td>string</td>
+              <td>Short free-text reason the initiator gives the approver.
+              <bcp14>MUST NOT</bcp14> exceed 280 characters.</td>
+            </tr>
+          </tbody>
+        </table>
+        <t>Enum semantics:</t>
+        <ul>
+          <li><tt>irreversibility</tt> -- the action cannot be undone once
+          executed.</li>
+          <li><tt>magnitude</tt> -- the amount or scope exceeds what the
+          initiator should act on alone.</li>
+          <li><tt>uncertainty</tt> -- the initiator's confidence in its own
+          assessment is too low to proceed unaided.</li>
+          <li><tt>novelty</tt> -- the action or counterparty has no
+          precedent in the initiator's history.</li>
+          <li><tt>authority_gap</tt> -- the action requires authority the
+          initiator was never granted.</li>
+          <li><tt>policy_rule</tt> -- a deterministic policy rule required
+          signoff and none of the five substantive categories above
+          captures why; <tt>policy_basis</tt> names the rule.</li>
+        </ul>
+        <t>Example context (fields as above, with the new member):</t>
+        <sourcecode type="json"><![CDATA[
+{
+  "ep_version": "1.0",
+  "context_type": "ep.signoff.v1",
+  "action_hash": "sha256:9f2c...",
+  "policy_id": "ep:policy:wires-over-100k@v12",
+  "policy_hash": "sha256:77ab...",
+  "initiator": "ep:entity:agent-recon-7",
+  "initiator_attestation": {
+    "escalation_trigger": "magnitude",
+    "policy_basis": "ep:policy:wires-over-100k@v12/rule:dual-auth",
+    "statement": "Exceeds my single-action limit; new beneficiary."
+  },
+  "approver": "ep:approver:jchen-controller",
+  "approver_index": 1,
+  "required_approvals": 2,
+  "nonce": "b64u:R9w1...",
+  "issued_at": "2026-06-09T17:21:05Z",
+  "expires_at": "2026-06-09T17:36:05Z"
+}
+]]></sourcecode>
+        <t>Rules:</t>
+        <ul>
+          <li><strong>Status.</strong> The member is
+          <bcp14>OPTIONAL</bcp14>. Existing issuers remain conformant; the
+          field can be adopted policy-by-policy.</li>
+          <li><strong>Binding.</strong> No new signature, digest, or
+          verification step is introduced. The context is
+          JCS-canonicalized as already required above; JCS serializes
+          every member present, so <tt>initiator_attestation</tt> and
+          everything inside it are part of the signed bytes. The
+          approver's signature therefore covers the stated reason: the
+          receipt proves the stated reason was part of what the approver
+          signed. Receipts carrying this member verify under the existing
+          <xref target="offline-verification"/> verifiers unmodified; a
+          context without the member produces byte-identical canonical
+          material to one produced today.</li>
+          <li><strong>Trigger/basis precedence.</strong>
+          <tt>escalation_trigger</tt> always carries the substantive
+          reason: when one of the first five enum values applies, the
+          producer <bcp14>MUST</bcp14> use it, whether or not a
+          deterministic rule also fired; <tt>policy_rule</tt>
+          <bcp14>MUST</bcp14> be used only when no substantive category
+          fits. Independently of which trigger is chosen, whenever a
+          deterministic policy rule fired, <tt>policy_basis</tt>
+          <bcp14>MUST</bcp14> be populated with that rule's
+          identifier.</li>
+          <li><strong>Cross-context consistency.</strong> When a receipt
+          contains multiple contexts (m-of-n approvals), the
+          <tt>initiator_attestation</tt> object, if present in any
+          context, <bcp14>MUST</bcp14> be present in every context of that
+          receipt, and its canonical form --
+          <tt>canonicalize(initiator_attestation)</tt> -- <bcp14>MUST</bcp14>
+          be identical across all of them. Every approver signs the same
+          stated reason.</li>
+          <li>Producers <bcp14>MUST NOT</bcp14> add members beyond the
+          three defined above in v1.</li>
+          <li>A signing client implementing this member
+          <bcp14>MUST</bcp14> render the attestation to the approver
+          alongside the faithful human-readable rendering of the Action
+          Object that this section already requires, subject to the
+          untrusted-content display rules in
+          <xref target="initiator-attestation-security"/>.</li>
+          <li>A signing client presented with a context whose
+          <tt>statement</tt> exceeds 280 characters <bcp14>MUST</bcp14>
+          refuse to render it for signing.</li>
+        </ul>
+        <t>The attestation is a claim by the initiator, which this
+        document identifies but never trusts
+        (<xref target="terminology"/>): it is the initiator's stated
+        reason, not a verified fact, and it is not evidence of the
+        initiator's internal state. Verifiers implementing this member
+        <bcp14>MUST</bcp14> check the cross-context consistency rule above
+        and <bcp14>SHOULD</bcp14> surface the attestation and flag other
+        violations of this section in verification reports; none of these
+        checks affects signature validity, by design, so receipts verify
+        on verifiers that predate this member.</t>
+      </section>
+      <section anchor="agent-binding">
+        <name>Agent Binding (OPTIONAL)</name>
+        <t>A producer <bcp14>MAY</bcp14> include an <tt>agent_binding</tt>
+        member in any <tt>ep.signoff.v1</tt> Authorization Context. The
+        member attributes the authorized action to an external <strong>agent
+        identity</strong> and, optionally, the external
+        <strong>delegation</strong> under which that agent was authorized to
+        act. When present it <bcp14>MUST</bcp14> be a JSON object with the
+        following members and no others:</t>
+        <table>
+          <thead>
+            <tr><th>Field</th><th>Required</th><th>Type</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><tt>agent_id</tt></td>
+              <td><bcp14>REQUIRED</bcp14></td>
+              <td>string</td>
+              <td>Non-empty external agent-identity reference (URI, DID, or
+              opaque id). This document does not constrain its scheme.</td>
+            </tr>
+            <tr>
+              <td><tt>delegation</tt></td>
+              <td><bcp14>OPTIONAL</bcp14></td>
+              <td>object</td>
+              <td>The external delegation that authorized the agent; members
+              below, no others.</td>
+            </tr>
+            <tr>
+              <td><tt>statement</tt></td>
+              <td><bcp14>OPTIONAL</bcp14></td>
+              <td>string</td>
+              <td>Short free-text note for the approver. <bcp14>MUST NOT</bcp14>
+              exceed 280 characters.</td>
+            </tr>
+          </tbody>
+        </table>
+        <t>When <tt>delegation</tt> is present it <bcp14>MUST</bcp14> be a
+        JSON object with the following members and no others:</t>
+        <table>
+          <thead>
+            <tr><th>Field</th><th>Required</th><th>Type</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><tt>scheme</tt></td>
+              <td><bcp14>REQUIRED</bcp14></td>
+              <td>string</td>
+              <td>Non-empty name of the external delegation standard, e.g.
+              <tt>"WIMSE"</tt>, <tt>"DRP"</tt>.</td>
+            </tr>
+            <tr>
+              <td><tt>ref</tt></td>
+              <td><bcp14>REQUIRED</bcp14></td>
+              <td>string</td>
+              <td>Non-empty external receipt/credential identifier.</td>
+            </tr>
+            <tr>
+              <td><tt>hash</tt></td>
+              <td><bcp14>OPTIONAL</bcp14></td>
+              <td>string</td>
+              <td>Content hash of the referenced artifact, formatted
+              <tt>"sha256:&lt;64-lowercase-hex&gt;"</tt>.</td>
+            </tr>
+            <tr>
+              <td><tt>observed_at</tt></td>
+              <td><bcp14>OPTIONAL</bcp14></td>
+              <td>string</td>
+              <td>RFC 3339 timestamp recording when the external delegation
+              evidence was observed or known valid. See L4 evidence freshness
+              below.</td>
+            </tr>
+          </tbody>
+        </table>
+        <t>Example context (fields as above, with the new member):</t>
+        <sourcecode type="json"><![CDATA[
+{
+  "ep_version": "1.0",
+  "context_type": "ep.signoff.v1",
+  "action_hash": "sha256:9f2c...",
+  "policy_id": "ep:policy:wires-over-100k@v12",
+  "policy_hash": "sha256:77ab...",
+  "initiator": "ep:entity:agent-recon-7",
+  "agent_binding": {
+    "agent_id": "did:web:agents.example.com:recon-7",
+    "delegation": {
+      "scheme": "WIMSE",
+      "ref": "urn:wimse:cred:9c41ab",
+      "hash": "sha256:2f9a...",
+      "observed_at": "2026-06-09T17:20:48Z"
+    },
+    "statement": "Acting for treasury-ops under wire delegation."
+  },
+  "approver": "ep:approver:jchen-controller",
+  "approver_index": 1,
+  "required_approvals": 2,
+  "nonce": "b64u:R9w1...",
+  "issued_at": "2026-06-09T17:21:05Z",
+  "expires_at": "2026-06-09T17:36:05Z"
+}
+]]></sourcecode>
+        <t>Rules:</t>
+        <ul>
+          <li><strong>Status.</strong> The member is <bcp14>OPTIONAL</bcp14>.
+          Existing issuers remain conformant; the field can be adopted
+          policy-by-policy.</li>
+          <li><strong>Claim, not proof.</strong> <tt>agent_binding</tt>
+          records that the action was <em>presented</em> as being taken by
+          <tt>agent_id</tt> under delegation <tt>ref</tt>. This document
+          identifies but never trusts the binding
+          (<xref target="terminology"/>): it is neither proof of the agent's
+          identity nor proof of the delegation's validity, both of which
+          remain the responsibility of the referenced external system. A
+          verifier <bcp14>MUST NOT</bcp14> treat <tt>agent_binding</tt> as
+          proof of either; it <bcp14>MAY</bcp14> surface <tt>agent_id</tt> and
+          <tt>delegation</tt> to the relying party as part of the verified
+          context, clearly labeled as a reference to an external system.</li>
+          <li><strong>Binding.</strong> No new signature, digest, or
+          verification step is introduced. The context is JCS-canonicalized as
+          already required above; JCS serializes every member present, so
+          <tt>agent_binding</tt> and everything inside it are part of the
+          signed bytes. The approver's signature therefore covers the binding.
+          Receipts carrying this member verify under the existing
+          <xref target="offline-verification"/> verifiers unmodified; a context
+          without it produces byte-identical canonical material to one produced
+          today.</li>
+          <li><strong>Cross-context consistency.</strong> When a receipt
+          contains multiple contexts (m-of-n approvals), the
+          <tt>agent_binding</tt> object, if present in any context,
+          <bcp14>MUST</bcp14> be present in every context of that receipt, and
+          its canonical form -- <tt>canonicalize(agent_binding)</tt> --
+          <bcp14>MUST</bcp14> be identical across all of them. Every approver
+          signs the same attribution.</li>
+          <li>Producers <bcp14>MUST NOT</bcp14> add members beyond those
+          defined above in v1, in either <tt>agent_binding</tt> or its
+          <tt>delegation</tt>.</li>
+          <li>A signing client implementing this member <bcp14>SHOULD</bcp14>
+          render <tt>agent_id</tt> (and <tt>delegation</tt> if present) to the
+          approver alongside the faithful human-readable rendering of the
+          Action Object that this section already requires, subject to the
+          untrusted-content display rules in
+          <xref target="initiator-attestation-security"/>. A signing client
+          presented with a context whose <tt>statement</tt> exceeds 280
+          characters <bcp14>MUST</bcp14> refuse to render it for signing.</li>
+        </ul>
+        <t><strong>L4 evidence freshness (OPTIONAL).</strong> A human
+        authorization decision is only as trustworthy as the upstream
+        agent-identity and delegation evidence it relied on. If a decision is
+        enforced correctly against a delegation claim that was never
+        constrained or has since expired, the failure surfaces at the
+        authorization layer but originates in the identity/delegation layer
+        beneath it. This document makes that dependency explicit and recordable
+        without absorbing the identity layer:</t>
+        <ul>
+          <li>A producer <bcp14>MAY</bcp14> populate
+          <tt>delegation.observed_at</tt> with the RFC 3339 time at which the
+          external delegation evidence was observed or known valid. Like the
+          rest of the binding, it is covered by the approver's signature.</li>
+          <li>A relying party <bcp14>MAY</bcp14> enforce freshness against
+          <tt>observed_at</tt>. When it does, the evaluation
+          <bcp14>MUST</bcp14> fail closed: a missing <tt>observed_at</tt>, a
+          timestamp later than the evaluation time, or an age exceeding the
+          relying party's configured maximum <bcp14>MUST</bcp14> be treated as
+          not-fresh. When no maximum age is configured, freshness is not
+          evaluated and the evidence is still surfaced for the audit
+          record.</li>
+        </ul>
+        <t>This keeps the receipt agnostic to which external
+        identity/delegation scheme prevails: the relying party binds to and
+        records whatever evidence was presented rather than requiring that
+        layer to converge, and a stale or unconstrained upstream claim becomes
+        detectable after the fact rather than silently absorbed. As with the
+        Initiator Attestation, none of these checks affects signature validity,
+        by design, so receipts verify on verifiers that predate this
+        member.</t>
+      </section>
+    </section>
+    <section anchor="approver-keys">
+      <name>Approver Keys and the Signoff Signature</name>
+      <t>This section is the core upgrade over server-side approval
+      systems.</t>
+      <section anchor="key-classes">
+        <name>Key Classes</name>
+        <t>Key classes classify KEY CUSTODY -- who holds and exercises
+        the approver's signing key -- and nothing else. They are
+        distinct from, and unrelated to, any assurance-level or
+        conformance-class vocabulary used elsewhere. Cross-protocol
+        requirements ought to name verifier-visible properties such as
+        user verification, device binding, initiator exclusion, distinct
+        humans, freshness, and status rather than treating these
+        receipt-local custody labels as universal assurance grades.</t>
+        <t><strong>Class A -- Device-bound keys
+        (<bcp14>RECOMMENDED</bcp14>).</strong> The approver's key is
+        generated and held in a platform authenticator or security key
+        and exercised via WebAuthn <xref target="WEBAUTHN"/>. The
+        signature algorithm is ES256 (P-256) or Ed25519 where supported.
+        The WebAuthn challenge <bcp14>MUST</bcp14> be the context hash.
+        The authenticator's user-verification flag (biometric or PIN)
+        <bcp14>MUST</bcp14> be required for signoff credentials. This
+        user-verification-gated signature is the native EP human-approval
+        act; it is fully defined by this section and does not rely on any
+        external acquiescence or confirmation mechanism. Attestation
+        <bcp14>SHOULD</bcp14> be captured at enrollment so relying parties
+        can establish that the key is hardware-bound.</t>
+        <t><strong>Class B -- Software keys.</strong> An Ed25519 keypair
+        held in the approver's client environment (CLI keychain, mobile
+        secure enclave via app). Acceptable where WebAuthn is impractical
+        (headless approval terminals), with the reduced assurance noted
+        in receipts.</t>
+        <t><strong>Class C -- Operator-custodied keys (LEGACY).</strong>
+        The EP operator signs on the approver's behalf after
+        authenticating them. This class exists only to describe
+        pre-existing deployments. Receipts produced under Class C
+        <bcp14>MUST</bcp14> be labeled <tt>key_class: "C"</tt> and
+        relying parties <bcp14>SHOULD</bcp14> treat them as evidence of
+        operator assertion, not approver signature. New deployments
+        <bcp14>SHOULD NOT</bcp14> use Class C.</t>
+      </section>
+      <section anchor="approver-directory">
+        <name>Enrollment and the Approver Directory</name>
+        <t>Approver public keys are enrolled into a signed Approver
+        Directory maintained per organization: a Merkle tree over
+        <tt>(approver_id, public_key, key_class, valid_from, valid_to,
+        roles)</tt> entries, with signed tree heads published alongside
+        receipt log checkpoints. A receipt's offline verifiability (G5)
+        includes an inclusion proof of the approver's key entry, so a
+        verifier needs no live directory access. Key rotation appends a
+        new entry and terminates the old one; signatures verify against
+        the key entry valid at <tt>issued_at</tt>.</t>
+        <t>Directory authority is a trust root and <bcp14>MUST
+        NOT</bcp14> default to the EP operator. The directory tree head
+        <bcp14>MUST</bcp14> be signed by an organization-controlled
+        directory key (custody options parallel
+        <xref target="key-classes"/>; an organization-held hardware key
+        is <bcp14>RECOMMENDED</bcp14>). Where directory
+        <em>operation</em> is delegated to the EP operator, every
+        enrollment entry <bcp14>MUST</bcp14> carry a second-party
+        attestation -- a signature over the new entry by an organization
+        administrator key or by a quorum of already-enrolled approvers --
+        and that attestation <bcp14>MUST</bcp14> be included in the
+        receipt's <tt>approver_key_proofs</tt>. Verifiers
+        <bcp14>MUST</bcp14> treat a directory head signed only by an
+        operator-held key as operator assertion (Class C-equivalent
+        assurance), regardless of the key class of the individual
+        signoffs. Rationale: an operator that unilaterally controls
+        directory membership cannot forge an enrolled approver's
+        signature, but it can enroll a key it controls under a legitimate
+        approver's name -- relocating the forgery rather than preventing
+        it. See <xref target="directory-authority"/>.</t>
+        <t>This directory is also the binding point between approver
+        identifiers and real-world persons
+        (<xref target="scope-of-identity"/>). The strength of that binding
+        -- how an organization proves that an enrolled identifier is the
+        person it names, and how key-discovery layers attach to it -- is a
+        property of the directory authority and any identity layer bound
+        to it, not of the receipt format defined here.</t>
+      </section>
+      <section>
+        <name>The Signoff</name>
+        <t>A signoff is:</t>
+        <sourcecode type="json"><![CDATA[
+{
+  "context_hash": "sha256:c41e...",
+  "signature": "b64u:MEUCIQ...",
+  "key_class": "A",
+  "approver_key_id": "ep:key:jchen-controller#2026-01",
+  "signed_at": "2026-06-09T17:24:40Z",
+  "webauthn": { "authenticator_data": "b64u:...",
+                "client_data_json": "b64u:..." }
+}
+]]></sourcecode>
+        <t>For Class A, verifiers <bcp14>MUST</bcp14> validate the
+        WebAuthn assertion per <xref target="WEBAUTHN"/> including that
+        <tt>clientDataJSON.challenge</tt> equals the context hash and
+        that the user-verification bit is set. A denial is also signed
+        (over the context hash with a <tt>decision: "denied"</tt>
+        envelope) so that refusals are equally attributable,
+        tamper-evident, and terminal. This is a cryptographic statement;
+        legal non-repudiation is out of scope.</t>
+      </section>
+    </section>
+    <section anchor="consumption">
+      <name>Consumption, Commitment, and the Trust Receipt</name>
+      <section>
+        <name>State Machine</name>
+        <t>An authorization attempt proceeds:</t>
+        <artwork><![CDATA[
+REQUESTED -> {PARTIALLY_APPROVED}* -> APPROVED -> COMMITTED
+          \-> DENIED                          \-> EXPIRED
+          \-> EXPIRED
+]]></artwork>
+        <t>COMMITTED, DENIED, and EXPIRED are terminal. The protocol
+        invariants -- maintained as machine-checked models and
+        <bcp14>REQUIRED</bcp14> of conforming implementations -- are:</t>
+        <ul>
+          <li><strong>ConsumeOnce.</strong> Within one conforming shared,
+          atomic consumption domain, a nonce transitions to a terminal
+          state at most once. Any second presentation to that domain
+          <bcp14>MUST</bcp14> be rejected with a replay error. The model
+          does not assert coordination with an independent store that
+          does not share this state.</li>
+          <li><strong>BindingMatch.</strong> A signoff satisfies only the
+          context (and therefore only the action hash) it signs.</li>
+          <li><strong>TerminalIrreversibility.</strong> No transition
+          exits a terminal state.</li>
+          <li><strong>SelfApprovalImpossible.</strong> For every signoff,
+          <tt>approver != initiator</tt>; for m-of-n policies, approvers
+          are pairwise distinct and each distinct from the
+          initiator.</li>
+          <li><strong>NoBypassWrite.</strong> A COMMITTED state is
+          reachable only through the full sequence; conforming verifying
+          executors <bcp14>MUST NOT</bcp14> execute without verifying it
+          (<xref target="conformance"/>).</li>
+        </ul>
+      </section>
+      <section>
+        <name>The Trust Receipt</name>
+        <t>Upon commitment the orchestrator assembles and logs the Trust
+        Receipt:</t>
+        <sourcecode type="json"><![CDATA[
+{
+  "receipt_id": "ep:receipt:01J...",
+  "action": { "...": "full Action Object" },
+  "action_hash": "sha256:9f2c...",
+  "contexts": [ { "...": "Authorization Context 1" } ],
+  "signoffs": [ { "...": "Signoff 1" },
+                { "...": "Signoff 2" } ],
+  "consumption": { "nonce": "b64u:R9w1...",
+                   "state": "COMMITTED",
+                   "committed_at": "2026-06-09T17:25:02Z" },
+  "log_proof": { "leaf_index": 88412,
+                 "inclusion_path": ["sha256:...", "..."],
+                 "checkpoint": { "tree_size": 90210,
+                                 "root_hash": "sha256:...",
+                                 "log_signature": "b64u:...",
+                                 "log_key_id": "ep:log:acme#1" } },
+  "approver_key_proofs": [ { "directory_inclusion": "..." } ]
+}
+]]></sourcecode>
+      </section>
+      <section anchor="offline-verification">
+        <name>Offline Verification Algorithm</name>
+        <t>A verifier with (receipt, trusted log public key, trusted
+        directory root or pinned approver keys) and <strong>no network
+        access</strong> <bcp14>MUST</bcp14> be able to establish all of
+        the following; the published verifier package performs exactly
+        these steps:</t>
+        <ol>
+          <li>Recompute the action hash from the canonical Action Object;
+          compare.</li>
+          <li>For each context: recompute the context hash; confirm it
+          commits to the action hash, the policy hash, and a distinct
+          approver.</li>
+          <li>For each signoff: verify the signature (and WebAuthn
+          assertion where present) over the context hash against the
+          approver key entry, checking the key's validity window contains
+          <tt>issued_at</tt>.</li>
+          <li>Confirm SoD: initiator appears in no approver slot;
+          approvers are pairwise distinct; the approval count satisfies
+          <tt>required_approvals</tt>.</li>
+          <li>Verify the Merkle inclusion proof of the receipt leaf
+          against the checkpoint root, and the checkpoint signature
+          against the log key.</li>
+          <li>Confirm <tt>signed_at</tt> and <tt>committed_at</tt> fall
+          within <tt>[issued_at, expires_at]</tt>.</li>
+        </ol>
+        <t>Degenerate empty-path rule (step 5). An empty
+        <tt>inclusion_path</tt> <bcp14>MUST</bcp14> be accepted only when
+        the checkpoint's <tt>tree_size</tt> is exactly 1 and the
+        <tt>leaf_index</tt>, when present, is 0; an empty path presented
+        with any other tree size (including a missing or non-integer
+        <tt>tree_size</tt>) <bcp14>MUST</bcp14> be refused, before any
+        Merkle computation. Without this rule an empty path degenerates
+        to "leaf hash equals root hash", which a forged checkpoint can
+        satisfy at any claimed tree size by simply repeating the leaf
+        hash as its root. Two public reject vectors in the EP conformance
+        suite (<tt>reject_empty_path_tree_size_not_1</tt> and
+        <tt>reject_empty_path_nonzero_leaf_index</tt>) pin this rule
+        across the cross-language reference verifiers.</t>
+        <t>Step 5 is what distinguishes EP receipts from log-access
+        designs: the checkpoint travels <em>inside</em> the receipt, so
+        verification requires no query to the log. Detecting log
+        equivocation (split-view attacks) additionally benefits from
+        gossip or witness cosigning (<xref target="log-equivocation"/>),
+        which is an online activity; the offline guarantee is that
+        <em>this receipt is internally consistent, correctly signed by
+        enrolled approver keys, and was included in a log tree whose head
+        the log operator signed</em>.</t>
+        <t>Offline verification establishes authenticity, not currency.
+        Two properties are explicitly NOT established offline: (a)
+        post-issuance revocation -- a receipt whose approver key was
+        revoked an hour after commitment still verifies; the artifact is
+        evidence of validity <em>at commit time</em>; and (b) log honesty
+        against split views (<xref target="log-equivocation"/>). A
+        relying party with freshness or revocation requirements
+        <bcp14>MUST</bcp14> additionally consult a current directory head
+        and log checkpoint online. Implementations <bcp14>MUST
+        NOT</bcp14> describe offline verification as establishing that a
+        receipt is "currently valid."</t>
+        <t>The Initiator Attestation
+        (<xref target="initiator-attestation"/>), where present, is
+        covered by the context hash recomputed in step 2 above; no
+        additional verification step is required for it.</t>
+      </section>
+    </section>
+    <section anchor="receipt-extensions">
+      <name>Companion Receipt Extensions and Digest Binding</name>
+      <t>Extensions <bcp14>MUST NOT</bcp14> be inserted into the base Trust
+      Receipt.  The <tt>EP-RECEIPT-v1</tt> object, its closed schema, its
+      canonical bytes, and the verification procedure in
+      <xref target="offline-verification"/> remain unchanged.  In particular,
+      a base verifier <bcp14>MUST NOT</bcp14> strip, ignore, or otherwise
+      preprocess an unrecognized receipt member before verification.</t>
+      <t>A producer <bcp14>MAY</bcp14> convey lifecycle or composition bindings
+      in a separate companion object whose version is
+      <tt>EP-RECEIPT-EXTENSIONS-v1</tt>.  The companion is not part of the
+      base Trust Receipt and confers no authority by itself.  It
+      <bcp14>MUST</bcp14> be a closed object with exactly
+      <tt>version</tt>, <tt>base_receipt_digest</tt>,
+      <tt>base_action_digest</tt>, and <tt>entries</tt>:</t>
+      <sourcecode type="json"><![CDATA[
+{
+  "version": "EP-RECEIPT-EXTENSIONS-v1",
+  "base_receipt_digest": "sha256:...",
+  "base_action_digest": "sha256:...",
+  "entries": [
+    {
+      "name": "ai.emiliaprotocol.trust-program.stage-receipts.v1",
+      "operation_id": "provider-stable-operation-id",
+      "consequence_digest": null,
+      "artifact_digest": "sha256:..."
+    }
+  ]
+}
+]]></sourcecode>
+      <t>The <tt>base_receipt_digest</tt> <bcp14>MUST</bcp14> be SHA-256 over
+      the JCS canonicalization of the complete, unchanged base Trust Receipt.
+      No member is removed or added for this calculation.  This value is the
+      identity of the complete portable receipt, not the Merkle leaf hash;
+      implementations <bcp14>MUST NOT</bcp14> substitute a leaf digest that
+      omits <tt>log_proof</tt> or <tt>approver_key_proofs</tt>.  The
+      <tt>base_action_digest</tt> <bcp14>MUST</bcp14> equal that base receipt's
+      <tt>action_hash</tt>.  Digest values in this companion
+      <bcp14>MUST</bcp14> use the lowercase
+      <tt>sha256:</tt> prefix followed by exactly 64 lowercase hexadecimal
+      characters.  The <tt>entries</tt> member <bcp14>MUST</bcp14> contain
+      between 1 and 32 closed objects, each with exactly
+      <tt>name</tt>, <tt>operation_id</tt>, <tt>consequence_digest</tt>, and
+      <tt>artifact_digest</tt>.</t>
+      <ul>
+        <li><tt>name</tt> <bcp14>MUST</bcp14> be an ASCII lowercase,
+        dot-separated extension name.  Each label begins and ends with a
+        lowercase letter or digit and can contain interior hyphens.  A name
+        <bcp14>MUST NOT</bcp14> exceed 255 ASCII characters.  A name
+        allocated outside the document-local namespace
+        <bcp14>SHOULD</bcp14> begin with a reversed DNS name controlled by its
+        allocator.  Control of a name is only collision avoidance; it conveys
+        no trust.  An entries array <bcp14>MUST NOT</bcp14> contain the same
+        name more than once.</li>
+        <li><tt>operation_id</tt> is either null or the stable operation
+        identifier selected by the extension profile.  A lifecycle extension
+        governing a material attempt <bcp14>MUST</bcp14> use a non-null value
+        and <bcp14>MUST NOT</bcp14> derive it from presenter-controlled display
+        text.  A non-null value <bcp14>MUST</bcp14> be non-empty, contain no
+        control characters, and contain no more than 512 Unicode scalar
+        values.</li>
+        <li><tt>consequence_digest</tt> is either null for a pre-effect
+        extension or the extension profile's digest of the exact observed,
+        claimed, or settled consequence.  A null value conveys no execution
+        or outcome proof.</li>
+        <li><tt>artifact_digest</tt> <bcp14>MUST</bcp14> be the SHA-256 digest
+        of the exact companion artifact under the canonicalization rule named
+        by the selected extension definition.</li>
+      </ul>
+      <t>An extension-aware relying party <bcp14>MUST</bcp14> first verify the
+      unchanged base Trust Receipt using the base verification procedure.  It
+      then separately verifies the companion version, recomputes both base
+      digests, and evaluates the extension names required by its own policy.
+      The companion envelope is an untrusted index, not an authenticated
+      assertion.  Companion artifacts are conveyed separately; this document
+      defines no network retrieval or presenter-supplied locator.  Parsers
+      <bcp14>MUST</bcp14> apply the duplicate-member, surrogate, number, and
+      depth rejection rules in <xref target="canonicalization-robustness"/>
+      to the companion before using any entry.
+      For each required entry, an extension-specific verifier
+      <bcp14>MUST</bcp14> verify the companion artifact under
+      relying-party-selected trust and <bcp14>MUST</bcp14> require that
+      artifact to bind the same extension name, base action digest, base
+      receipt digest, operation identifier, and consequence digest.  It then
+      recomputes the artifact digest over that exact artifact.  The extension
+      profile <bcp14>MUST</bcp14> define any freshness, replay, revocation,
+      and terminal-state checks needed for its assurance claim.  Merely
+      carrying a digest does not establish the artifact's validity, authority,
+      freshness, non-replay, or execution semantics.</t>
+      <t>An extension-aware relying party <bcp14>MAY</bcp14> ignore an unknown
+      sidecar entry only when its policy does not require that extension name.
+      It <bcp14>MUST</bcp14> fail closed when a required entry is absent,
+      unknown, duplicated, malformed, untrusted, or mismatched.  The required
+      extension set is selected independently by relying-party policy; a
+      presenter cannot weaken it by omitting an entry.  A verifier that
+      implements only <tt>EP-RECEIPT-v1</tt> does not process the companion and
+      gains no additional assurance from its presence.</t>
+      <section anchor="provisional-extension-registry">
+        <name>Provisional Extension Registry</name>
+        <t>This revision defines the design rules for a provisional,
+        document-local namespace; it does not create an IANA registry.  Names
+        beginning with <tt>ep.</tt> are reserved for assignments made by a
+        future revision of this document or by a separately versioned public
+        extension index explicitly referenced by such a revision.  This
+        revision makes no <tt>ep.</tt> assignments.  Other specifications can
+        self-allocate a reversed-DNS name under a domain they control.</t>
+        <t>Every extension definition <bcp14>MUST</bcp14> specify its immutable
+        name, controlling specification and version, companion artifact
+        version, canonicalization rule, artifact-digest rule,
+        operation-identifier semantics, consequence-digest semantics,
+        relying-party trust inputs, freshness and replay behavior, and
+        fail-closed conditions.  An incompatible semantic change
+        <bcp14>MUST</bcp14> allocate a new name.  An extension definition
+        <bcp14>MUST NOT</bcp14> redefine the base Action Object, Authorization
+        Context, signoff, consumption, or log-proof bytes.</t>
+        <t>A relying party <bcp14>MUST</bcp14> pin the exact extension
+        definition it accepts; discovering a syntactically valid name is not
+        authorization to trust it.  A future document could request an IANA
+        registry if interoperable use demonstrates that centralized
+        allocation is needed.  Such a request is outside the scope of this
+        revision.</t>
+      </section>
+      <section anchor="action-lifecycle-relationship">
+        <name>Relationship to the Action Lifecycle</name>
+        <t>This subsection is informative.  The companion seam permits a
+        revocation statement to retract future authority without rewriting an
+        executed effect; an outcome-binding artifact to compare approved bytes
+        with an observed effect; an action-remedy receipt to describe a newly
+        authorized compensating action with its own CAID and
+        <tt>rollback: false</tt>; or an evidence challenge to name evidence
+        missing before execution.  These examples do not soften the base
+        receipt's terminal or consumption semantics.</t>
+      <t>An Authority Program (also described informally as a Trust Program)
+      can use the same companion seam for immutable stage receipts whose sorted
+      predecessor receipt digests bind a relying-party-pinned recursive
+      series/parallel program to one root CAID and action.  An Authorization
+      Evidence Chain composition artifact can bind a separately verified set
+      of evidence nodes to the same receipt and action digests.  A staged DTC
+      settlement profile could likewise bind a receipt or certificate state
+      root.  These are informative, non-exhaustive consumers.  Base receipt
+      verification does not validate any such chain, program, lifecycle, or
+      settlement artifact.  This document does not claim that Authority
+      Program or DTC settlement infrastructure is standardized, independently
+      implemented, deployed, or proved by base receipt or companion-envelope
+      verification.</t>
+      </section>
+    </section>
+    <section>
+      <name>Multi-Approver Policies (m-of-n)</name>
+      <t>A policy <bcp14>MAY</bcp14> require k distinct approvers from a
+      role set. Each approver receives and signs an individual
+      Authorization Context sharing the same <tt>action_hash</tt> and
+      <tt>nonce</tt> family but a distinct <tt>approver_index</tt>.
+      Commitment occurs only when k valid, distinct signoffs exist before
+      <tt>expires_at</tt>. Partial approval confers no authority: a
+      verifying executor presented with fewer than k signoffs
+      <bcp14>MUST</bcp14> refuse.</t>
+    </section>
+    <section>
+      <name>Delegation Constraints</name>
+      <t>Where an approver's authority is itself delegated, the
+      delegation record <bcp14>MUST</bcp14> be presented in the receipt's
+      <tt>approver_key_proofs</tt>, and the constraint
+      <strong>DelegateCannotExceedPrincipal</strong> applies: the
+      effective scope of a delegate is the intersection of the delegation
+      grant and the principal's authority at signing time. Delegation
+      chains are bounded (<bcp14>RECOMMENDED</bcp14> depth of at most 2)
+      and every link is independently signed.</t>
+    </section>
+    <section anchor="conformance">
+      <name>Conformance Classes and Execution-Side Enforcement</name>
+      <t>Honesty about deployment topology is a protocol feature. Three
+      classes:</t>
+      <t><strong>EP-Verified Execution (STRONG).</strong> The system of
+      record (payment switch, registry, deployment controller) verifies
+      the Authorization Bundle (receipt-less pre-execution form: action
+      object, contexts, signoffs, consumption attestation) before
+      executing, and refuses otherwise. The gate cannot be bypassed by
+      any party that does not control the system of record itself.</t>
+      <t><strong>EP-Gated Middleware (STANDARD).</strong> An interception
+      layer between the agent and the executing credential enforces the
+      gate. Provides strong protection against agent error and prompt
+      injection; an operator with code control can bypass. Receipts
+      remain valid evidence of what <em>was</em> approved.</t>
+      <t><strong>EP-Evidence Only (BASIC).</strong> Actions execute
+      independently; receipts are produced for audit. No enforcement
+      claim is made.</t>
+      <t>Implementations <bcp14>MUST</bcp14> declare their class in
+      receipts (<tt>enforcement_class</tt>), and marketing or compliance
+      claims <bcp14>MUST NOT</bcp14> state a stronger class than
+      deployed. This section exists because the difference between "we
+      proved the protocol" and "your deployment is unbypassable" is the
+      most common overclaim in this category.</t>
+    </section>
+    <section anchor="related-work">
+      <name>Relationship to Other Work</name>
+      <t><strong>DRP</strong>
+      (<xref target="I-D.nelson-agent-delegation-receipts"/>) binds a
+      <em>user's</em> delegation to an <em>operator's</em> instructions --
+      upstream consumer delegation. EP binds an <em>organizational
+      approver</em> to an <em>exact action</em> -- downstream
+      authorization under its own SoD and m-of-n profiles. The two
+      compose: a DRP delegation can be referenced in
+      an EP Action Object's provenance field.</t>
+      <t><strong>Bounded Capability Receipts</strong>
+      <xref target="EP-BOUNDED-CAP"/> authorize a different lifecycle.
+      An EP Authorization Receipt can approve the exact act of issuing a
+      bounded capability, and that issuance receipt is consumed when the
+      capability is registered. It <bcp14>MUST NOT</bcp14> then be reused
+      as though it approved every later capability-funded operation. The
+      capability binds the complete issuance-receipt digest, scope, budget,
+      holder proof, and validity interval; its shared reserve/commit store
+      accounts later operations. A deployment that requires human approval of
+      an individual exercise obtains a new action-bound EP receipt or
+      EP-QUORUM for that exercise.</t>
+      <t><strong>CIBA</strong> <xref target="CIBA"/> transports an
+      authentication-time approval to a backchannel device; it does not
+      produce an action-bound, offline-verifiable, one-time-consumable
+      artifact. CIBA <bcp14>MAY</bcp14> serve as the transport by which
+      an approver is reached; the EP signoff is what they produce when
+      they get there.</t>
+      <t><strong>AI Agent Authentication and Authorization</strong>
+      (<xref target="I-D.klrc-aiagent-auth"/>) keeps the final authorization
+      decision with the authorization server, requires local user
+      confirmation to be bound to a verifiable grant, and identifies
+      mid-execution confirmation as an area where additional work may be
+      needed. An EP Authorization Context is one candidate evidence object
+      for that binding; it does not replace the grant or authorization
+      server decision. The same document requires durable, tamper-evident
+      audit records. An EP Trust Receipt can supply an action, decision, and
+      terminal-consumption record under the selected profile, but does not
+      by itself satisfy deployment monitoring, remediation, retention, or
+      compliance requirements. A profile can carry the Authorization Context
+      or Trust Receipt digest in transaction context without redefining
+      transaction-token semantics.</t>
+      <t><strong>Mastercard Verifiable Intent</strong> <xref target="FIDO-VI"/>,
+      co-developed with Google and contributed to the FIDO Alliance,
+      describes portable, verifiable evidence of
+      user intent. The cited page describes a contribution and prospective
+      standardization, not a final FIDO specification. EP does not claim
+      portable human evidence is absent.
+      Its receipt profile separately specifies an enrolled organizational
+      approver directory, exact Authorization Context, initiator exclusion,
+      terminal consumption record, and optional distinct-human quorum.</t>
+      <t><strong>AuthZEN Access Request and Approval Profile</strong>
+      <xref target="AUTHZEN-AARP"/> defines requestable denial,
+      asynchronous approval tasks, an approval object whose optional state
+      carries opaque proof or verifier state, JWS interoperability when that
+      state is carried by value, an exact-match baseline, and PDP re-evaluation
+      at enforcement time. EP
+      does not replace that profile. A deployment can select an EP receipt
+      as an additional evidence profile when it requires a verifier-visible
+      approver-held device ceremony, enrolled-human directory binding,
+      portable initiator exclusion, or one-time executor consumption. The
+      relying party remains responsible for deciding which profile satisfies
+      its requirement.</t>
+      <t><strong>WIMSE / workload identity</strong> authenticates the
+      workload to services; EP supplies action-bound approval evidence that
+      a relying party may require in its local authorization decision.
+      These are complementary layers.</t>
+      <t><strong>Receiver-attested logging (e.g., Sello)</strong> has the
+      receiving service sign what it observed, post-hoc. EP is
+      pre-execution authorization. A complete deployment benefits from
+      both: EP records the pre-execution signing and consumption event under
+      a selected profile; receiver attestation records what the receiver
+      observed afterward. Local policy determines whether the former is
+      sufficient for authorization.</t>
+      <t><strong>AgentROA (draft-nivalto-agentroa-route-authorization),
+      AIIP, and CIRP</strong> define machine-side, per-hop execution and
+      route receipts for agent actions under delegated authority. Their
+      approval-state or approval-reference fields do not by themselves
+      define the EP ceremony and directory profile. EP evidence can fill
+      such a reference where that profile is selected, and its delegation
+      constraints share AgentROA's monotonic ("tighten-only")
+      scope-narrowing discipline.</t>
+      <t><strong>The Entity Attestation Token (RFC 9711, RATS)</strong>
+      attests the <em>agent or platform</em> -- model, keys, posture; EP
+      carries evidence of an enrolled approver key's action-bound decision.
+      The two are orthogonal and
+      composable: an EAT says the machine is what it claims; an EP receipt
+      says a named person approved the exact action.</t>
+      <t><strong>Transaction Tokens
+      (draft-ietf-oauth-transaction-tokens)</strong> propagate workload and
+      agent authorization context across a machine call chain; an EP
+      receipt can be one referenced approval artifact when a relying
+      party requires that profile.</t>
+      <t><strong>Evidence Record Syntax (RFC 4998)</strong> preserves
+      signed evidence across algorithm aging by periodic re-timestamping.
+      EP applies the same approach to long-lived receipts via an
+      evidence-record renewal chain, so a receipt verifiable today remains
+      verifiable after its original algorithms weaken -- a property the
+      10-25+ year retention schedules of government records require.</t>
+    </section>
+    <section>
+      <name>Security Considerations</name>
+      <section>
+        <name>Operator Compromise</name>
+        <t>Under key classes A/B, a compromised EP operator can deny
+        service and can fail to route signoff requests, and it cannot
+        <em>forge a signature</em>: it lacks approver keys, and it cannot
+        replay one (nonces are single-consumption and receipts chain).
+        Two operator-compromise paths remain and are stated plainly
+        rather than claimed away. First, an operator that controls the
+        signing client's rendering can harvest a <em>genuine</em>
+        signature over an action the approver misunderstood -- a
+        presentation attack (<xref target="presentation-attacks"/>); for
+        this reason an independently-authored rendering surface is
+        <bcp14>REQUIRED</bcp14> for high-value policies. Second, an operator
+        that unilaterally controls the Approver Directory can enroll keys
+        it controls (<xref target="approver-directory"/>,
+        <xref target="directory-authority"/>). Accordingly, the accurate
+        claim for classes A/B is: "the operator cannot forge an
+        approver's signature." The stronger claim -- "the operator cannot
+        obtain an unauthorized approval" -- additionally requires the
+        directory-authority and independent-rendering controls. Under
+        class C the operator can fabricate outright; hence the labeling
+        requirement.</t>
+      </section>
+      <section>
+        <name>Approver Device Compromise</name>
+        <t>A stolen authenticator with user verification still requires
+        the biometric/PIN. Organizations <bcp14>SHOULD</bcp14> require
+        key class A for high-value policies and <bcp14>SHOULD</bcp14>
+        pair approval with out-of-band action rendering (the approver
+        sees the wire details on a second surface).</t>
+      </section>
+      <section anchor="presentation-attacks">
+        <name>Presentation Attacks</name>
+        <t>The gravest risk in this protocol, stated without
+        minimization: the approver signs context hash H believing it
+        represents action X when it represents action Y. A signature
+        proves user presence and an act of approval toward <em>whatever
+        was rendered</em>; cryptography cannot prove the rendering was
+        faithful. Required mitigations, in increasing strength: (1) the
+        signing client <bcp14>MUST</bcp14> render the Action Object from
+        the exact bytes that were hashed -- never from a separately
+        supplied description; (2) for high-value policies, render
+        templates <bcp14>MUST</bcp14> be registered with the policy and
+        committed by <tt>policy_hash</tt>, so the display logic is part
+        of what the approver's signature covers; (3) for policies above
+        an organization-designated threshold, the material action
+        parameters (amount, beneficiary identifiers) <bcp14>MUST</bcp14>
+        additionally be rendered on a second surface not authored by the
+        orchestrating operator -- for example, delivered by the verifying
+        executor or an independent operator to the approver's enrolled
+        device over a separate channel. The residual risk is stated
+        honestly: absent a trusted display path (hardware the operator
+        does not author), rendering fidelity is enforced by controls
+        (2)-(3), by audit, and by consented mismatch drills
+        (<xref target="approver-fatigue"/>) -- not by mathematics. What
+        the cryptography does guarantee is exactness of evidence: the
+        receipt contains the full Action Object actually signed, so any
+        divergence between what was displayed and what was executed is
+        detectable after the fact with proof rather than testimony.</t>
+      </section>
+      <section anchor="log-equivocation">
+        <name>Log Equivocation</name>
+        <t>A malicious log could show different trees to different
+        parties. Checkpoints <bcp14>SHOULD</bcp14> be witness-cosigned
+        and/or gossiped between independent EP operators; the federation
+        profile makes cross-operator checkpoint exchange mandatory. Before a
+        witness signs a checkpoint or a gossip participant accepts it for
+        comparison, that participant <bcp14>MUST</bcp14> verify the
+        checkpoint's log signature under the pinned log key and
+        <bcp14>MUST</bcp14> verify any required consistency proof from the
+        participant's previously accepted checkpoint. A quorum of witness
+        signatures over a caller-supplied but unauthenticated tuple is not
+        evidence that the named log produced that tuple.</t>
+        <t>For this purpose, independent operators require separate
+        administrative control, key custody, and failure domains; multiple
+        co-located processes under one operator do not provide independent
+        witnessing. Comparing supplied authenticated views can prove that the
+        views conflict. It does not by itself prove freshness, completeness,
+        or that every relying party received the latest checkpoint.</t>
+      </section>
+      <section>
+        <name>What the Formal Models Do and Do Not Prove</name>
+        <t>The TLA+/Alloy models prove safety of the authorization state
+        machine: no replay, no self-approval, no bypass <em>within the
+        modeled system</em>, no partial commitment. They prove nothing
+        about any AI model's behavior, about host compromise, or about
+        deployments in a weaker conformance class. Implementations
+        <bcp14>MUST NOT</bcp14> represent the proofs as covering
+        deployment topologies they do not model. For the same honesty:
+        three normative mechanisms in this document are specified ahead
+        of the reference implementation and are not yet exercised by it
+        or by conformance vectors -- the operator-signed-directory
+        assurance downgrade (Section 5.2), delegation records in
+        approver_key_proofs and the DelegateCannotExceedPrincipal check
+        (Section 8), and enforcement_class emission (Section 9).
+        Implementers MUST treat the text as normative and the reference
+        implementation as incomplete on these three points, not the
+        reverse. The m-of-n quorum flow IS
+        now modeled: a checked Alloy model (formal/ep_quorum.als in the
+        repository) proves SelfApprovalImpossible, NoHumanFillsTwoSlots,
+        NoKeyFillsTwoSlots, TwoPersonRuleHolds, and ordered-chain
+        acyclicity/linearity against the quorum verifier and its
+        conformance vectors. The models additionally
+        do not yet cover the WebAuthn challenge binding, the Approver
+        Directory, log checkpoints, or the Initiator
+        Attestation (<xref target="initiator-attestation"/>); those sections
+        are specified, not proven, and extending the models to them is
+        tracked work.</t>
+        <t>A separate composed Tamarin model joins signed challenge, CAID,
+        two distinct user-verification-gated approvals, scoped authority
+        under an exact pinned registry view, revocation, receipt-issuer
+        pinning, one-time consumption, and execution in one symbolic trace
+        <xref target="FORMAL-STATUS"/>. Ten named obligations verify,
+        including execution_requires_full_composition,
+        initiator_cannot_self_approve, no_issuer_laundering,
+        strict_registry_view_is_exact, and
+        injective_execution_with_consumption. Two deliberately unsafe
+        comparison lemmas are falsified with concrete traces: one omits
+        consumption and admits same-receipt replay; the other omits exact
+        registry-view binding and admits a stale or equivocating view. The
+        model treats signatures as perfect symbolic primitives and does not
+        prove WebAuthn internals, parser correctness, amount arithmetic,
+        policy authorship, clock freshness, transparency-log completeness,
+        collusion resistance, or downstream exactly-once physical effects.</t>
+        <t>The quorum abstraction in the standalone symbolic model is a fixed
+        2-of-2 instance. Its checked result is evidence for that instance, not
+        a proof of the arbitrary k-of-n construction defined by the companion
+        EP-QUORUM document and not a proof of production code. CI regression
+        gating of an existing prover result increases reproducibility; it does
+        not add a lemma or enlarge the model's scope.</t>
+        <t>Independent implementation status, stated precisely: the
+        three reference verifiers (JavaScript, Python, Go) agree on the
+        published conformance vectors but live in one repository -- a
+        cross-language consistency check, not independent
+        implementations. A separately authored Rust verifier was evaluated
+        on 11 July 2026 and passed 16 suites and 164 vectors from a
+        hash-pinned bundle <xref target="EXTERNAL-RUST-PIN"/>. That result
+        is time-pinned: it does not cover the current larger vector bundle,
+        and the available construction statement predates the evaluated
+        hardening commit. It is therefore evidence of external implementation
+        and execution for that bundle, not yet strict clean-room construction
+        acceptance for the current specification.</t>
+      </section>
+      <section anchor="directory-authority">
+        <name>Directory Authority</name>
+        <t><xref target="approver-keys"/> removes the operator from the
+        signature path; <xref target="approver-directory"/> must not
+        readmit it as the authority that decides which keys count. If the
+        EP operator alone signs the Approver Directory, a malicious
+        operator can satisfy policy by enrolling a key it controls under
+        a nominally legitimate approver's name. The controls in
+        <xref target="approver-directory"/> (organization-held directory
+        key; second-party attestation on enrollment; Class C-equivalent
+        treatment otherwise) exist for this reason. Auditors
+        <bcp14>SHOULD</bcp14> verify directory key custody as part of any
+        assessment that relies on receipts.</t>
+      </section>
+      <section>
+        <name>What Separation of Duties Does and Does Not Provide</name>
+        <t>SelfApprovalImpossible (<xref target="consumption"/>) defeats
+        <em>unilateral</em> self-approval: no initiator can approve its
+        own action, and m-of-n approvers are pairwise distinct
+        identities. It does not defeat collusion among distinct enrolled
+        humans, one human who controls multiple enrolled identities (an
+        enrollment control -- <xref target="approver-directory"/>), or a
+        coerced approver. Receipts make such events <em>attributable</em>
+        -- named, signed, and evidenced -- which raises the cost of insider
+        fraud; they do not make it impossible, and implementations
+        <bcp14>MUST NOT</bcp14> claim otherwise.</t>
+      </section>
+      <section anchor="approver-fatigue">
+        <name>Approver Fatigue</name>
+        <t>A gate that humans route around protects nothing;
+        rubber-stamping is the empirical failure mode of every
+        human-in-the-loop control under volume. This protocol is
+        therefore not a general approval workflow: deployments
+        <bcp14>MUST</bcp14> scope signoff policies to genuinely
+        high-risk, low-frequency actions and <bcp14>SHOULD</bcp14> handle
+        volume with policy (thresholds, allow-lists, velocity rules)
+        rather than human throughput. Operational countermeasures
+        <bcp14>SHOULD</bcp14> include monitoring time-to-sign
+        distributions (signing latencies near the floor indicate approval
+        without review), tracking deny rates (a gate that never denies is
+        either perfectly upstream-filtered or ceremonial), and consented
+        render-mismatch drills that measure whether approvers read what
+        they sign. Such telemetry is deployment guidance, not protocol;
+        but the protocol's guarantees are only as strong as the attention
+        of the human at its center, and implementations
+        <bcp14>SHOULD</bcp14> say so to their customers.</t>
+      </section>
+      <section anchor="initiator-attestation-security">
+        <name>Initiator Attestation as an Attack Surface</name>
+        <t>The <tt>statement</tt> member of an Initiator Attestation
+        (<xref target="initiator-attestation"/>) is
+        attacker-influenceable free text rendered to a human at the moment
+        of decision -- a social-engineering surface aimed at the approver,
+        adjacent to the presentation attacks of
+        <xref target="presentation-attacks"/>. A compromised or
+        prompt-injected initiator can state any trigger and any reason;
+        injection can change what the initiator <em>proposes</em>,
+        including this field, but it cannot change what a human
+        <em>approves</em> on their own hardware, because the device-bound
+        signature (<xref target="key-classes"/>) is outside the model
+        context. Conforming signing clients <bcp14>MUST</bcp14> therefore
+        render the <tt>statement</tt> as untrusted content: plain text
+        only, with no markup, links, or control characters rendered; the
+        280-character cap enforced; and visually distinct styling that
+        labels it as the initiator's unverified claim, clearly separated
+        from the operator-rendered Action Object. This is consistent with
+        the rendering-faithfulness discipline of
+        <xref target="presentation-attacks"/>: the approver's decision
+        input is the rendered Action Object; the statement is commentary
+        from a party the protocol never trusts. A related residual vector
+        is divide-and-misinform: because each approver signs their own
+        context, a malicious orchestrator can show different approvers of
+        an m-of-n receipt different attestations, and every individual
+        signature remains valid. The cross-context consistency rule
+        (<xref target="initiator-attestation"/>) exists for this;
+        verifiers implementing the member <bcp14>MUST</bcp14> flag
+        violations, but on verifiers that predate the member such a
+        receipt still verifies -- the rule is a conformance check, not a
+        signature property.</t>
+        <t>Privacy: statements written by an agent mid-task can leak
+        sensitive operational context -- counterparty details, internal
+        findings, fragments of prompts -- into receipts that are long-lived
+        and portable by design. Deployments <bcp14>SHOULD</bcp14> prefer
+        <tt>escalation_trigger</tt> plus <tt>policy_basis</tt> identifiers
+        over free text wherever a rule id captures the reason,
+        <bcp14>SHOULD</bcp14> constrain or template <tt>statement</tt>
+        generation for regulated data, and <bcp14>MUST</bcp14> apply the
+        same retention and disclosure controls to attestation content as
+        to the rest of the receipt.</t>
+        <t>Absence is not evidence: a receipt without an attestation means
+        only that the issuer did not populate it -- not that the initiator
+        judged the action routine, and not that no escalation reasoning
+        occurred. Verifiers and auditors <bcp14>MUST NOT</bcp14> infer
+        anything from the absence of an attestation alone. (Separately,
+        and unchanged: for an action a policy gates on signoff, the
+        absence of any valid receipt at all remains evidence that the
+        control was bypassed -- that property comes from the gate, not from
+        this member.)</t>
+        <t>No trust feedback: policy engines <bcp14>MUST NOT</bcp14> use
+        <tt>initiator_attestation</tt> content to relax thresholds, skip
+        approvers, or raise any trust score. The initiator must gain
+        nothing by saying the right words; the attestation is a claim by a
+        party the protocol identifies but never trusts, not proof of its
+        internal state.</t>
+      </section>
+      <section>
+        <name>No symmetric key on the verification trust path</name>
+        <t>Every artifact a relying party verifies offline -- the approver
+        signoff (Class A: ES256/P-256), the operator commit and receipt
+        (Ed25519), the log inclusion proof, and the portable revocation
+        statement (Ed25519) -- is bound by an ASYMMETRIC signature whose
+        verifying key the relying party holds independently of the issuer. No
+        step in offline verification relies on a Message Authentication Code, a
+        shared secret, or any symmetric primitive. This is deliberate and
+        load-bearing: a symmetric construction (for example an HMAC-chained
+        audit log) is verifiable only by a party holding the same secret as the
+        producer, so it does not provide public verification outside that trust
+        domain. An asymmetric issuer can still sign conflicting histories;
+        witness cosigning or gossip is required to detect that equivocation.
+        Conforming verifier
+        implementations <bcp14>MUST NOT</bcp14> introduce a symmetric primitive
+        on the verification path; an implementation that does so does not
+        provide EP's public-verifiability property. (HMAC <bcp14>MAY</bcp14> appear
+        elsewhere in a deployment -- e.g. authenticating an operator's own cron
+        or webhook calls -- provided it is never a link in the chain a third
+        party verifies.)</t>
+      </section>
+      <section anchor="canonicalization-robustness">
+        <name>Canonicalization Robustness</name>
+        <t>Every signed EP artifact is verified over its canonical JSON
+        form (<xref target="action-object"/>,
+        <xref target="authorization-context"/>), so any divergence
+        between two implementations' canonicalization behavior is a
+        signature-verification divergence and therefore a malleability
+        hazard. Implementations <bcp14>MUST</bcp14> reject the known
+        malleability hazard classes, and <bcp14>MUST</bcp14> reject them
+        identically: duplicate object member names (compared after
+        escape decoding), unpaired UTF-16 surrogate escapes, and inputs
+        outside the profile's number and depth bounds (non-integer
+        numbers or integers with magnitude greater than 2^53-1, and
+        container nesting deeper than the profile-pinned bound of 64).
+        The public EP-CANONICALIZATION-v1 vector suite exercises these
+        classes as raw JSON texts, with pinned SHA-256 digests over the
+        canonical bytes of every accepted input, across the
+        cross-language reference verifiers; divergence from the pinned
+        results is a conformance defect, not an implementation choice.
+        (In the reference stack the duplicate-name, surrogate, and depth
+        gates are applied at the parse boundary by the conformance
+        runners, since the verifier packages receive already-parsed
+        values; the profile predicate, canonical serialization, and
+        digests exercise the verifier packages themselves.)</t>
+      </section>
+    </section>
+    <section>
+      <name>IANA Considerations</name>
+      <t>This document has no IANA actions.  The extension-name registry in
+      <xref target="provisional-extension-registry"/> is provisional and
+      document-local.  A future version may request an IANA registry and may
+      register the <tt>application/ep-receipt+json</tt> media type.</t>
+    </section>
+  </middle>
+  <back>
+    <references>
+      <name>Normative References</name>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml"/>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"/>
+      <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8785.xml"/>
+      <reference anchor="WEBAUTHN" target="https://www.w3.org/TR/webauthn-2/">
+        <front>
+          <title>Web Authentication: An API for accessing Public Key Credentials, Level 2</title>
+          <author><organization>W3C</organization></author>
+          <date year="2021" month="April"/>
+        </front>
+      </reference>
+      <reference anchor="CIBA" target="https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html">
+        <front>
+          <title>OpenID Connect Client-Initiated Backchannel Authentication Flow - Core 1.0</title>
+          <author><organization>OpenID Foundation</organization></author>
+          <date year="2021" month="September"/>
+        </front>
+      </reference>
+    </references>
+    <references>
+      <name>Informative References</name>
+      <reference anchor="I-D.klrc-aiagent-auth" target="https://datatracker.ietf.org/doc/draft-klrc-aiagent-auth/">
+        <front>
+          <title>AI Agent Authentication and Authorization</title>
+          <author fullname="Pieter Kasselman"><organization>Defakto Security</organization></author>
+          <author fullname="Jeff Lombardo"><organization>AWS</organization></author>
+          <author fullname="Yaroslav Rosomakho"><organization>Zscaler</organization></author>
+          <author fullname="Brian Campbell"><organization>Ping Identity</organization></author>
+          <author fullname="Nick Steele"><organization>OpenAI</organization></author>
+          <author fullname="Aaron Parecki"><organization>Okta</organization></author>
+          <date year="2026" month="July" day="6"/>
+        </front>
+        <seriesInfo name="Internet-Draft" value="draft-klrc-aiagent-auth-03"/>
+      </reference>
+      <reference anchor="I-D.nelson-agent-delegation-receipts" target="https://datatracker.ietf.org/doc/draft-nelson-agent-delegation-receipts/">
+        <front>
+          <title>Delegation Receipt Protocol for AI Agent Authorization</title>
+          <author fullname="Ryan Nelson"><organization>Authproof</organization></author>
+          <date year="2026" month="June" day="13"/>
+        </front>
+        <seriesInfo name="Internet-Draft" value="draft-nelson-agent-delegation-receipts-10"/>
+      </reference>
+      <reference anchor="FIDO-VI" target="https://fidoalliance.org/building-the-trust-layer-for-agentic-payments-with-ap2-and-verifiable-intent/">
+        <front>
+          <title>Building the Trust Layer for Agentic Payments with AP2 and Verifiable Intent</title>
+          <author><organization>FIDO Alliance</organization></author>
+          <date year="2026" month="May" day="26"/>
+        </front>
+      </reference>
+      <reference anchor="AUTHZEN-AARP" target="https://openid.github.io/authzen/authzen-access-request-approval-profile-1_0.html">
+        <front>
+          <title>AuthZEN Access Request and Approval Profile - Draft 1</title>
+          <author><organization>OpenID Foundation</organization></author>
+          <date year="2026" month="July"/>
+        </front>
+      </reference>
+      <reference anchor="EP-BOUNDED-CAP" target="https://datatracker.ietf.org/doc/draft-schrock-ep-bounded-capability-receipts/">
+        <front>
+          <title>Bounded Capability Receipts and Durable Spend Control for Agent Actions</title>
+          <author fullname="Iman Schrock"/>
+          <date year="2026" month="July"/>
+        </front>
+        <seriesInfo name="Internet-Draft" value="draft-schrock-ep-bounded-capability-receipts-00"/>
+      </reference>
+      <reference anchor="FORMAL-STATUS" target="https://github.com/emiliaprotocol/emilia-protocol/blob/main/formal/PROOF_STATUS.md">
+        <front>
+          <title>EMILIA Formal Proof Status and Scope</title>
+          <author><organization>EMILIA Protocol</organization></author>
+          <date year="2026" month="July" day="10"/>
+        </front>
+      </reference>
+      <reference anchor="EXTERNAL-RUST-PIN" target="https://github.com/emiliaprotocol/emilia-protocol/blob/main/conformance/external/rust-cleanroom-jdieselny.v1.json">
+        <front>
+          <title>Time-Pinned External Rust Verifier Evaluation Record</title>
+          <author><organization>EMILIA Protocol</organization></author>
+          <date year="2026" month="July" day="11"/>
+        </front>
+      </reference>
+    </references>
+    <section anchor="changes-since-08" numbered="true">
+      <name>Changes since -08</name>
+      <ul>
+        <li>Changed the intended status from Informational to Standards Track;
+        the wire format, canonicalization, signature inputs, and consumption
+        rules are unchanged.</li>
+        <li>Clarified composition with the authorization-server, human-in-the-
+        loop, transaction-token, and audit requirements in
+        <xref target="I-D.klrc-aiagent-auth"/> without treating confirmation
+        evidence as authorization.</li>
+      </ul>
+    </section>
+    <section anchor="changes-since-07" numbered="true">
+      <name>Changes since -07</name>
+      <ul>
+        <li>Added the separate <tt>EP-RECEIPT-EXTENSIONS-v1</tt> companion
+        envelope, a bind-by-digest procedure, and a provisional extension
+        namespace and registry design.  The base Trust Receipt schema, parser,
+        canonical bytes, signature inputs, consumption rules, and log-proof
+        verification remain unchanged; a base verifier never strips or ignores
+        a new receipt member.</li>
+        <li>Defined one common base action, base receipt, operation, and
+        consequence seam for companion artifacts.</li>
+        <li>Added informative, non-exhaustive lifecycle examples including
+        revocation, outcome binding, action remedy, evidence challenge,
+        Authorization Evidence Chain composition, Authority Program stage
+        receipts, and staged DTC settlement binding.  No implementation,
+        deployment, or standards-adoption claim is made for an example merely
+        because it is named here.</li>
+      </ul>
+    </section>
+    <section anchor="changes-since-06" numbered="true">
+      <name>Changes since -06</name>
+      <ul>
+        <li>Narrowed the abstract and introduction from category-wide
+        novelty claims to the guarantees of the selected EP verification
+        profile.</li>
+        <li>Scoped ConsumeOnce to one conforming shared atomic consumption
+        domain and stated that offline evidence cannot prove global
+        non-replay across independent executors.</li>
+        <li>Replaced legal non-repudiation language with cryptographic
+        attribution, tamper evidence, and public verifiability; stated the
+        issuer-equivocation boundary.</li>
+        <li>Added the CAID Action-Mapping composition boundary without
+        changing the EP v1 signature input.</li>
+        <li>Added Mastercard Verifiable Intent and AuthZEN AARP as adjacent,
+        composable work.</li>
+        <li>Clarified that a receipt can authorize and be consumed for
+        capability issuance, but cannot be reused as per-operation approval;
+        the capability protocol binds the full issuance-receipt digest.</li>
+      </ul>
+    </section>
+    <section anchor="changes-since-04" numbered="true">
+      <name>Changes since -04</name>
+      <t>-05 adds the human-authorization-receipt composition frame for
+      the SCITT agent-action statement cluster (how a WHO receipt is
+      referenced, by digest, from capsule/record-style statements);
+      updates the SCITT citation to RFC 9943; adds the key-custody
+      disambiguation note in Section 5.1 (key classes classify custody,
+      not assurance levels); corrects the formal-models status (the
+      m-of-n quorum flow is now Alloy-checked) and states plainly which
+      three normative mechanisms the reference implementation does not
+      yet cover.</t>
+    </section>
+    <section anchor="changes-since-00" numbered="true">
+      <name>Changes since -00 (through -04)</name>
+      <t>This summary covers -00 through -04. Section
+      numbering is stable; all changes are new subsections or in-place
+      additions.</t>
+      <ol>
+        <li>New <bcp14>OPTIONAL</bcp14> Authorization Context member
+        <tt>initiator_attestation</tt> (new
+        <xref target="initiator-attestation"/>): a
+        <bcp14>REQUIRED</bcp14> <tt>escalation_trigger</tt> enum
+        (<tt>irreversibility</tt>, <tt>magnitude</tt>,
+        <tt>uncertainty</tt>, <tt>novelty</tt>, <tt>authority_gap</tt>,
+        <tt>policy_rule</tt>), an <bcp14>OPTIONAL</bcp14>
+        <tt>policy_basis</tt> rule identifier, and an
+        <bcp14>OPTIONAL</bcp14> length-capped (&lt;= 280 character)
+        <tt>statement</tt>. The member is <bcp14>OPTIONAL</bcp14>;
+        it is covered by the context hash via the JCS canonicalization
+        already normative in <xref target="authorization-context"/>, so
+        the approver's signature covers the stated reason; receipts
+        carrying it verify under the existing
+        <xref target="offline-verification"/> verifiers unmodified; and it
+        is a claim by the initiator -- identified but never trusted -- not
+        proof of the initiator's internal state. A terminology entry and a
+        step-2 note in <xref target="offline-verification"/> were added
+        accordingly.</li>
+        <li>Security Considerations additions (new
+        <xref target="initiator-attestation-security"/>): the
+        <tt>statement</tt> is attacker-influenceable text presented to a
+        human (prompt-injection -> social-engineering surface); conforming
+        signing clients <bcp14>MUST</bcp14> render it as untrusted content
+        (no markup, length cap, distinct styling), consistent with the
+        <xref target="presentation-attacks"/> rendering-faithfulness
+        caveat. Adds privacy guidance for free-text statements in
+        long-lived receipts (prefer <tt>policy_basis</tt> identifiers),
+        the rule that absence of an attestation is not evidence of
+        non-escalation, the cross-context consistency requirement, and the
+        prohibition on using attestation content as a trust input. The
+        formal-models section now lists the Initiator Attestation among
+        the not-yet-modeled areas.</li>
+        <li>Introduction/terminology clarifications (new text in the
+        Introduction, new <xref target="scope-of-identity"/>, and a
+        sentence in <xref target="key-classes"/> and
+        <xref target="approver-directory"/>): makes unmistakable that
+        (a) EP's user-verification-gated Class-A signoff is native to this
+        draft and does not depend on any other draft's
+        acquiescence/confirmation mechanism, and (b) proof of a specific
+        natural-person identity is out of scope -- the Approver Directory
+        trust root is the explicit slot where identity/key-discovery
+        layers bind keys to named persons.</li>
+        <li>New <bcp14>OPTIONAL</bcp14> Authorization Context member
+        <tt>agent_binding</tt> (new <xref target="agent-binding"/>): an
+        external agent-identity reference (<tt>agent_id</tt>) and an
+        <bcp14>OPTIONAL</bcp14> <tt>delegation</tt> (<tt>scheme</tt>,
+        <tt>ref</tt>, <bcp14>OPTIONAL</bcp14> <tt>hash</tt>,
+        <bcp14>OPTIONAL</bcp14> <tt>observed_at</tt>), plus an
+        <bcp14>OPTIONAL</bcp14> length-capped (&lt;= 280 character)
+        <tt>statement</tt>. Like <tt>initiator_attestation</tt>, it is
+        <bcp14>OPTIONAL</bcp14>, covered by the context hash via the JCS
+        canonicalization already normative in
+        <xref target="authorization-context"/>, verifies under the existing
+        <xref target="offline-verification"/> verifiers unmodified, and is a
+        claim -- identified but never trusted -- not proof of the agent's
+        identity or the delegation's validity. The <bcp14>OPTIONAL</bcp14>
+        <tt>delegation.observed_at</tt> records when the upstream
+        identity/delegation (L4) evidence was observed; a relying party
+        <bcp14>MAY</bcp14> enforce freshness against it fail-closed, keeping
+        the receipt agnostic to which external identity scheme prevails while
+        making a stale or unconstrained upstream claim detectable after the
+        fact.</li>
+        <li>Housekeeping: version and date bumped in the header; this
+        appendix added; the idnits non-ASCII em-dash / curly-quote cleanup
+        from -00 carried forward as a build step.</li>
+      </ol>
+    </section>
+  </back>
+</rfc>


### PR DESCRIPTION
## Outcome

Stages `draft-schrock-ep-authorization-receipts-09` as the Standards Track candidate while preserving the boundary that a receipt is evidence, not authorization. The revision adds related-work positioning and grouped companion references without changing the receipt schema, canonicalization, signature inputs, or consumption rules.

The upload XML remains an individual submission: it does not claim an adopted IETF document stream.

## Verification

- `xml2rfc 3.34.0` renders TXT and HTML
- `idnits 3.1.0 -m submission` passes on XML and TXT with zero nits
- `node scripts/check-authorization-receipts-09.mjs`
- `node scripts/check-standards-staged.mjs`
- `git diff --check`

The isolated upload directory contains exactly one XML source; Additional Resources are pre-keyed separately.