### PR TITLE
feat(examples): prove the two unexercised gateway-handoff properties (DMSC 7.7 / 6.9)

### DIFF
--- a/examples/cross-gateway/README.md
+++ b/examples/cross-gateway/README.md
@@ -15,7 +15,7 @@ node examples/cross-gateway/demo.mjs          # narrated run
 node examples/cross-gateway/demo.mjs --json   # machine-readable result
 ```
 
-Six cases, one executor, exactly one execution:
+Eight cases, one executor, exactly one execution:
 
 1. `a-refuses-without-evidence`: the first enforcement point fails closed with
    the check named (`receipt_required`).
@@ -35,9 +35,98 @@ Six cases, one executor, exactly one execution:
    ACCEPTED under another.
 6. `replay-refused-at-b`: the consumed artifact cannot drive a second
    execution (`replay_refused`).
+7. `stale-status-refused-at-b`: the artifact still verifies, but the signed
+   statement about whether it is *still* good is past its own `next_update`
+   and past Gateway B's own freshness bound. Gateway B refuses with
+   `status_stale`, refuses `status_evidence_absent` when no bundle is
+   presented at all, and refuses `fresh_head_stale` for a bundle still inside
+   its issuer's window but older than B's bound. A stale bundle never reads as
+   current.
+8. `indeterminate-does-not-reopen-a`: Gateway B enters its provider and the
+   deadline passes with the outcome unresolved. Gate records the execution as
+   `indeterminate`, commits the authorization instead of releasing it, refuses
+   the blind retry (`replay_refused`), and leaves Gateway A's reserved leg
+   byte-for-byte unchanged.
 
 The gate instances share nothing: not a trust store, not a consumption
 ledger, not an evidence log. The artifact travels; the trust does not have to.
+Currency and unresolved outcomes stay with the receiver.
+
+## What each case demonstrates
+
+`draft-dunbar-dmsc-gw-scenarios-gap-analysis-03` §7.7 names a standardization
+candidate: a mechanism-neutral interoperability profile for carrying and
+verifying action-bound authorization evidence at a gateway, covering action
+binding, evidence status and freshness, independent trust-anchor evaluation,
+refusal behavior, replay protection, and single-use consumption. §6.9 adds
+that an indeterminate outcome should not be silently retried as though the
+authorization remained unused.
+
+Each property below maps to the case that exercises it and the exact string
+that case produces. Every reason in the table is returned verbatim by a
+repository verifier or by Gate, with one exception: `status_evidence_absent`
+is this gateway's own name for "you presented no status bundle at all", since
+no verifier is reached in that path. It is named here rather than left
+implicit precisely because a missing bundle must not read as a passing one.
+
+| §7.7 property | Case | Exact reason produced |
+| --- | --- | --- |
+| Action binding | `tampered-in-transit-refused-at-b` | `execution_binding_failed` |
+| Evidence status and freshness | `stale-status-refused-at-b` | `status_stale`; also `status_evidence_absent` when nothing is presented and `fresh_head_stale` inside the issuer's window but past B's bound |
+| Independent trust-anchor evaluation | `b-does-not-inherit-a-trust` | `receipt_rejected:untrusted_or_invalid_signature` |
+| Refusal behavior | `a-refuses-without-evidence`, `decision-does-not-travel` | `receipt_required` |
+| Replay protection | `replay-refused-at-b` | `replay_refused` |
+| Single-use consumption | `one-artifact-two-independent-verifications` | no refusal; one artifact, one execution, `executor_call_count = 1` |
+| §6.9: an indeterminate outcome is not silently retried as though the authorization remained unused | `indeterminate-does-not-reopen-a` | `effect_attempted_outcome_unknown`, then `replay_refused` on the retry |
+
+### Where the freshness and indeterminate behavior comes from
+
+Case 7 runs at Gateway B's provider-entry boundary, the last point at which B
+still owns the decision and no effect has begun. The bundle is checked twice
+by two repository verifiers: `verifyStatusArtifact` (EP-STATUS-v1,
+`packages/verify/src/status.ts`) decides whether the signed bundle is about
+this exact artifact, from the authority B pinned, and inside its own declared
+window; `evaluateCurrency` (EP-CURRENCY-v1, `packages/verify/src/currency.ts`)
+then decides whether it is recent enough for *this* receiver, against Gateway
+B's own `maxStalenessSeconds`. Only a bundle that passes both is admitted, and
+case 2 passing through the same policy is what shows the check discriminates
+rather than refusing everything. The second check is not a restatement of the
+first: a bundle whose issuer gave it a twenty-minute window is still refused
+`fresh_head_stale` ten minutes in, because the issuer's window is not the
+receiver's bound.
+
+Case 8 uses Gate's own post-entry path (`packages/gate/src/index.ts`, the
+`run()` catch that follows provider entry). Once the effect has been entered,
+an exception cannot establish that nothing happened, so Gate commits the
+reservation, writes an execution record with outcome `indeterminate` and code
+`effect_attempted_outcome_unknown`, and raises a terminal outcome rather than
+returning a refusal a caller could mistake for "safe to retry". The lab reads
+Gateway A's consumption ledger and evidence head immediately before and after
+that attempt and asserts they are identical, so "the leg at A was not
+reopened" is a compared value rather than a claim.
+
+For the same behavior over a *budgeted* capability, where the thing that must
+not reopen is a spend allowance rather than a single approval, see
+[`examples/indeterminate-effect-reconciliation`](../indeterminate-effect-reconciliation).
+
+## Scope and non-claims
+
+- `draft-dunbar-dmsc-gw-scenarios-gap-analysis` is an **individual
+  Internet-Draft**. It has no working-group status, and nothing here is
+  adopted, endorsed, or approved by the IETF or any working group.
+- This example is a **synthetic local demonstration of composition
+  semantics**. It is not a conformance claim against any standard, not
+  evidence of interoperability with any other implementation, and not proof of
+  a real deployment.
+- Every gateway, organization, settlement, and status authority in it is
+  fabricated for the demo. Keys are generated at run time.
+- The consumption ledgers and evidence logs are in-memory and single-process.
+  They are an explicit test/demo opt-in (`allowEphemeralStore: true`); a
+  deployment needs shared durable storage before any of these properties hold
+  across processes.
+- Verification here establishes what the artifacts and the local policy say.
+  It does not establish that an external provider told the truth, and case 8
+  is specifically the case where nobody knows what the provider did.
 
 ## DMSC physical-action companion
 

--- a/examples/cross-gateway/demo.mjs
+++ b/examples/cross-gateway/demo.mjs
@@ -17,9 +17,17 @@
  * Neither gateway ingests the other's decision or log into its own trust
  * boundary, and the two audit trails join by the shared action digest, not by
  * cross-reference to each other's verdicts.
+ *
+ * Gateway B additionally owns two receiver-side properties that no presenter
+ * can supply for it: whether the carried status evidence is still current
+ * against B's own freshness bound, and what happens when B's own provider
+ * leaves an attempt unresolved.
  */
-import { createGate, createEg1Harness, hashCanonical, } from '../../packages/gate/index.js';
+import crypto from 'node:crypto';
+import { createGate, createEg1Harness, hashCanonical, MemoryConsumptionStore, } from '../../packages/gate/index.js';
 import { manifestFromPack } from '../../packages/gate/adapters/_kit.js';
+import { evaluateCurrency, verifyStatusArtifact } from '../../packages/verify/index.js';
+import { buildRevokerAuthorityCertificate, buildStatusArtifact, deriveRevokerKeyId, } from '../../lib/revocation/status.js';
 export const LAB_VERSION = 'EP-CROSS-GATEWAY-EVIDENCE-LAB-v1';
 export const EXACT_ACTION = Object.freeze({
     action_type: 'interorg.settlement.execute',
@@ -49,13 +57,29 @@ const QUORUM = Object.freeze({
     threshold: 2,
 });
 /**
+ * Gateway B's own freshness bound for carried status evidence, in seconds.
+ * "Still current" is a receiver policy, never a presenter claim: B measures
+ * the status bundle it was handed against this number and its own clock.
+ */
+const B_STATUS_MAX_STALENESS_SEC = 300;
+/**
+ * Gateway B's provider deadline, in milliseconds. A provider that has not
+ * answered by the deadline has not failed; its outcome is unknown, which is a
+ * different thing and is handled differently.
+ */
+const B_PROVIDER_DEADLINE_MS = 25;
+/**
  * One gateway = one gate instance: its own trust anchors, its own consumption
  * ledger, its own evidence log. `pins` is what THIS gateway trusts out of
- * band; nothing else reaches its trust boundary.
+ * band; nothing else reaches its trust boundary. An explicit consumption store
+ * is handed in so the lab can read the ledger a downstream failure must not
+ * silently reopen.
  */
-function makeGateway(gatewayId, pins) {
+function makeGateway(gatewayId, pins, { providerEntryGuard = null } = {}) {
+    const store = new MemoryConsumptionStore();
     return {
         gatewayId,
+        store,
         gate: createGate({
             manifest: manifestFromPack([...ACTION_PACK]),
             trustedKeys: [pins.issuerKey],
@@ -63,6 +87,8 @@ function makeGateway(gatewayId, pins) {
             rpId: pins.rpId,
             allowedOrigins: pins.allowedOrigins,
             quorumPolicy: pins.quorumPolicy,
+            store,
+            providerEntryGuard,
             allowEphemeralStore: true, // local compatibility lab; production gateways require durable shared state
         }),
     };
@@ -89,8 +115,172 @@ async function gatewayACheck(gatewayA, action, receipt) {
     });
     return decisionRecord(gatewayA.gatewayId, decision);
 }
+/**
+ * Gateway A holding its own leg. Used only where the lab needs a state at A
+ * that a downstream failure could wrongly reopen: A reserves the artifact in
+ * its own ledger, so "the leg at A" is an observable value and not a phrase.
+ */
+async function gatewayAHoldLeg(gatewayA, action, receipt) {
+    const decision = await gatewayA.gate.check({
+        selector: { ...SELECTOR },
+        receipt,
+        observedAction: action,
+        consumptionMode: 'reserve',
+    });
+    return decisionRecord(gatewayA.gatewayId, decision);
+}
+/** Everything a downstream failure could reopen at a gateway, in one value. */
+async function ledgerSnapshot(gateway) {
+    const records = await gateway.gate.evidence.all();
+    return {
+        gateway: gateway.gatewayId,
+        reserved: [...gateway.store.reserved].sort(),
+        consumed: [...gateway.store.seen].sort(),
+        evidence_records: records.length,
+        evidence_head: records.at(-1)?.hash ?? null,
+    };
+}
+/**
+ * The receiving organization's status authority. Gateway B pins its root out
+ * of band exactly as it pins the issuer and approver keys; a status bundle is
+ * only evidence to B because B pinned who may sign one.
+ */
+async function createStatusAuthority(at) {
+    const root = crypto.generateKeyPairSync('ed25519');
+    const revoker = crypto.generateKeyPairSync('ed25519');
+    const spki = (key) => key.export({ type: 'spki', format: 'der' }).toString('base64url');
+    const signerFor = (keys, keyId) => ({
+        algorithm: 'Ed25519',
+        keyId,
+        async sign(bytes) {
+            return crypto.sign(null, Buffer.from(bytes), keys.privateKey).toString('base64url');
+        },
+    });
+    const authorityPin = Object.freeze({
+        authority_domain: 'status.org-b.example',
+        authority_id: 'org:org-b',
+        key_id: 'key:org-b-status-root',
+        public_key: spki(root.publicKey),
+    });
+    const certificate = await buildRevokerAuthorityCertificate({
+        certificateId: 'revoker-authority:org-b:primary:v1',
+        authorityPin,
+        revokerId: 'revoker:org-b:primary',
+        revokerPublicKey: spki(revoker.publicKey),
+        scope: { allowed_target_types: ['receipt'], allowed_usages: ['authorization'] },
+        issuedAt: at(-30 * 86_400_000),
+        expiresAt: at(30 * 86_400_000),
+        signer: signerFor(root, authorityPin.key_id),
+    });
+    const revokerSigner = signerFor(revoker, deriveRevokerKeyId(spki(revoker.publicKey)));
+    return {
+        authorityPin,
+        certificate,
+        /** The exact target a status bundle must name to be about THIS artifact. */
+        target(receipt) {
+            return {
+                type: 'receipt',
+                id: receipt.payload.receipt_id,
+                digest: `sha256:${hashCanonical(receipt)}`,
+                usage: 'authorization',
+            };
+        },
+        async issue(receipt, { issuedAt, nextUpdate }) {
+            return buildStatusArtifact({
+                authorityPin,
+                certificate,
+                target: this.target(receipt),
+                status: 'not_revoked',
+                issuedAt,
+                nextUpdate,
+                signer: revokerSigner,
+            });
+        },
+    };
+}
+/**
+ * Gateway B's status-and-freshness policy, evaluated at the provider-entry
+ * boundary: the last point at which B still owns the decision and the effect
+ * has not begun. Both checks are the repository's own verifiers, so the
+ * refusal reason is the one the mechanism produced, not one this file chose.
+ *
+ * Fail-closed in both directions: no bundle refuses, and a bundle that is past
+ * its own next_update or older than B's bound refuses. Nothing here can return
+ * "current" because the presenter said so.
+ */
+function statusFreshnessGuard(authority, presentedStatus) {
+    return (context) => {
+        const receiptId = context.authorization?.evidence?.receipt_id ?? null;
+        const presentation = receiptId === null ? null : presentedStatus.get(receiptId);
+        if (!presentation) {
+            return {
+                ok: false,
+                reason: 'status_evidence_absent',
+                status: 409,
+                reservation: 'release',
+                evidence: { mechanism: 'EP-STATUS-v1', presented: false },
+            };
+        }
+        // EP-STATUS-v1: is this signed bundle about this exact artifact, from the
+        // authority B pinned, and still inside its own declared validity window?
+        const statusCheck = verifyStatusArtifact(presentation.target, presentation.status, {
+            authorityPin: authority.authorityPin,
+            certificate: authority.certificate,
+            now: context.checked_at,
+        });
+        if (!statusCheck.valid) {
+            return {
+                ok: false,
+                reason: statusCheck.reasons[0],
+                status: 409,
+                reservation: 'release',
+                evidence: {
+                    mechanism: 'EP-STATUS-v1',
+                    status_outcome: statusCheck.outcome,
+                    reasons: [...statusCheck.reasons],
+                    next_update: statusCheck.next_update,
+                    evaluated_at: context.checked_at,
+                },
+            };
+        }
+        // EP-CURRENCY-v1: the bundle is internally valid, but is it recent enough
+        // for THIS receiver? Only a head inside B's own bound reaches 'fresh'.
+        const currency = evaluateCurrency({
+            receipt: presentation.receipt,
+            authentic_as_of_commit: true,
+            now: context.checked_at,
+            maxStalenessSeconds: B_STATUS_MAX_STALENESS_SEC,
+            freshHead: { observed_at: presentation.status.issued_at },
+            freshHeadRequired: true,
+        });
+        if (currency.currency_at_T.status !== 'fresh') {
+            return {
+                ok: false,
+                reason: currency.currency_at_T.reason,
+                status: 409,
+                reservation: 'release',
+                evidence: {
+                    mechanism: 'EP-CURRENCY-v1',
+                    currency_status: currency.currency_at_T.status,
+                    evaluated_at: currency.currency_at_T.evaluated_at,
+                    max_staleness_sec: B_STATUS_MAX_STALENESS_SEC,
+                },
+            };
+        }
+        return {
+            ok: true,
+            evidence: {
+                status_outcome: statusCheck.outcome,
+                currency_status: currency.currency_at_T.status,
+                max_staleness_sec: B_STATUS_MAX_STALENESS_SEC,
+            },
+        };
+    };
+}
 /** Run the cross-gateway lab and return a machine-readable result. */
 export async function runCrossGatewayLab() {
+    const labNow = Date.now();
+    const at = (offsetMs) => new Date(labNow + offsetMs).toISOString();
     // The approving humans and the issuer live in the sending organization.
     const harness = createEg1Harness({ action: /** @type {any} */ (EXACT_ACTION), idPrefix: 'xgw' });
     const pins = {
@@ -100,21 +290,63 @@ export async function runCrossGatewayLab() {
         allowedOrigins: harness.allowedOrigins,
         quorumPolicy: harness.quorumPolicy,
     };
+    // Gateway B pins its own status root out of band, alongside its issuer and
+    // approver pins. Gateway A never sees it and cannot speak for it.
+    const authority = await createStatusAuthority(at);
+    const presentedStatus = new Map();
     // Both organizations pinned the issuer and approver keys OUT OF BAND.
     // The gate instances share nothing: not a store, not a log, not a registry.
     const gatewayA = makeGateway('gateway-a.org-a.example', pins);
-    const gatewayB = makeGateway('gateway-b.org-b.example', pins);
+    const gatewayB = makeGateway('gateway-b.org-b.example', pins, {
+        providerEntryGuard: statusFreshnessGuard(authority, presentedStatus),
+    });
+    /** Hand Gateway B the status bundle that travels with an artifact. */
+    async function present(receipt, window) {
+        const status = await authority.issue(receipt, window);
+        presentedStatus.set(receipt.payload.receipt_id, {
+            receipt,
+            status,
+            target: authority.target(receipt),
+        });
+        return status;
+    }
+    const currentWindow = () => ({ issuedAt: at(-60_000), nextUpdate: at(4 * 60_000) });
+    const staleWindow = () => ({ issuedAt: at(-20 * 60_000), nextUpdate: at(-15 * 60_000) });
     const executorCalls = [];
     const executor = async () => {
         executorCalls.push(structuredClone(EXACT_ACTION));
         return { settled: true, settlement_id: EXACT_ACTION.settlement_id };
     };
-    async function gatewayBExecute(action, receipt) {
-        const outcome = await gatewayB.gate.run({ selector: { ...SELECTOR }, receipt, observedAction: action }, executor);
+    // A provider that is entered and then goes quiet past Gateway B's deadline.
+    // Entry is recorded because entry is exactly what makes the outcome unknown.
+    const providerEntries = [];
+    const unresolvedProvider = async () => {
+        providerEntries.push(structuredClone(EXACT_ACTION));
+        await new Promise((_, reject) => {
+            setTimeout(() => reject(new Error('provider deadline exceeded, outcome unknown')), B_PROVIDER_DEADLINE_MS);
+        });
+        return { settled: true, settlement_id: EXACT_ACTION.settlement_id };
+    };
+    async function gatewayBExecute(action, receipt, effect = executor) {
+        const outcome = await gatewayB.gate.run({ selector: { ...SELECTOR }, receipt, observedAction: action }, effect);
         return {
             record: decisionRecord(gatewayB.gatewayId, outcome.authorization),
             outcome,
         };
+    }
+    /**
+     * Same call, but keeping the terminal outcome the gate raises once the
+     * effect has been entered. Gate signals that case by throwing, because a
+     * caller must not be able to mistake it for a plain refusal.
+     */
+    async function gatewayBAttempt(action, receipt, effect) {
+        try {
+            const outcome = await gatewayBExecute(action, receipt, effect);
+            return { ...outcome, terminal: null };
+        }
+        catch (error) {
+            return { record: null, outcome: null, terminal: error?.emiliaGateOutcome ?? null };
+        }
     }
     const cases = [];
     // 1. Fail-closed at the first enforcement point: no artifact, no forward.
@@ -131,6 +363,7 @@ export async function runCrossGatewayLab() {
     // 2. The through-case: one artifact, two independent verifications, one execution.
     const artifact = harness.mint({ outcome: 'allow_with_signoff', quorum: QUORUM });
     const aDecision = await gatewayACheck(gatewayA, EXACT_ACTION, artifact);
+    const throughStatus = await present(artifact, currentWindow());
     const before = executorCalls.length;
     const { record: bDecision, outcome } = await gatewayBExecute(EXACT_ACTION, artifact);
     cases.push({
@@ -149,6 +382,11 @@ export async function runCrossGatewayLab() {
                 && aDecision.observed_action_hash === hashCanonical(EXACT_ACTION),
         },
         execution_binds_authorization: outcome.execution?.authorizes_decision === outcome.packet?.summary?.decision_hash,
+        status_evidence: {
+            mechanism: 'EP-STATUS-v1 + EP-CURRENCY-v1',
+            next_update: throughStatus.next_update,
+            admitted_by_b: true,
+        },
     });
     // 3. A gateway's verdict is not evidence. Forwarding Gateway A's allow
     //    decision without the artifact gets refused: decisions do not travel.
@@ -230,6 +468,96 @@ export async function runCrossGatewayLab() {
         verdict: 'refuse',
         reason: replay.authorization.reason,
     });
+    // 7. Status and freshness are the receiver's question. The artifact itself
+    //    still verifies; the signed statement about whether it is STILL good is
+    //    past its own next_update and past Gateway B's bound. B refuses by the
+    //    name the status mechanism produced, and never falls open.
+    const staleArtifact = harness.mint({ outcome: 'allow_with_signoff', quorum: QUORUM });
+    const aStale = await gatewayACheck(gatewayA, EXACT_ACTION, staleArtifact);
+    const staleStatus = await present(staleArtifact, staleWindow());
+    const beforeStale = executorCalls.length;
+    const { record: bStale, outcome: staleOutcome } = await gatewayBExecute(EXACT_ACTION, staleArtifact);
+    // Same policy, nothing presented at all: absence is not currency either.
+    const unattestedArtifact = harness.mint({ outcome: 'allow_with_signoff', quorum: QUORUM });
+    const { record: bUnattested } = await gatewayBExecute(EXACT_ACTION, unattestedArtifact);
+    // Same policy, a bundle still inside its OWN declared window but older than
+    // Gateway B's bound. The issuer's window is not the receiver's bound, and
+    // the second check is refusing on its own here, not echoing the first.
+    const looseArtifact = harness.mint({ outcome: 'allow_with_signoff', quorum: QUORUM });
+    await present(looseArtifact, { issuedAt: at(-10 * 60_000), nextUpdate: at(10 * 60_000) });
+    const { record: bLoose } = await gatewayBExecute(EXACT_ACTION, looseArtifact);
+    cases.push({
+        id: 'stale-status-refused-at-b',
+        title: 'The carried status evidence is past its own next_update and past Gateway B\'s freshness bound; Gateway B refuses',
+        a: aStale,
+        b: bStale,
+        executor_called: executorCalls.length > beforeStale,
+        verdict: 'refuse',
+        reason: bStale.reason,
+        status_evidence: {
+            ...(staleOutcome.authorization?.evidence?.guard_evidence ?? {}),
+            presented_next_update: staleStatus.next_update,
+            b_max_staleness_sec: B_STATUS_MAX_STALENESS_SEC,
+        },
+        fail_closed_without_status: {
+            reason: bUnattested.reason,
+            allow: bUnattested.allow,
+        },
+        b_bound_refuses_inside_issuer_window: {
+            reason: bLoose.reason,
+            allow: bLoose.allow,
+        },
+        control_current_status_admitted: cases[1].verdict === 'execute',
+        note: 'The same policy admitted a current bundle in case 2, so this is a discriminating check and not a blanket refusal. Gateway A validated the artifact and would have forwarded it; currency is not A\'s to assert.',
+    });
+    // 8. Gateway B enters its provider and the deadline passes with the outcome
+    //    unresolved. The attempt may have landed. The authorization is therefore
+    //    committed at B and NOT returned to the pool, a blind retry is refused,
+    //    and nothing about the leg Gateway A is holding changes.
+    const indeterminateArtifact = harness.mint({ outcome: 'allow_with_signoff', quorum: QUORUM });
+    const beforeIndeterminate = executorCalls.length;
+    const aLeg = await gatewayAHoldLeg(gatewayA, EXACT_ACTION, indeterminateArtifact);
+    const aBefore = await ledgerSnapshot(gatewayA);
+    await present(indeterminateArtifact, currentWindow());
+    const attempt = await gatewayBAttempt(EXACT_ACTION, indeterminateArtifact, unresolvedProvider);
+    const aAfter = await ledgerSnapshot(gatewayA);
+    // A blind retry, carrying a freshly issued current status bundle so the only
+    // thing standing in its way is the unresolved attempt itself.
+    await present(indeterminateArtifact, currentWindow());
+    const { record: bRetry } = await gatewayBExecute(EXACT_ACTION, indeterminateArtifact);
+    const aStillFenced = await gatewayAHoldLeg(gatewayA, EXACT_ACTION, indeterminateArtifact);
+    const consumptionKey = indeterminateArtifact.payload.receipt_id;
+    cases.push({
+        id: 'indeterminate-does-not-reopen-a',
+        title: 'Gateway B\'s provider leaves the outcome unresolved; the authorization is committed at B, the retry is refused, and Gateway A\'s leg is untouched',
+        a: aLeg,
+        b: null,
+        executor_called: executorCalls.length > beforeIndeterminate,
+        provider_entered: providerEntries.length === 1,
+        verdict: 'indeterminate',
+        reason: attempt.terminal?.reason ?? null,
+        indeterminate: {
+            outcome: attempt.terminal?.outcome ?? null,
+            execution_record_kind: attempt.terminal?.execution?.kind ?? null,
+            execution_record_outcome: attempt.terminal?.execution?.outcome ?? null,
+            execution_record_code: attempt.terminal?.execution?.detail?.code ?? null,
+            authorizes_decision: attempt.terminal?.execution?.authorizes_decision ?? null,
+        },
+        not_returned_to_pool: {
+            consumption_key: consumptionKey,
+            committed_at_b: gatewayB.store.seen.has(consumptionKey),
+            still_reserved_at_b: gatewayB.store.reserved.has(consumptionKey),
+            blind_retry_at_b: { allow: bRetry.allow, reason: bRetry.reason },
+        },
+        a_leg: {
+            before: aBefore,
+            after: aAfter,
+            unchanged: JSON.stringify(aBefore) === JSON.stringify(aAfter),
+            still_reserved: gatewayA.store.reserved.has(consumptionKey),
+            re_presentation: { allow: aStillFenced.allow, reason: aStillFenced.reason },
+        },
+        note: 'An unresolved provider is not a proven non-effect. Committing rather than releasing is what makes the retry refusable; releasing would have handed the same approval back for a second attempt.',
+    });
     return {
         '@version': LAB_VERSION,
         title: 'Cross-Gateway Evidence Lab',
@@ -240,31 +568,48 @@ export async function runCrossGatewayLab() {
             exact_fields: [...ACTION_PACK[0].execution_binding.required_fields],
             verifier_trust: 'each gateway pins issuer and approver keys out of band; no gateway trusts another gateway\'s verdict',
             one_time_consumption: 'local to the enforcement point that fronts the effect',
+            status_freshness: `Gateway B pins its own status root and admits a status bundle only within ${B_STATUS_MAX_STALENESS_SEC}s of issuance and before its own next_update`,
+            indeterminate_outcome: 'an entered provider that does not resolve commits the authorization; it is never released back for a retry',
         },
         cases,
         executor_call_count: executorCalls.length,
-        invariant: 'one approval artifact, independently verified at each enforcement point, executes exactly once; decisions never travel as evidence',
+        provider_entry_count: providerEntries.length,
+        invariant: 'one approval artifact, independently verified at each enforcement point, executes exactly once; decisions never travel as evidence; stale status and unresolved outcomes both fail closed',
     };
 }
 function print(result) {
     const width = 76;
+    const label = { execute: 'EXECUTE', indeterminate: 'UNKNOWN', refuse: 'REFUSE ' };
     console.log('\nCROSS-GATEWAY EVIDENCE LAB');
     console.log('='.repeat(width));
     console.log(`Action: ${result.action.action_type} · ${result.action.amount} ${result.action.currency} -> ${result.action.counterparty}`);
     console.log('-'.repeat(width));
     for (const [index, item] of result.cases.entries()) {
-        const verdict = item.verdict === 'execute' ? 'EXECUTE' : 'REFUSE ';
+        const verdict = label[item.verdict] ?? 'REFUSE ';
         console.log(`${index + 1}. ${verdict} · ${item.id}`);
         console.log(`   ${item.title}`);
         if (item.reason)
-            console.log(`   refusal names: ${item.reason}`);
+            console.log(`   ${item.verdict === 'indeterminate' ? 'outcome names' : 'refusal names'}: ${item.reason}`);
         if (item.audit_join)
             console.log(`   audit records join by action digest: ${item.audit_join.joined_by_action_digest ? 'yes' : 'NO'}`);
+        if (item.fail_closed_without_status)
+            console.log(`   no status bundle at all names: ${item.fail_closed_without_status.reason}`);
+        if (item.b_bound_refuses_inside_issuer_window)
+            console.log(`   inside the issuer's window but past B's bound names: ${item.b_bound_refuses_inside_issuer_window.reason}`);
+        if (item.not_returned_to_pool) {
+            console.log(`   authorization committed at B, not released: ${item.not_returned_to_pool.committed_at_b && !item.not_returned_to_pool.still_reserved_at_b ? 'yes' : 'NO'}`);
+            console.log(`   blind retry at B names: ${item.not_returned_to_pool.blind_retry_at_b.reason}`);
+        }
+        if (item.a_leg)
+            console.log(`   Gateway A's leg unchanged: ${item.a_leg.unchanged ? 'yes' : 'NO'} (re-presentation names: ${item.a_leg.re_presentation.reason})`);
+        if (item.provider_entered !== undefined)
+            console.log(`   provider entered: ${item.provider_entered ? 'yes' : 'no'}`);
         console.log(`   executor called: ${item.executor_called ? 'yes' : 'no'}`);
     }
     console.log('-'.repeat(width));
     console.log(`Executor call count: ${result.executor_call_count} (expected exactly 1)`);
