### PR TITLE
Add AOP policy-binding interoperability vector

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -215,6 +215,7 @@ examples/action-escrow/scenario.test.mjs linguist-generated=true
 examples/action-escrow/standalone.test.mjs linguist-generated=true
 examples/admissibility/admissibility-vector.mjs linguist-generated=true
 examples/adverse-determination.mjs linguist-generated=true
+examples/agent-operation-authorization/policy-binding.mjs linguist-generated=true
 examples/async-signoff.mjs linguist-generated=true
 examples/audit/agentic-audit-trail-demo.mjs linguist-generated=true
 examples/authority/authority-closure-vector.mjs linguist-generated=true

--- a/examples/agent-operation-authorization/README.md
+++ b/examples/agent-operation-authorization/README.md
@@ -1,0 +1,61 @@
+# Agent Operation Authorization: Policy-Resolution Binding Review Vector
+
+This runnable review vector targets one narrow interoperability question in
+[`draft-liu-agent-operation-authorization-02`](https://datatracker.ietf.org/doc/draft-liu-agent-operation-authorization/):
+does an Agent Operation Authorization Token identify immutable policy content,
+or only a policy locator whose meaning can change after confirmation?
+
+The draft places `agent_operation_authorization.policy_id` in the signed token.
+It separately describes the proposal as a Rego policy and says the
+Authorization Server presents the rendered operation to the user. The current
+text does not state that `policy_id` is immutable, versioned, or bound to the
+approved policy bytes.
+
+## Reproduced ambiguity
+
+The vector keeps all of these values unchanged:
+
+- the signed JWT bytes and valid Authorization Server signature;
+- `policy_id = "opa-policy-789"`;
+- the confirmation record saying `Permit purchases up to USD 50.00`; and
+- the operation presented to the Resource Server.
+
+Only the policy registry changes. At confirmation, the identifier resolves to
+a Rego rule capped at USD 50. At execution, the same identifier resolves to a
+rule capped at USD 5,000. A USD 500 operation is then allowed by the resolved
+policy even though the token remains byte-for-byte unchanged.
+
+That does **not** establish that the draft is vulnerable or that any deployed
+implementation uses mutable aliases. It establishes a portability gap: from
+the token alone, an independent verifier cannot distinguish an immutable
+deployment from a changed-semantics deployment. The honest portable verdict is
+`INDETERMINATE`.
+
+## Candidate repair
+
+The comparison profile binds a digest of the complete policy-resolution tuple:
+
+- policy media type;
+- language version;
+- evaluation entrypoint;
+- input-schema digest; and
+- exact policy source bytes.
+
+Before evaluating the policy, the Resource Server recomputes that digest from
+the resolved policy and refuses `policy_digest_mismatch`. A specification could
+instead define `policy_id` as an immutable content address; the required
+property is the same.
+
+## Run
+
+```bash
+node examples/agent-operation-authorization/policy-binding.mjs
+```
+
+The source vector is
+[`policy-alias-substitution.v1.json`](./policy-alias-substitution.v1.json).
+
+This is an implementation review artifact, not an EMILIA extension claim. It
+exists so the draft authors can confirm whether the current text already
+intends immutable policy resolution, reject the model, or adopt a testable
+binding rule.

--- a/examples/agent-operation-authorization/policy-alias-substitution.v1.json
+++ b/examples/agent-operation-authorization/policy-alias-substitution.v1.json
@@ -1,0 +1,50 @@
+{
+  "profile": "AOP-POLICY-RESOLUTION-BINDING-REVIEW-v0",
+  "source_draft": "draft-liu-agent-operation-authorization-02",
+  "finding": "signed_token_changed_policy_semantics",
+  "token_claims": {
+    "evidence": {
+      "user_confirmation_record": {
+        "displayed_content": "Permit purchases up to USD 50.00",
+        "user_action": "confirmed_via_button_click",
+        "timestamp": 1785780000
+      }
+    },
+    "agent_operation_authorization": {
+      "policy_id": "opa-policy-789"
+    }
+  },
+  "policy_at_confirmation": {
+    "policy_id": "opa-policy-789",
+    "media_type": "application/rego",
+    "language_version": "rego.v1",
+    "entrypoint": "data.agent.allow",
+    "input_schema_digest": "sha256:8a3fe3d7433982f5905ed8bb8bb2f79d64b3f30f7d55c94175e75eddb645e9f9",
+    "source": "package agent\n\ndefault allow := false\n\nallow if { input.transaction.amount <= 50.0 }"
+  },
+  "policy_at_execution": {
+    "policy_id": "opa-policy-789",
+    "media_type": "application/rego",
+    "language_version": "rego.v1",
+    "entrypoint": "data.agent.allow",
+    "input_schema_digest": "sha256:8a3fe3d7433982f5905ed8bb8bb2f79d64b3f30f7d55c94175e75eddb645e9f9",
+    "source": "package agent\n\ndefault allow := false\n\nallow if { input.transaction.amount <= 5000.0 }"
+  },
+  "attempted_input": {
+    "transaction": {
+      "amount": 500
+    }
+  },
+  "expected": {
+    "unbound_resolution": {
+      "token_signature": "valid",
+      "policy_id": "unchanged",
+      "resolved_policy_decision": "allow",
+      "portable_verdict": "INDETERMINATE"
+    },
+    "digest_bound_resolution": {
+      "verdict": "REFUSED",
+      "reason": "policy_digest_mismatch"
+    }
+  }
+}

--- a/examples/agent-operation-authorization/policy-binding.mjs
+++ b/examples/agent-operation-authorization/policy-binding.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Generated from policy-binding.mts by scripts/build-standalone-runtimes.mjs. Do not edit.
+/* eslint-disable */
+/**
+ * Review vector for draft-liu-agent-operation-authorization-02.
+ *
+ * The draft's signed token carries policy_id while the executable Rego policy
+ * is resolved separately. This lab shows that a token can remain byte-for-byte
+ * identical and signature-valid while the policy behind that identifier gains
+ * broader semantics. The candidate repair binds the complete policy-resolution
+ * descriptor by digest and refuses before evaluation when it changes.
+ *
+ * This is an interoperability review artifact, not a claim that the draft
+ * requires mutable policy identifiers or that any implementation is vulnerable.
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import { SignJWT, jwtVerify } from 'jose';
+import { canonicalize } from '../../packages/issue/index.js';
+const VECTOR_URL = new URL('./policy-alias-substitution.v1.json', import.meta.url);
+const ISSUER = 'https://as.example';
+const AUDIENCE = 'https://api.online-shop.example';
+const SUBJECT = 'user_12345@myassistant.example';
+const KEY_ID = 'as.example#operation-authorization-1';
+function readVector() {
+    return JSON.parse(fs.readFileSync(VECTOR_URL, 'utf8'));
+}
+function sha256(value) {
+    return `sha256:${crypto.createHash('sha256').update(value, 'utf8').digest('hex')}`;
+}
+/** Bind the full interpretation tuple, not only the Rego source bytes. */
+export function policyResolutionDigest(policy) {
+    return sha256(canonicalize({
+        media_type: policy.media_type,
+        language_version: policy.language_version,
+        entrypoint: policy.entrypoint,
+        input_schema_digest: policy.input_schema_digest,
+        source: policy.source,
+    }));
+}
+function policyAllows(policy, amount) {
+    const match = /input\.transaction\.amount\s*<=\s*([0-9]+(?:\.[0-9]+)?)/u.exec(policy.source);
+    if (!match)
+        throw new Error('review vector contains an unsupported Rego expression');
+    return amount <= Number(match[1]);
+}
+function confirmedDisplayLimit(claims) {
+    const content = claims.evidence?.user_confirmation_record?.displayed_content;
+    const match = typeof content === 'string'
+        ? /\bUSD\s+([0-9]+(?:\.[0-9]+)?)/u.exec(content)
+        : null;
+    if (!match)
+        throw new Error('review vector does not state a parseable displayed USD limit');
+    return Number(match[1]);
+}
+async function issueToken({ claims, privateKey, policyDigest }) {
+    const authorization = structuredClone(claims.agent_operation_authorization);
+    if (policyDigest) {
+        authorization.policy_binding = {
+            digest: policyDigest,
+            profile: 'AOP-POLICY-RESOLUTION-BINDING-v0',
+        };
+    }
+    return new SignJWT({
+        evidence: claims.evidence,
+        agent_operation_authorization: authorization,
+    })
+        .setProtectedHeader({ alg: 'ES256', kid: KEY_ID, typ: 'at+jwt' })
+        .setIssuer(ISSUER)
+        .setAudience(AUDIENCE)
+        .setSubject(SUBJECT)
+        .setJti('urn:uuid:1c89dcaa-93f5-43df-8188-e75559fce629')
+        .setIssuedAt(1785780010)
+        .setExpirationTime(1785783610)
+        .sign(privateKey);
+}
+async function verifyToken(token, publicKey) {
+    return jwtVerify(token, publicKey, {
+        issuer: ISSUER,
+        audience: AUDIENCE,
+        algorithms: ['ES256'],
+        typ: 'at+jwt',
+        currentDate: new Date(1785780100 * 1000),
+    });
+}
+export async function runAgentOperationAuthorizationPolicyBindingLab({ resolveApprovedPolicyAtExecution = false, attemptedAmount, } = {}) {
+    const vector = readVector();
+    const amount = attemptedAmount ?? vector.attempted_input.transaction.amount;
+    const policyAtConfirmation = vector.policy_at_confirmation;
+    const policyAtExecution = resolveApprovedPolicyAtExecution
+        ? policyAtConfirmation
+        : vector.policy_at_execution;
+    const confirmationDigest = policyResolutionDigest(policyAtConfirmation);
+    const executionDigest = policyResolutionDigest(policyAtExecution);
+    const displayedLimit = confirmedDisplayLimit(vector.token_claims);
+    const asKey = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    const unboundToken = await issueToken({
+        claims: vector.token_claims,
+        privateKey: asKey.privateKey,
+    });
+    const tokenAtConfirmation = unboundToken;
+    const tokenAtExecution = unboundToken;
+    const unboundVerification = await verifyToken(tokenAtExecution, asKey.publicKey);
+    const unboundAuthorization = unboundVerification.payload.agent_operation_authorization;
+    const unboundPolicyId = unboundAuthorization?.policy_id;
+    const unboundAllows = policyAllows(policyAtExecution, amount);
+    const boundToken = await issueToken({
+        claims: vector.token_claims,
+        privateKey: asKey.privateKey,
+        policyDigest: confirmationDigest,
+    });
+    const boundVerification = await verifyToken(boundToken, asKey.publicKey);
+    const boundAuthorization = boundVerification.payload.agent_operation_authorization;
+    const boundDigest = boundAuthorization?.policy_binding?.digest;
+    const policyBindingValid = boundDigest === executionDigest;
+    return {
+        '@version': vector.profile,
+        source_draft: vector.source_draft,
+        finding: vector.finding,
+        same_signed_token: tokenAtConfirmation === tokenAtExecution,
+        same_policy_id: unboundPolicyId === policyAtConfirmation.policy_id
+            && policyAtConfirmation.policy_id === policyAtExecution.policy_id,
+        policy_at_confirmation: {
+            policy_id: policyAtConfirmation.policy_id,
+            digest: confirmationDigest,
+        },
+        policy_at_execution: {
+            policy_id: policyAtExecution.policy_id,
+            digest: executionDigest,
+        },
+        unbound_resolution: {
+            token_signature_valid: true,
+            displayed_limit: displayedLimit,
+            attempted_amount: amount,
+            resolved_policy_allows: unboundAllows,
+            substitution_detectable_from_token: false,
+            portable_verdict: 'INDETERMINATE',
+        },
+        digest_bound_resolution: {
+            token_signature_valid: true,
+            policy_binding_valid: policyBindingValid,
+            resolved_policy_allows: policyBindingValid && policyAllows(policyAtExecution, amount),
+            reason: policyBindingValid ? null : 'policy_digest_mismatch',
+        },
+    };
+}
+function printLab(result) {
+    console.log(JSON.stringify(result, null, 2));
+}
+if (import.meta.url === `file://${process.argv[1]}`) {
+    printLab(await runAgentOperationAuthorizationPolicyBindingLab());
+}

--- a/examples/agent-operation-authorization/policy-binding.mts
+++ b/examples/agent-operation-authorization/policy-binding.mts
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Review vector for draft-liu-agent-operation-authorization-02.
+ *
+ * The draft's signed token carries policy_id while the executable Rego policy
+ * is resolved separately. This lab shows that a token can remain byte-for-byte
+ * identical and signature-valid while the policy behind that identifier gains
+ * broader semantics. The candidate repair binds the complete policy-resolution
+ * descriptor by digest and refuses before evaluation when it changes.
+ *
+ * This is an interoperability review artifact, not a claim that the draft
+ * requires mutable policy identifiers or that any implementation is vulnerable.
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import { SignJWT, jwtVerify } from 'jose';
+import { canonicalize } from '../../packages/issue/index.js';
+
+const VECTOR_URL = new URL('./policy-alias-substitution.v1.json', import.meta.url);
+const ISSUER = 'https://as.example';
+const AUDIENCE = 'https://api.online-shop.example';
+const SUBJECT = 'user_12345@myassistant.example';
+const KEY_ID = 'as.example#operation-authorization-1';
+
+type PolicyDescriptor = {
+  policy_id: string;
+  media_type: string;
+  language_version: string;
+  entrypoint: string;
+  input_schema_digest: string;
+  source: string;
+};
+
+type ReviewVector = {
+  profile: string;
+  source_draft: string;
+  finding: string;
+  token_claims: Record<string, any>;
+  policy_at_confirmation: PolicyDescriptor;
+  policy_at_execution: PolicyDescriptor;
+  attempted_input: { transaction: { amount: number } };
+};
+
+type LabOptions = {
+  resolveApprovedPolicyAtExecution?: boolean;
+  attemptedAmount?: number;
+};
+
+function readVector(): ReviewVector {
+  return JSON.parse(fs.readFileSync(VECTOR_URL, 'utf8')) as ReviewVector;
+}
+
+function sha256(value: string): string {
+  return `sha256:${crypto.createHash('sha256').update(value, 'utf8').digest('hex')}`;
+}
+
+/** Bind the full interpretation tuple, not only the Rego source bytes. */
+export function policyResolutionDigest(policy: PolicyDescriptor): string {
+  return sha256(canonicalize({
+    media_type: policy.media_type,
+    language_version: policy.language_version,
+    entrypoint: policy.entrypoint,
+    input_schema_digest: policy.input_schema_digest,
+    source: policy.source,
+  }));
+}
+
+function policyAllows(policy: PolicyDescriptor, amount: number): boolean {
+  const match = /input\.transaction\.amount\s*<=\s*([0-9]+(?:\.[0-9]+)?)/u.exec(policy.source);
+  if (!match) throw new Error('review vector contains an unsupported Rego expression');
+  return amount <= Number(match[1]);
+}
+
+function confirmedDisplayLimit(claims: Record<string, any>): number {
+  const content = claims.evidence?.user_confirmation_record?.displayed_content;
+  const match = typeof content === 'string'
+    ? /\bUSD\s+([0-9]+(?:\.[0-9]+)?)/u.exec(content)
+    : null;
+  if (!match) throw new Error('review vector does not state a parseable displayed USD limit');
+  return Number(match[1]);
+}
+
+async function issueToken({ claims, privateKey, policyDigest }: {
+  claims: Record<string, any>;
+  privateKey: crypto.KeyObject;
+  policyDigest?: string;
+}): Promise<string> {
+  const authorization = structuredClone(claims.agent_operation_authorization);
+  if (policyDigest) {
+    authorization.policy_binding = {
+      digest: policyDigest,
+      profile: 'AOP-POLICY-RESOLUTION-BINDING-v0',
+    };
+  }
+  return new SignJWT({
+    evidence: claims.evidence,
+    agent_operation_authorization: authorization,
+  })
+    .setProtectedHeader({ alg: 'ES256', kid: KEY_ID, typ: 'at+jwt' })
+    .setIssuer(ISSUER)
+    .setAudience(AUDIENCE)
+    .setSubject(SUBJECT)
+    .setJti('urn:uuid:1c89dcaa-93f5-43df-8188-e75559fce629')
+    .setIssuedAt(1785780010)
+    .setExpirationTime(1785783610)
+    .sign(privateKey);
+}
+
+async function verifyToken(token: string, publicKey: crypto.KeyObject) {
+  return jwtVerify(token, publicKey, {
+    issuer: ISSUER,
+    audience: AUDIENCE,
+    algorithms: ['ES256'],
+    typ: 'at+jwt',
+    currentDate: new Date(1785780100 * 1000),
+  });
+}
+
+export async function runAgentOperationAuthorizationPolicyBindingLab({
+  resolveApprovedPolicyAtExecution = false,
+  attemptedAmount,
+}: LabOptions = {}) {
+  const vector = readVector();
+  const amount = attemptedAmount ?? vector.attempted_input.transaction.amount;
+  const policyAtConfirmation = vector.policy_at_confirmation;
+  const policyAtExecution = resolveApprovedPolicyAtExecution
+    ? policyAtConfirmation
+    : vector.policy_at_execution;
+  const confirmationDigest = policyResolutionDigest(policyAtConfirmation);
+  const executionDigest = policyResolutionDigest(policyAtExecution);
+  const displayedLimit = confirmedDisplayLimit(vector.token_claims);
+
+  const asKey = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+  const unboundToken = await issueToken({
+    claims: vector.token_claims,
+    privateKey: asKey.privateKey,
+  });
+  const tokenAtConfirmation = unboundToken;
+  const tokenAtExecution = unboundToken;
+  const unboundVerification = await verifyToken(tokenAtExecution, asKey.publicKey);
+  const unboundAuthorization = unboundVerification.payload.agent_operation_authorization as
+    | { policy_id?: unknown }
+    | undefined;
+  const unboundPolicyId = unboundAuthorization?.policy_id;
+  const unboundAllows = policyAllows(policyAtExecution, amount);
+
+  const boundToken = await issueToken({
+    claims: vector.token_claims,
+    privateKey: asKey.privateKey,
+    policyDigest: confirmationDigest,
+  });
+  const boundVerification = await verifyToken(boundToken, asKey.publicKey);
+  const boundAuthorization = boundVerification.payload.agent_operation_authorization as
+    | { policy_binding?: { digest?: unknown } }
+    | undefined;
+  const boundDigest = boundAuthorization?.policy_binding?.digest;
+  const policyBindingValid = boundDigest === executionDigest;
+
+  return {
+    '@version': vector.profile,
+    source_draft: vector.source_draft,
+    finding: vector.finding,
+    same_signed_token: tokenAtConfirmation === tokenAtExecution,
+    same_policy_id: unboundPolicyId === policyAtConfirmation.policy_id
+      && policyAtConfirmation.policy_id === policyAtExecution.policy_id,
+    policy_at_confirmation: {
+      policy_id: policyAtConfirmation.policy_id,
+      digest: confirmationDigest,
+    },
+    policy_at_execution: {
+      policy_id: policyAtExecution.policy_id,
+      digest: executionDigest,
+    },
+    unbound_resolution: {
+      token_signature_valid: true,
+      displayed_limit: displayedLimit,
+      attempted_amount: amount,
+      resolved_policy_allows: unboundAllows,
+      substitution_detectable_from_token: false,
+      portable_verdict: 'INDETERMINATE',
+    },
+    digest_bound_resolution: {
+      token_signature_valid: true,
+      policy_binding_valid: policyBindingValid,
+      resolved_policy_allows: policyBindingValid && policyAllows(policyAtExecution, amount),
+      reason: policyBindingValid ? null : 'policy_digest_mismatch',
+    },
+  };
+}
+
+function printLab(result: Awaited<ReturnType<typeof runAgentOperationAuthorizationPolicyBindingLab>>) {
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  printLab(await runAgentOperationAuthorizationPolicyBindingLab());
+}

--- a/lib/proof-stats.json
+++ b/lib/proof-stats.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-08-04T08:22:48.243Z",
+  "generatedAt": "2026-08-04T08:41:29.579Z",
   "tests": {
-    "total": 8676,
-    "files": 512,
+    "total": 8678,
+    "files": 513,
     "policy": "all platform-applicable cases must pass; platform-specific cases may skip"
   },
   "tla": {

--- a/tests/agent-operation-authorization-policy-binding.test.ts
+++ b/tests/agent-operation-authorization-policy-binding.test.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import {
+  runAgentOperationAuthorizationPolicyBindingLab,
+} from '../examples/agent-operation-authorization/policy-binding.mjs';
+
+describe('Agent Operation Authorization policy-resolution binding', () => {
+  it('reproduces a valid-signature policy-alias substitution and refuses it with a digest binding', async () => {
+    const result = await runAgentOperationAuthorizationPolicyBindingLab();
+
+    expect(result.source_draft).toBe('draft-liu-agent-operation-authorization-02');
+    expect(result.finding).toBe('signed_token_changed_policy_semantics');
+    expect(result.same_signed_token).toBe(true);
+    expect(result.same_policy_id).toBe(true);
+    expect(result.policy_at_confirmation.digest).not.toBe(result.policy_at_execution.digest);
+
+    expect(result.unbound_resolution).toMatchObject({
+      token_signature_valid: true,
+      displayed_limit: 50,
+      attempted_amount: 500,
+      resolved_policy_allows: true,
+      substitution_detectable_from_token: false,
+      portable_verdict: 'INDETERMINATE',
+    });
+
+    expect(result.digest_bound_resolution).toMatchObject({
+      token_signature_valid: true,
+      policy_binding_valid: false,
+      resolved_policy_allows: false,
+      reason: 'policy_digest_mismatch',
+    });
+  });
+
+  it('accepts the approved policy bytes under the same digest-bound profile', async () => {
+    const result = await runAgentOperationAuthorizationPolicyBindingLab({
+      resolveApprovedPolicyAtExecution: true,
+      attemptedAmount: 25,
+    });
+
+    expect(result.digest_bound_resolution).toMatchObject({
+      token_signature_valid: true,
+      policy_binding_valid: true,
+      resolved_policy_allows: true,
+      reason: null,
+    });
+  });
+});

--- a/tests/gate-qualification-product-boundary.test.ts
+++ b/tests/gate-qualification-product-boundary.test.ts
@@ -16,7 +16,6 @@ describe('Gate Qualification v2 public product boundary', () => {
       'app/HomePageClient.tsx',
       'app/gate/page.tsx',
       'app/pricing/page.tsx',
-      'app/investors/page.tsx',
       'app/proof/page.tsx',
     ].map(read);
 
@@ -56,7 +55,8 @@ describe('Gate Qualification v2 public product boundary', () => {
     expect(pricing).toContain('PRODUCTION_GATE.scopeLabel');
     expect(pricing).toContain('PRODUCTION_GATE.availabilityLabel');
     expect(pricing).toContain("cta: { label: 'Scope a deployment'");
-    expect(investors).toContain('PRODUCTION_GATE.availabilityLabel');
+    expect(investors).toContain('PRODUCTION_GATE.priceLabel');
+    expect(investors).toContain('operated Gate follow only after the boundary is accepted');
     expect(homepage).not.toContain('Open the live Gate');
     expect(gate).not.toContain('Open live Gate');
   });

--- a/tests/homepage-category.test.ts
+++ b/tests/homepage-category.test.ts
@@ -112,10 +112,10 @@ describe('homepage category contract', () => {
     expect(gate).toContain('RECEIPT PROGRAMS');
     expect(gate).toContain('npm run demo:receipt-program');
     expect(gate).toContain('It is not a ZK proof, consensus result, provider attestation');
-    expect(investors).toContain('CAID names the material action; AEB joins independently verified evidence');
-    expect(investors).toContain('Neither authorizes. Gate applies local policy');
-    expect(investors).toContain('They are not RFCs, working-group items, adopted standards, or IETF endorsement.');
-    expect(investors).toContain('No production hardware-attestation fleet or independently operated witness network is claimed today.');
+    expect(investors).toContain('EMILIA Gate is the Consequence Firewall for autonomous software.');
+    expect(investors).toContain('Identity proves who or what is present. Policy describes a rule. Neither proves that one exact consequential action may proceed now, once, under current limits.');
+    expect(investors).toContain('currently claims no customer traction, recurring revenue, live payer integration');
+    expect(investors).toContain('certification, RFC status, or standards-body endorsement.');
     expect(productBrief).toContain('No independently administered operator has produced external witness evidence');
     expect(productBrief).toContain('they do not prove the deployed service, provider, or physical world.');
   });

--- a/tests/site-product-navigation.test.ts
+++ b/tests/site-product-navigation.test.ts
@@ -10,19 +10,18 @@ describe('public product naming and navigation contract', () => {
   it('keeps every top-navigation destination with a slash-form label', () => {
     const navigation = read('components/SiteNav.tsx');
     const expectedLinks = [
-      ['/signal', '/signal'],
       ['/gate', '/gate'],
       ['/use-cases', '/solutions'],
-      ['/assurance', '/assurance'],
-      ['/grace', '/grace'],
-      ['/model-to-matter', '/model-to-matter'],
+      ['/docs', '/developers'],
       ['/protocol', '/protocol'],
       ['/proof', '/proof'],
-      ['/docs', '/docs'],
       ['/pricing', '/pricing'],
     ];
     for (const [href, label] of expectedLinks) {
       expect(navigation).toContain(`[\'${href}\', \'${label}\']`);
+    }
+    for (const promotedExperiment of ['/signal', '/assurance', '/grace', '/model-to-matter']) {
+      expect(navigation).not.toContain(`[\'${promotedExperiment}\', \'${promotedExperiment}\']`);
     }
   });
 


### PR DESCRIPTION
Adds a reproducible policy-alias substitution review vector for Agent Operation Policy interoperability.

Also aligns governed site-claim tests with the merged Gate-first investor and navigation surfaces.

Verified locally:
- focused AOP vector tests: 2/2
- affected governed site tests: 9/9
- core typecheck and lint
- complete proof regeneration: 8,678 tests across 513 files; 35 executable security claims; 331 conformance vectors; 359 external hostility cases