### PR TITLE
Reconcile consequence-control migration history

### DIFF
--- a/supabase/migration-history.v1.json
+++ b/supabase/migration-history.v1.json
@@ -1,17 +1,13 @@
 {
   "schema_version": "EP-MIGRATION-HISTORY-v1",
   "as_of": "2026-08-03",
-  "remote_head": "20260803010000",
+  "remote_head": "20260803231000",
   "private_remote_versions": [
     "20260723192504"
   ],
   "retroactive_pending_versions": [],
-  "forward_pending_versions": [
-    "20260803020000"
-  ],
-  "deployment_sequence": [
-    "20260803020000"
-  ],
+  "forward_pending_versions": [],
+  "deployment_sequence": [],
   "requires_include_all": false,
   "remote_versions": [
     "001",
@@ -203,7 +199,10 @@
     "20260802230000",
     "20260802231000",
     "20260802232000",
-    "20260803010000"
+    "20260803010000",
+    "20260803020000",
+    "20260803230000",
+    "20260803231000"
   ],
   "public_files": {
     "001_emilia_core_schema.sql": "f5e3c6c40fdaf54fbfc7a986f1b7cb021bfa8bee21a81bac39fe2da15f654060",
@@ -395,6 +394,8 @@
     "20260802231000_restore_webauthn_directory_anchor.sql": "90bb596edff8f495de541ab5df582fb45023abff077fc527a48eea4e635afd76",
     "20260802232000_scim_authority_atomic.sql": "334619a03c3a089d3ae038ab9b20dd4c3dab28a9af0eff0b12ac3b2bdfd38e92",
     "20260803010000_capability_action_digest_fence.sql": "cb3ace0456137a5c0286ddd84c4552c402181193827aedb03d94e6fab0eeee5e",
-    "20260803020000_agent_record_v1.sql": "096c5ccbfd181d0df9ce33692f95695ef4a45853ec6eba751ebceb70fac9b29a"
+    "20260803020000_agent_record_v1.sql": "096c5ccbfd181d0df9ce33692f95695ef4a45853ec6eba751ebceb70fac9b29a",
+    "20260803230000_tenant_panic_control.sql": "08b22e339481d5a40336d7cfae08032fa439f1fa62976d2a3373b603361e5781",
+    "20260803231000_signoff_ceremony_velocity.sql": "f88f2a3a25d9f384ba63a60fa76019ecda531a4b432d73b4c4a1686df7ea82d4"
   }
 }


### PR DESCRIPTION
## What changed

- Recorded `20260803020000_agent_record_v1` as deployed after verifying the production Supabase migration ledger.
- Applied `20260803230000_tenant_panic_control` and `20260803231000_signoff_ceremony_velocity` to production in their declared order.
- Recorded both consequence-control migrations as deployed and added their exact SHA-256 pins.

## Why

The Gate Product job was failing because two executable SQL migrations were absent from `public_files`. The governed ledger also still marked `20260803020000` pending even though production reports it applied. The live-schema contract then confirmed the two consequence-control migrations themselves had not reached production.

## Verification

- Production Supabase project `xmiiwehtivksdjbultym` is active and healthy.
- Production migration journal now ends at `20260803231000`.
- Verified both new tables and both public RPC functions exist.
- `npm run check:migration-history` — 193 remote, 1 private, 0 pending; hashes and archive verified.
- `npx vitest run tests/migration-history.test.ts` — 8/8 passed.
- `git diff --check`.

The commit includes the required DCO sign-off.