-    console.log('The artifact travels; the trust does not have to.\n');
+    console.log('The artifact travels; the trust does not have to.');
+    console.log('Currency and unresolved outcomes stay with the receiver.\n');
 }
 if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
     const result = await runCrossGatewayLab();

--- a/examples/cross-gateway/demo.mts
+++ b/examples/cross-gateway/demo.mts
@@ -15,13 +15,27 @@
  * Neither gateway ingests the other's decision or log into its own trust
  * boundary, and the two audit trails join by the shared action digest, not by
  * cross-reference to each other's verdicts.
+ *
+ * Gateway B additionally owns two receiver-side properties that no presenter
+ * can supply for it: whether the carried status evidence is still current
+ * against B's own freshness bound, and what happens when B's own provider
+ * leaves an attempt unresolved.
  */
+import crypto from 'node:crypto';
+
 import {
   createGate,
   createEg1Harness,
   hashCanonical,
+  MemoryConsumptionStore,
 } from '../../packages/gate/index.js';
 import { manifestFromPack } from '../../packages/gate/adapters/_kit.js';
+import { evaluateCurrency, verifyStatusArtifact } from '../../packages/verify/index.js';
+import {
+  buildRevokerAuthorityCertificate,
+  buildStatusArtifact,
+  deriveRevokerKeyId,
+} from '../../lib/revocation/status.js';
 
 export const LAB_VERSION = 'EP-CROSS-GATEWAY-EVIDENCE-LAB-v1';
 
@@ -57,13 +71,31 @@ const QUORUM = Object.freeze({
 });
 
 /**
+ * Gateway B's own freshness bound for carried status evidence, in seconds.
+ * "Still current" is a receiver policy, never a presenter claim: B measures
+ * the status bundle it was handed against this number and its own clock.
+ */
+const B_STATUS_MAX_STALENESS_SEC = 300;
+
+/**
+ * Gateway B's provider deadline, in milliseconds. A provider that has not
+ * answered by the deadline has not failed; its outcome is unknown, which is a
+ * different thing and is handled differently.
+ */
+const B_PROVIDER_DEADLINE_MS = 25;
+
+/**
  * One gateway = one gate instance: its own trust anchors, its own consumption
  * ledger, its own evidence log. `pins` is what THIS gateway trusts out of
- * band; nothing else reaches its trust boundary.
+ * band; nothing else reaches its trust boundary. An explicit consumption store
+ * is handed in so the lab can read the ledger a downstream failure must not
+ * silently reopen.
  */
-function makeGateway(gatewayId, pins) {
+function makeGateway(gatewayId, pins, { providerEntryGuard = null }: any = {}) {
+  const store = new MemoryConsumptionStore();
   return {
     gatewayId,
+    store,
     gate: createGate({
       manifest: manifestFromPack([...ACTION_PACK]),
       trustedKeys: [pins.issuerKey],
@@ -71,6 +103,8 @@ function makeGateway(gatewayId, pins) {
       rpId: pins.rpId,
       allowedOrigins: pins.allowedOrigins,
       quorumPolicy: pins.quorumPolicy,
+      store,
+      providerEntryGuard,
       allowEphemeralStore: true, // local compatibility lab; production gateways require durable shared state
     }),
   };
@@ -100,8 +134,177 @@ async function gatewayACheck(gatewayA, action, receipt) {
   return decisionRecord(gatewayA.gatewayId, decision);
 }
 
+/**
+ * Gateway A holding its own leg. Used only where the lab needs a state at A
+ * that a downstream failure could wrongly reopen: A reserves the artifact in
+ * its own ledger, so "the leg at A" is an observable value and not a phrase.
+ */
+async function gatewayAHoldLeg(gatewayA, action, receipt) {
+  const decision = await gatewayA.gate.check({
+    selector: { ...SELECTOR },
+    receipt,
+    observedAction: action,
+    consumptionMode: 'reserve',
+  });
+  return decisionRecord(gatewayA.gatewayId, decision);
+}
+
+/** Everything a downstream failure could reopen at a gateway, in one value. */
+async function ledgerSnapshot(gateway) {
+  const records = await gateway.gate.evidence.all();
+  return {
+    gateway: gateway.gatewayId,
+    reserved: [...gateway.store.reserved].sort(),
+    consumed: [...gateway.store.seen].sort(),
+    evidence_records: records.length,
+    evidence_head: records.at(-1)?.hash ?? null,
+  };
+}
+
+/**
+ * The receiving organization's status authority. Gateway B pins its root out
+ * of band exactly as it pins the issuer and approver keys; a status bundle is
+ * only evidence to B because B pinned who may sign one.
+ */
+async function createStatusAuthority(at) {
+  const root = crypto.generateKeyPairSync('ed25519');
+  const revoker = crypto.generateKeyPairSync('ed25519');
+  const spki = (key) => key.export({ type: 'spki', format: 'der' }).toString('base64url');
+  const signerFor = (keys, keyId) => ({
+    algorithm: 'Ed25519' as const,
+    keyId,
+    async sign(bytes) {
+      return crypto.sign(null, Buffer.from(bytes), keys.privateKey).toString('base64url');
+    },
+  });
+  const authorityPin = Object.freeze({
+    authority_domain: 'status.org-b.example',
+    authority_id: 'org:org-b',
+    key_id: 'key:org-b-status-root',
+    public_key: spki(root.publicKey),
+  });
+  const certificate = await buildRevokerAuthorityCertificate({
+    certificateId: 'revoker-authority:org-b:primary:v1',
+    authorityPin,
+    revokerId: 'revoker:org-b:primary',
+    revokerPublicKey: spki(revoker.publicKey),
+    scope: { allowed_target_types: ['receipt'], allowed_usages: ['authorization'] },
+    issuedAt: at(-30 * 86_400_000),
+    expiresAt: at(30 * 86_400_000),
+    signer: signerFor(root, authorityPin.key_id),
+  });
+  const revokerSigner = signerFor(revoker, deriveRevokerKeyId(spki(revoker.publicKey)));
+  return {
+    authorityPin,
+    certificate,
+    /** The exact target a status bundle must name to be about THIS artifact. */
+    target(receipt) {
+      return {
+        type: 'receipt',
+        id: receipt.payload.receipt_id,
+        digest: `sha256:${hashCanonical(receipt)}`,
+        usage: 'authorization',
+      };
+    },
+    async issue(receipt, { issuedAt, nextUpdate }) {
+      return buildStatusArtifact({
+        authorityPin,
+        certificate,
+        target: this.target(receipt),
+        status: 'not_revoked',
+        issuedAt,
+        nextUpdate,
+        signer: revokerSigner,
+      });
+    },
+  };
+}
+
+/**
+ * Gateway B's status-and-freshness policy, evaluated at the provider-entry
+ * boundary: the last point at which B still owns the decision and the effect
+ * has not begun. Both checks are the repository's own verifiers, so the
+ * refusal reason is the one the mechanism produced, not one this file chose.
+ *
+ * Fail-closed in both directions: no bundle refuses, and a bundle that is past
+ * its own next_update or older than B's bound refuses. Nothing here can return
+ * "current" because the presenter said so.
+ */
+function statusFreshnessGuard(authority, presentedStatus) {
+  return (context) => {
+    const receiptId = context.authorization?.evidence?.receipt_id ?? null;
+    const presentation = receiptId === null ? null : presentedStatus.get(receiptId);
+    if (!presentation) {
+      return {
+        ok: false,
+        reason: 'status_evidence_absent',
+        status: 409,
+        reservation: 'release',
+        evidence: { mechanism: 'EP-STATUS-v1', presented: false },
+      };
+    }
+    // EP-STATUS-v1: is this signed bundle about this exact artifact, from the
+    // authority B pinned, and still inside its own declared validity window?
+    const statusCheck = verifyStatusArtifact(presentation.target, presentation.status, {
+      authorityPin: authority.authorityPin,
+      certificate: authority.certificate,
+      now: context.checked_at,
+    });
+    if (!statusCheck.valid) {
+      return {
+        ok: false,
+        reason: statusCheck.reasons[0],
+        status: 409,
+        reservation: 'release',
+        evidence: {
+          mechanism: 'EP-STATUS-v1',
+          status_outcome: statusCheck.outcome,
+          reasons: [...statusCheck.reasons],
+          next_update: statusCheck.next_update,
+          evaluated_at: context.checked_at,
+        },
+      };
+    }
+    // EP-CURRENCY-v1: the bundle is internally valid, but is it recent enough
+    // for THIS receiver? Only a head inside B's own bound reaches 'fresh'.
+    const currency = evaluateCurrency({
+      receipt: presentation.receipt,
+      authentic_as_of_commit: true,
+      now: context.checked_at,
+      maxStalenessSeconds: B_STATUS_MAX_STALENESS_SEC,
+      freshHead: { observed_at: presentation.status.issued_at },
+      freshHeadRequired: true,
+    });
+    if (currency.currency_at_T.status !== 'fresh') {
+      return {
+        ok: false,
+        reason: currency.currency_at_T.reason,
+        status: 409,
+        reservation: 'release',
+        evidence: {
+          mechanism: 'EP-CURRENCY-v1',
+          currency_status: currency.currency_at_T.status,
+          evaluated_at: currency.currency_at_T.evaluated_at,
+          max_staleness_sec: B_STATUS_MAX_STALENESS_SEC,
+        },
+      };
+    }
+    return {
+      ok: true,
+      evidence: {
+        status_outcome: statusCheck.outcome,
+        currency_status: currency.currency_at_T.status,
+        max_staleness_sec: B_STATUS_MAX_STALENESS_SEC,
+      },
+    };
+  };
+}
+
 /** Run the cross-gateway lab and return a machine-readable result. */
 export async function runCrossGatewayLab() {
+  const labNow = Date.now();
+  const at = (offsetMs) => new Date(labNow + offsetMs).toISOString();
+
   // The approving humans and the issuer live in the sending organization.
   const harness = createEg1Harness({ action: /** @type {any} */ (EXACT_ACTION), idPrefix: 'xgw' });
   const pins = {
@@ -112,10 +315,30 @@ export async function runCrossGatewayLab() {
     quorumPolicy: harness.quorumPolicy,
   };
 
+  // Gateway B pins its own status root out of band, alongside its issuer and
+  // approver pins. Gateway A never sees it and cannot speak for it.
+  const authority = await createStatusAuthority(at);
+  const presentedStatus = new Map();
+
   // Both organizations pinned the issuer and approver keys OUT OF BAND.
   // The gate instances share nothing: not a store, not a log, not a registry.
   const gatewayA = makeGateway('gateway-a.org-a.example', pins);
-  const gatewayB = makeGateway('gateway-b.org-b.example', pins);
+  const gatewayB = makeGateway('gateway-b.org-b.example', pins, {
+    providerEntryGuard: statusFreshnessGuard(authority, presentedStatus),
+  });
+
+  /** Hand Gateway B the status bundle that travels with an artifact. */
+  async function present(receipt, window) {
+    const status = await authority.issue(receipt, window);
+    presentedStatus.set(receipt.payload.receipt_id, {
+      receipt,
+      status,
+      target: authority.target(receipt),
+    });
+    return status;
+  }
+  const currentWindow = () => ({ issuedAt: at(-60_000), nextUpdate: at(4 * 60_000) });
+  const staleWindow = () => ({ issuedAt: at(-20 * 60_000), nextUpdate: at(-15 * 60_000) });
 
   const executorCalls: any[] = [];
   const executor = async () => {
@@ -123,15 +346,40 @@ export async function runCrossGatewayLab() {
     return { settled: true, settlement_id: EXACT_ACTION.settlement_id };
   };
 
-  async function gatewayBExecute(action, receipt) {
+  // A provider that is entered and then goes quiet past Gateway B's deadline.
+  // Entry is recorded because entry is exactly what makes the outcome unknown.
+  const providerEntries: any[] = [];
+  const unresolvedProvider = async () => {
+    providerEntries.push(structuredClone(EXACT_ACTION));
+    await new Promise((_, reject) => {
+      setTimeout(() => reject(new Error('provider deadline exceeded, outcome unknown')), B_PROVIDER_DEADLINE_MS);
+    });
+    return { settled: true, settlement_id: EXACT_ACTION.settlement_id };
+  };
+
+  async function gatewayBExecute(action, receipt, effect = executor) {
     const outcome = await gatewayB.gate.run(
       { selector: { ...SELECTOR }, receipt, observedAction: action },
-      executor,
+      effect,
     );
     return {
       record: decisionRecord(gatewayB.gatewayId, outcome.authorization),
       outcome,
     };
+  }
+
+  /**
+   * Same call, but keeping the terminal outcome the gate raises once the
+   * effect has been entered. Gate signals that case by throwing, because a
+   * caller must not be able to mistake it for a plain refusal.
+   */
+  async function gatewayBAttempt(action, receipt, effect) {
+    try {
+      const outcome = await gatewayBExecute(action, receipt, effect);
+      return { ...outcome, terminal: null };
+    } catch (error: any) {
+      return { record: null, outcome: null, terminal: error?.emiliaGateOutcome ?? null };
+    }
   }
 
   const cases: any[] = [];
@@ -151,6 +399,7 @@ export async function runCrossGatewayLab() {
   // 2. The through-case: one artifact, two independent verifications, one execution.
   const artifact = harness.mint({ outcome: 'allow_with_signoff', quorum: QUORUM });
   const aDecision = await gatewayACheck(gatewayA, EXACT_ACTION, artifact);
+  const throughStatus = await present(artifact, currentWindow());
   const before = executorCalls.length;
   const { record: bDecision, outcome } = await gatewayBExecute(EXACT_ACTION, artifact);
   cases.push({
@@ -171,6 +420,11 @@ export async function runCrossGatewayLab() {
     },
     execution_binds_authorization:
       outcome.execution?.authorizes_decision === outcome.packet?.summary?.decision_hash,
+    status_evidence: {
+      mechanism: 'EP-STATUS-v1 + EP-CURRENCY-v1',
+      next_update: throughStatus.next_update,
+      admitted_by_b: true,
+    },
   });
 
   // 3. A gateway's verdict is not evidence. Forwarding Gateway A's allow
@@ -260,6 +514,103 @@ export async function runCrossGatewayLab() {
     reason: replay.authorization.reason,
   });
 
+  // 7. Status and freshness are the receiver's question. The artifact itself
+  //    still verifies; the signed statement about whether it is STILL good is
+  //    past its own next_update and past Gateway B's bound. B refuses by the
+  //    name the status mechanism produced, and never falls open.
+  const staleArtifact = harness.mint({ outcome: 'allow_with_signoff', quorum: QUORUM });
+  const aStale = await gatewayACheck(gatewayA, EXACT_ACTION, staleArtifact);
+  const staleStatus = await present(staleArtifact, staleWindow());
+  const beforeStale = executorCalls.length;
+  const { record: bStale, outcome: staleOutcome } = await gatewayBExecute(EXACT_ACTION, staleArtifact);
+
+  // Same policy, nothing presented at all: absence is not currency either.
+  const unattestedArtifact = harness.mint({ outcome: 'allow_with_signoff', quorum: QUORUM });
+  const { record: bUnattested } = await gatewayBExecute(EXACT_ACTION, unattestedArtifact);
+
+  // Same policy, a bundle still inside its OWN declared window but older than
+  // Gateway B's bound. The issuer's window is not the receiver's bound, and
+  // the second check is refusing on its own here, not echoing the first.
+  const looseArtifact = harness.mint({ outcome: 'allow_with_signoff', quorum: QUORUM });
+  await present(looseArtifact, { issuedAt: at(-10 * 60_000), nextUpdate: at(10 * 60_000) });
+  const { record: bLoose } = await gatewayBExecute(EXACT_ACTION, looseArtifact);
+
+  cases.push({
+    id: 'stale-status-refused-at-b',
+    title: 'The carried status evidence is past its own next_update and past Gateway B\'s freshness bound; Gateway B refuses',
+    a: aStale,
+    b: bStale,
+    executor_called: executorCalls.length > beforeStale,
+    verdict: 'refuse',
+    reason: bStale.reason,
+    status_evidence: {
+      ...(staleOutcome.authorization?.evidence?.guard_evidence ?? {}),
+      presented_next_update: staleStatus.next_update,
+      b_max_staleness_sec: B_STATUS_MAX_STALENESS_SEC,
+    },
+    fail_closed_without_status: {
+      reason: bUnattested.reason,
+      allow: bUnattested.allow,
+    },
+    b_bound_refuses_inside_issuer_window: {
+      reason: bLoose.reason,
+      allow: bLoose.allow,
+    },
+    control_current_status_admitted: cases[1].verdict === 'execute',
+    note: 'The same policy admitted a current bundle in case 2, so this is a discriminating check and not a blanket refusal. Gateway A validated the artifact and would have forwarded it; currency is not A\'s to assert.',
+  });
+
+  // 8. Gateway B enters its provider and the deadline passes with the outcome
+  //    unresolved. The attempt may have landed. The authorization is therefore
+  //    committed at B and NOT returned to the pool, a blind retry is refused,
+  //    and nothing about the leg Gateway A is holding changes.
+  const indeterminateArtifact = harness.mint({ outcome: 'allow_with_signoff', quorum: QUORUM });
+  const beforeIndeterminate = executorCalls.length;
+  const aLeg = await gatewayAHoldLeg(gatewayA, EXACT_ACTION, indeterminateArtifact);
+  const aBefore = await ledgerSnapshot(gatewayA);
+  await present(indeterminateArtifact, currentWindow());
+  const attempt = await gatewayBAttempt(EXACT_ACTION, indeterminateArtifact, unresolvedProvider);
+  const aAfter = await ledgerSnapshot(gatewayA);
+
+  // A blind retry, carrying a freshly issued current status bundle so the only
+  // thing standing in its way is the unresolved attempt itself.
+  await present(indeterminateArtifact, currentWindow());
+  const { record: bRetry } = await gatewayBExecute(EXACT_ACTION, indeterminateArtifact);
+  const aStillFenced = await gatewayAHoldLeg(gatewayA, EXACT_ACTION, indeterminateArtifact);
+
+  const consumptionKey = indeterminateArtifact.payload.receipt_id;
+  cases.push({
+    id: 'indeterminate-does-not-reopen-a',
+    title: 'Gateway B\'s provider leaves the outcome unresolved; the authorization is committed at B, the retry is refused, and Gateway A\'s leg is untouched',
+    a: aLeg,
+    b: null,
+    executor_called: executorCalls.length > beforeIndeterminate,
+    provider_entered: providerEntries.length === 1,
+    verdict: 'indeterminate',
+    reason: attempt.terminal?.reason ?? null,
+    indeterminate: {
+      outcome: attempt.terminal?.outcome ?? null,
+      execution_record_kind: attempt.terminal?.execution?.kind ?? null,
+      execution_record_outcome: attempt.terminal?.execution?.outcome ?? null,
+      execution_record_code: attempt.terminal?.execution?.detail?.code ?? null,
+      authorizes_decision: attempt.terminal?.execution?.authorizes_decision ?? null,
+    },
+    not_returned_to_pool: {
+      consumption_key: consumptionKey,
+      committed_at_b: gatewayB.store.seen.has(consumptionKey),
+      still_reserved_at_b: gatewayB.store.reserved.has(consumptionKey),
+      blind_retry_at_b: { allow: bRetry.allow, reason: bRetry.reason },
+    },
+    a_leg: {
+      before: aBefore,
+      after: aAfter,
+      unchanged: JSON.stringify(aBefore) === JSON.stringify(aAfter),
+      still_reserved: gatewayA.store.reserved.has(consumptionKey),
+      re_presentation: { allow: aStillFenced.allow, reason: aStillFenced.reason },
+    },
+    note: 'An unresolved provider is not a proven non-effect. Committing rather than releasing is what makes the retry refusable; releasing would have handed the same approval back for a second attempt.',
+  });
+
   return {
     '@version': LAB_VERSION,
     title: 'Cross-Gateway Evidence Lab',
@@ -270,30 +621,43 @@ export async function runCrossGatewayLab() {
       exact_fields: [...ACTION_PACK[0].execution_binding.required_fields],
       verifier_trust: 'each gateway pins issuer and approver keys out of band; no gateway trusts another gateway\'s verdict',
       one_time_consumption: 'local to the enforcement point that fronts the effect',
+      status_freshness: `Gateway B pins its own status root and admits a status bundle only within ${B_STATUS_MAX_STALENESS_SEC}s of issuance and before its own next_update`,
+      indeterminate_outcome: 'an entered provider that does not resolve commits the authorization; it is never released back for a retry',
     },
     cases,
     executor_call_count: executorCalls.length,
-    invariant: 'one approval artifact, independently verified at each enforcement point, executes exactly once; decisions never travel as evidence',
+    provider_entry_count: providerEntries.length,
+    invariant: 'one approval artifact, independently verified at each enforcement point, executes exactly once; decisions never travel as evidence; stale status and unresolved outcomes both fail closed',
   };
 }
 
 function print(result) {
   const width = 76;
+  const label = { execute: 'EXECUTE', indeterminate: 'UNKNOWN', refuse: 'REFUSE ' };
   console.log('\nCROSS-GATEWAY EVIDENCE LAB');
   console.log('='.repeat(width));
   console.log(`Action: ${result.action.action_type} · ${result.action.amount} ${result.action.currency} -> ${result.action.counterparty}`);
   console.log('-'.repeat(width));
   for (const [index, item] of result.cases.entries()) {
-    const verdict = item.verdict === 'execute' ? 'EXECUTE' : 'REFUSE ';
+    const verdict = label[item.verdict] ?? 'REFUSE ';
     console.log(`${index + 1}. ${verdict} · ${item.id}`);
     console.log(`   ${item.title}`);
-    if (item.reason) console.log(`   refusal names: ${item.reason}`);
+    if (item.reason) console.log(`   ${item.verdict === 'indeterminate' ? 'outcome names' : 'refusal names'}: ${item.reason}`);
     if (item.audit_join) console.log(`   audit records join by action digest: ${item.audit_join.joined_by_action_digest ? 'yes' : 'NO'}`);
+    if (item.fail_closed_without_status) console.log(`   no status bundle at all names: ${item.fail_closed_without_status.reason}`);
+    if (item.b_bound_refuses_inside_issuer_window) console.log(`   inside the issuer's window but past B's bound names: ${item.b_bound_refuses_inside_issuer_window.reason}`);
+    if (item.not_returned_to_pool) {
+      console.log(`   authorization committed at B, not released: ${item.not_returned_to_pool.committed_at_b && !item.not_returned_to_pool.still_reserved_at_b ? 'yes' : 'NO'}`);
+      console.log(`   blind retry at B names: ${item.not_returned_to_pool.blind_retry_at_b.reason}`);
+    }
+    if (item.a_leg) console.log(`   Gateway A's leg unchanged: ${item.a_leg.unchanged ? 'yes' : 'NO'} (re-presentation names: ${item.a_leg.re_presentation.reason})`);
+    if (item.provider_entered !== undefined) console.log(`   provider entered: ${item.provider_entered ? 'yes' : 'no'}`);
     console.log(`   executor called: ${item.executor_called ? 'yes' : 'no'}`);
   }
   console.log('-'.repeat(width));
   console.log(`Executor call count: ${result.executor_call_count} (expected exactly 1)`);
-  console.log('The artifact travels; the trust does not have to.\n');
+  console.log('The artifact travels; the trust does not have to.');
+  console.log('Currency and unresolved outcomes stay with the receiver.\n');
 }
 
 if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {

--- a/tests/cross-gateway.test.ts
+++ b/tests/cross-gateway.test.ts
@@ -22,6 +22,7 @@ describe('Cross-Gateway Evidence Lab', () => {
       'tampered-in-transit-refused-at-b',
       'b-does-not-inherit-a-trust',
       'replay-refused-at-b',
+      'stale-status-refused-at-b',
     ]) {
       expect(byId[id].verdict, id).toBe('refuse');
       expect(byId[id].executor_called, id).toBe(false);
@@ -54,5 +55,78 @@ describe('Cross-Gateway Evidence Lab', () => {
 
     // The verdict that did not travel was a genuine allow at Gateway A.
     expect(byId['decision-does-not-travel'].a.allow).toBe(true);
+
+    // Status and freshness: the artifact still verifies, but the signed
+    // statement about whether it is STILL good is past its own next_update.
+    // The refusal is the EP-STATUS-v1 verifier's own reason string.
+    const stale = byId['stale-status-refused-at-b'];
+    expect(stale.reason).toBe('status_stale');
+    expect(stale.b.allow).toBe(false);
+    expect(stale.status_evidence.mechanism).toBe('EP-STATUS-v1');
+    expect(stale.status_evidence.status_outcome).toBe('indeterminate');
+    expect(stale.status_evidence.reasons).toContain('status_stale');
+    expect(stale.status_evidence.b_max_staleness_sec).toBe(300);
+    // Gateway A validated the same artifact and would have forwarded it;
+    // currency is the receiver's question.
+    expect(stale.a.allow).toBe(true);
+    // Never fails open: absence of a status bundle is not currency either.
+    expect(stale.fail_closed_without_status.allow).toBe(false);
+    expect(stale.fail_closed_without_status.reason).toBe('status_evidence_absent');
+    // The issuer's window is not the receiver's bound. A bundle still inside
+    // its own next_update but older than Gateway B's bound is refused by the
+    // second mechanism on its own, so neither check is decorative.
+    expect(stale.b_bound_refuses_inside_issuer_window.allow).toBe(false);
+    expect(stale.b_bound_refuses_inside_issuer_window.reason).toBe('fresh_head_stale');
+    // And the same policy admitted a current bundle, so it discriminates.
+    expect(stale.control_current_status_admitted).toBe(true);
+
+    // An unresolved provider outcome is neither success nor a clean refusal,
+    // and it must not hand the approval back for a second attempt.
+    const indeterminate = byId['indeterminate-does-not-reopen-a'];
+    expect(indeterminate.verdict).toBe('indeterminate');
+    expect(indeterminate.provider_entered).toBe(true);
+    expect(indeterminate.executor_called).toBe(false);
+    expect(result.provider_entry_count).toBe(1);
+    // (a) recorded as indeterminate by the gate, not labelled so by this lab.
+    expect(indeterminate.reason).toBe('effect_attempted_outcome_unknown');
+    expect(indeterminate.indeterminate.outcome).toBe('indeterminate');
+    expect(indeterminate.indeterminate.execution_record_kind).toBe('execution');
+    expect(indeterminate.indeterminate.execution_record_outcome).toBe('indeterminate');
+    expect(indeterminate.indeterminate.execution_record_code).toBe('effect_attempted_outcome_unknown');
+    expect(indeterminate.indeterminate.authorizes_decision).toBeTruthy();
+    // (b) a blind retry at Gateway B is refused.
+    expect(indeterminate.not_returned_to_pool.blind_retry_at_b.allow).toBe(false);
+    expect(indeterminate.not_returned_to_pool.blind_retry_at_b.reason).toBe('replay_refused');
+    // (c) the authorization was committed at B, never released back to the
+    // pool, and Gateway A's leg is byte-for-byte what it was before.
+    expect(indeterminate.not_returned_to_pool.committed_at_b).toBe(true);
+    expect(indeterminate.not_returned_to_pool.still_reserved_at_b).toBe(false);
+    expect(indeterminate.a_leg.unchanged).toBe(true);
+    expect(indeterminate.a_leg.after).toEqual(indeterminate.a_leg.before);
+    // "Unchanged" is only worth asserting against a snapshot that had
+    // something in it: Gateway A was holding this exact leg and had already
+    // written its own evidence when Gateway B's attempt went unresolved.
+    expect(indeterminate.a_leg.before.reserved).toContain(
+      indeterminate.not_returned_to_pool.consumption_key,
+    );
+    expect(indeterminate.a_leg.before.evidence_records).toBeGreaterThan(0);
+    expect(indeterminate.a_leg.before.evidence_head).toBeTruthy();
+    expect(indeterminate.a_leg.still_reserved).toBe(true);
+    expect(indeterminate.a_leg.re_presentation.allow).toBe(false);
+    expect(indeterminate.a_leg.re_presentation.reason).toBe('replay_refused');
+
+    // The machine-readable result is safe to publish: no key material, no
+    // approver credentials, and no provider payloads ride along in it.
+    const serialized = JSON.stringify(result);
+    for (const marker of [
+      'PRIVATE KEY',
+      'privateKey',
+      'private_key',
+      'privateKeyB64u',
+      'secret',
+      'BEGIN ',
+    ]) {
+      expect(serialized, marker).not.toContain(marker);
+    }
   });
 });


### PR DESCRIPTION
`draft-dunbar-dmsc-gw-scenarios-gap-analysis-03` section 7.7 names six properties for a mechanism-neutral profile for action-bound authorization evidence at a gateway: action binding, evidence status and freshness, independent trust-anchor evaluation, refusal behavior, replay protection, and single-use consumption. The cross-gateway example demonstrated five. Section 6.9 adds that an indeterminate outcome must not be silently retried as though the authorization remained unused, and nothing exercised that at all.

This adds the two missing cases. The draft is an individual Internet-Draft with no working-group status; DMSC is a non-WG-forming diagnostic BOF. No conformance claim against any standard is made.

## Case 7, stale-status-refused-at-b (7.7 evidence status and freshness)

Three distinct refusals, so freshness is shown to be two independent mechanisms rather than one:
- past its own `next_update` -> `status_stale` (`packages/verify/src/status.ts:759`)
- no bundle at all -> `status_evidence_absent`
- inside the issuer's window but past the receiver's own bound -> `fresh_head_stale` (`packages/verify/src/currency.ts:181`)

Enforced at Gate's provider-entry boundary, so the executor is structurally unreachable rather than merely uncalled.

## Case 8, indeterminate-does-not-reopen-a (6.9)

The provider leaves the outcome unresolved. Asserted: `outcome: indeterminate` with `effect_attempted_outcome_unknown` from the gate's own post-provider-entry path; the authorization is **committed** at B rather than released; the blind retry refuses `replay_refused`; and Gateway A's ledger is deep-equal before and after, with a non-vacuous record count so "unchanged" means something.

**Mutation-tested:** deleting the committed key at B, simulating a return to the pool, makes the identical retry execute. That is precisely the failure 6.9 names, which confirms the commit is what makes the retry refusable.

## Unchanged

The six pre-existing cases pass with byte-identical reason strings. Case 2 now also presents a current status bundle because B's provider-entry policy is global to that gateway; its outcome, assertions and audit join are unchanged. Executor call count across all eight cases remains exactly 1.

Also adds a no-secrets assertion to the test, which it previously lacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)