### PR TITLE
feat(site): /ai-agent-audit-trail and /ai-agent-approvals pillar pages

### DIFF
--- a/app/ai-agent-approvals/_content.ts
+++ b/app/ai-agent-approvals/_content.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared copy for /ai-agent-approvals.
+ *
+ * The FAQ lives here so the visible section (page.tsx, a client component) and
+ * the FAQPage JSON-LD (layout.tsx, a server component that needs the CSP nonce)
+ * are rendered from one array and can never drift apart.
+ *
+ * @license Apache-2.0
+ */
+
+export const PAGE_URL = 'https://www.emiliaprotocol.ai/ai-agent-approvals';
+
+export const FAQ = [
+  {
+    q: 'What is an AI agent approval workflow?',
+    a: 'A single decision point in front of every consequential action an agent attempts, with three outcomes: run it '
+      + 'because it is inside policy, escalate it to a named human because it is outside policy, or refuse it because no '
+      + 'approver could make it acceptable. The design work is in the second outcome and in what that escalation produces.',
+  },
+  {
+    q: 'How do you stop an agent from approving its own actions?',
+    a: 'By making authority flow only downward and fail closed. A principal that itself holds delegated authority cannot '
+      + 'grant more than it holds, and a request for a scope outside that is refused as a scope escalation. If the '
+      + 'delegation record cannot be read at all, the request refuses rather than falling back to permissive. The assurance '
+      + 'tier is also not self-declared: a receipt that merely claims a higher tier is graded down and refused.',
+  },
+  {
+    q: 'What is the difference between an approval and an authorization receipt?',
+    a: 'An approval is an event in your system. A receipt is a portable artifact: a signature over the exact action, the '
+      + 'named approver, the pinned policy, and a one-time consumption key, verifiable by someone who does not trust your '
+      + 'systems and cannot query them.',
+  },
+  {
+    q: 'Can an approval be reused?',
+    a: 'Not on a mediated path. Consumption is keyed to a stable issuer-generated receipt identifier, and a second '
+      + 'presentation is refused as a replay rather than executing a second time. The key is deliberately not a hash of '
+      + 'the content, because canonicalization differences between language implementations would silently break replay '
+      + 'detection when services share a consumption store.',
+  },
+] as const;

--- a/app/ai-agent-approvals/layout.tsx
+++ b/app/ai-agent-approvals/layout.tsx
@@ -1,0 +1,85 @@
+import { headers } from 'next/headers';
+import type { Metadata } from 'next';
+import { FAQ, PAGE_URL } from './_content';
+
+// Kept under 160 characters so search engines render it without truncation.
+const description =
+  'Design an AI agent approval workflow: run routine work inside policy, escalate the rest to a '
+  + 'named human, bind each approval to one exact action, used once.';
+
+export const metadata: Metadata = {
+  // Layout title template appends "| EMILIA", rendering
+  // "AI Agent Approval Workflow: Escalate, Bind, Consume Once | EMILIA".
+  title: 'AI Agent Approval Workflow: Escalate, Bind, Consume Once',
+  description,
+  alternates: { canonical: '/ai-agent-approvals' },
+  // Page-level openGraph REPLACES the layout default rather than merging into
+  // it, so images must be restated here or the social card silently drops.
+  openGraph: {
+    title: 'AI Agent Approval Workflow: Escalate, Bind, Consume Once',
+    description:
+      'Approve routine work inside policy, escalate the rest to a named human, and never let the agent widen its own authority.',
+    url: PAGE_URL,
+    type: 'article',
+    images: ['/og-sequence.jpg'],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'AI Agent Approval Workflow: Escalate, Bind, Consume Once',
+    description,
+    images: ['/og-sequence.jpg'],
+  },
+  keywords: [
+    'AI agent approval workflow',
+    'agent approval process',
+    'human in the loop agent approval',
+    'agent escalation policy',
+    'exact-action binding',
+    'one-time approval consumption',
+    'delegated authority containment',
+  ],
+};
+
+const ARTICLE_JSONLD = {
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'Designing an AI agent approval workflow',
+  description,
+  about: 'Approval, escalation, and authority containment for autonomous agents',
+  url: PAGE_URL,
+  author: { '@type': 'Organization', name: 'EMILIA Protocol' },
+  publisher: { '@type': 'Organization', name: 'EMILIA Protocol', url: 'https://www.emiliaprotocol.ai' },
+  license: 'https://www.apache.org/licenses/LICENSE-2.0',
+};
+
+const FAQ_JSONLD = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: FAQ.map((f) => ({
+    '@type': 'Question',
+    name: f.q,
+    acceptedAnswer: { '@type': 'Answer', text: f.a },
+  })),
+};
+
+export default async function AiAgentApprovalsLayout({ children }: { children: React.ReactNode }) {
+  const nonce = (await headers()).get('x-nonce') ?? '';
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(ARTICLE_JSONLD) }}
+        nonce={nonce}
+      />
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(FAQ_JSONLD) }}
+        nonce={nonce}
+      />
+      {children}
+    </>
+  );
+}

--- a/app/ai-agent-approvals/page.tsx
+++ b/app/ai-agent-approvals/page.tsx
@@ -1,0 +1,194 @@
+/**
+ * AI agent approval workflow pillar page.
+ *
+ * Consolidates the approval argument that was scattered across /quickstart and
+ * the human-in-the-loop comparison pages into one buyer-facing surface.
+ *
+ * @license Apache-2.0
+ */
+'use client';
+
+import { useEffect } from 'react';
+import SiteNav from '@/components/SiteNav';
+import SiteFooter from '@/components/SiteFooter';
+import { styles, cta, color, font, radius, grid } from '@/lib/tokens';
+import proofStats from '@/lib/proof-stats.json';
+import { FAQ } from './_content';
+
+const TLA_INVARIANTS = String(proofStats.tla.invariants);
+const TLA_CHECKER = String(proofStats.tla.checker);
+
+// The three outcomes of one evaluation. Most approval systems ship the first
+// and the third; the product is in the middle one and in what it produces.
+const ROUTES = [
+  {
+    key: 'ALLOW',
+    tone: color.green,
+    title: 'Inside policy',
+    body: 'The action runs. Nobody is interrupted, and the decision is still recorded, because "no human was needed" is itself something a reviewer will want to see justified.',
+  },
+  {
+    key: 'ESCALATE',
+    tone: color.gold,
+    title: 'Outside policy, not forbidden',
+    body: 'Execution stops and a named human is asked for this exact action. The refusal is machine-readable (HTTP 428, carrying what to bring back), so the agent knows what would unblock it instead of retrying blind.',
+  },
+  {
+    key: 'DENY',
+    tone: color.red,
+    title: 'No approver would make it acceptable',
+    body: 'Refused outright, with a reason. There is no signoff path, because the problem is not missing authority; it is that the action is out of bounds.',
+  },
+];
+
+const ROWS = [
+  { dim: 'What was approved', msg: 'An action, described in prose', bound: 'The exact parameters, covered by the signature' },
+  { dim: 'Who approved', msg: 'Whoever held the session', bound: 'A named principal, inside the signed payload' },
+  { dim: 'How the yes was established', msg: 'A click', bound: 'An assurance tier that had to be proven, not claimed' },
+  { dim: 'Reuse', msg: 'Nothing prevents it', bound: 'One-time consumption; a second presentation is refused' },
+  { dim: 'Drift between approval and execution', msg: 'Undetected', bound: 'Compared against the observed action; refused on mismatch' },
+  { dim: 'How a third party checks it', msg: 'Ask the operator', bound: 'Verify the signature against a pinned issuer key' },
+  { dim: 'What the agent can influence', msg: 'The framing it presents', bound: 'Nothing that sits inside the signature' },
+];
+
+export default function AiAgentApprovalsPage(): React.ReactElement {
+  useEffect(() => {
+    const els = document.querySelectorAll('.ep-reveal');
+    const obs = new IntersectionObserver(
+      entries => entries.forEach(e => { if (e.isIntersecting) { e.target.classList.add('is-visible'); obs.unobserve(e.target); } }),
+      { threshold: 0.12 }
+    );
+    els.forEach(el => obs.observe(el));
+    return () => obs.disconnect();
+  }, []);
+
+  return (
+    <div style={styles.page}>
+      <SiteNav activePage="" />
+
+      <section style={{ ...styles.section, paddingTop: 100, paddingBottom: 56 }}>
+        <div className="ep-tag ep-hero-badge" style={{ color: color.gold }}>Approvals / AI Agents</div>
+        <h1 className="ep-hero-text" style={styles.h1}>Designing an AI agent approval workflow</h1>
+        <p className="ep-hero-text" style={{ ...styles.body, maxWidth: 640 }}>
+          Most of what an agent does should never reach a person. The workflow&rsquo;s job is to let routine work run inside policy, stop the rest at a named human, and make sure the agent can never move the line between the two.
+        </p>
+      </section>
+
+      <section style={{ ...styles.section, paddingTop: 0, paddingBottom: 72 }}>
+        <h2 className="ep-reveal" style={styles.h2}>Three routes out of one decision point</h2>
+        <p className="ep-reveal" style={styles.body}>
+          Every consequential action an agent attempts passes through a single evaluation, and that evaluation has exactly three outcomes.
+        </p>
+        <div className="ep-reveal" style={grid.auto(220)}>
+          {ROUTES.map(r => (
+            <div key={r.key} className="ep-card-hover" style={{ ...styles.card, borderTop: `3px solid ${r.tone}` }}>
+              <div style={{ fontFamily: font.mono, fontSize: 10, letterSpacing: 1.7, textTransform: 'uppercase', color: r.tone, marginBottom: 12 }}>{r.key}</div>
+              <div style={styles.cardTitle}>{r.title}</div>
+              <div style={styles.cardBody}>{r.body}</div>
+            </div>
+          ))}
+        </div>
+        <p className="ep-reveal" style={{ ...styles.body, marginTop: 24, marginBottom: 0 }}>
+          Almost every approval system has the first and the third. The value is in the middle one, and specifically in what the escalation leaves behind once the human has answered.
+        </p>
+      </section>
+
+      <section style={styles.sectionAlt}>
+        <div style={styles.section}>
+          <div className="ep-reveal ep-tag" style={{ color: color.gold }}>The load-bearing rule</div>
+          <h2 className="ep-reveal" style={styles.h2}>The agent must never widen its own authority</h2>
+          <p className="ep-reveal" style={styles.body}>
+            A workflow that can be argued into granting itself more room is not a control, it is a suggestion. Three rules carry most of the weight here, and each of them is a refusal rather than a warning.
+          </p>
+          <ul className="ep-reveal" style={styles.list}>
+            <li><strong>Authority only narrows on the way down.</strong> A principal that itself holds delegated authority cannot re-delegate more than it holds. A request for a scope outside what the grantor actually has is refused as a scope escalation, and the offending scope is named in the refusal.</li>
+            <li><strong>Unverifiable authority is not authority.</strong> If the delegation record cannot be read, the request does not degrade to permissive. It refuses, because a store that is unreachable and a store that says no should not produce different outcomes.</li>
+            <li><strong>The tier cannot be self-declared.</strong> Assurance runs software, then class_a (a device signoff), then quorum (m-of-n, the two-person rule). The action&rsquo;s risk sets the floor, and a receipt that merely claims a higher tier is graded down to software and refused.</li>
+          </ul>
+          <p className="ep-reveal" style={{ ...styles.body, marginTop: 24, marginBottom: 0 }}>
+            The models behind those transitions are analyzed as models, not only tested as code: {TLA_INVARIANTS} TLA+ invariants checked by {TLA_CHECKER} in CI.
+          </p>
+        </div>
+      </section>
+
+      <section style={{ ...styles.section, paddingTop: 72, paddingBottom: 72 }}>
+        <h2 className="ep-reveal" style={styles.h2}>An approval that is a message, and an approval that is bound</h2>
+        <p className="ep-reveal" style={styles.body}>
+          When a request goes to Slack and someone clicks Approve, the artifact produced is a message: a person, at a time, approved something. It reads like authorization. Structurally it is a notification with a timestamp, and two properties separate it from an approval that can carry weight.
+        </p>
+        <p className="ep-reveal" style={styles.body}>
+          <strong>Bound to the exact action.</strong> The signature covers the parameters, not just the action type: the amount, the beneficiary, the repository, the record. At execution the gate compares what was authorized against what the system of record actually observes and refuses on drift. When a field is declared as required and no observed value is supplied, the check fails closed instead of passing quietly, which is the difference between a control and a formality.
+        </p>
+        <p className="ep-reveal" style={styles.body}>
+          <strong>Used once.</strong> Consumption is keyed to a stable, issuer-generated receipt identifier, and a second presentation of the same approval is refused as a replay. The key is deliberately not a hash of the content: canonicalization can differ between language implementations, which would silently break replay detection exactly when services written in different languages share a consumption store.
+        </p>
+      </section>
+
+      <section className="ep-reveal" style={{ ...styles.section, paddingTop: 0, paddingBottom: 72 }}>
+        <h2 style={styles.h2}>Side by side</h2>
+        <div style={{ overflowX: 'auto', border: `1px solid ${color.border}`, borderRadius: radius.base }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontFamily: font.sans }}>
+            <thead>
+              <tr>
+                <th style={styles.tableHead}>Dimension</th>
+                <th style={styles.tableHead}>Approval as a message</th>
+                <th style={styles.tableHead}>Approval bound to the action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ROWS.map(r => (
+                <tr key={r.dim}>
+                  <td style={{ ...styles.tableCell, color: color.t1, fontWeight: 600 }}>{r.dim}</td>
+                  <td style={styles.tableCell}>{r.msg}</td>
+                  <td style={styles.tableCell}>{r.bound}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section style={{ ...styles.section, paddingTop: 0, paddingBottom: 72 }}>
+        <h2 className="ep-reveal" style={styles.h2}>Choosing what escalates</h2>
+        <p className="ep-reveal" style={styles.body}>
+          The failure mode of approval workflows is not being too strict. It is asking so often that approving becomes reflexive, at which point the human is a rubber stamp with a pager and the evidence trail records a ritual. Two heuristics keep the volume honest.
+        </p>
+        <ul className="ep-reveal" style={styles.list}>
+          <li><strong>Escalate on irreversibility, not on size.</strong> A small payment that cannot be clawed back deserves more scrutiny than a large one that can be reversed with a phone call.</li>
+          <li><strong>Escalate on the parameters that would hurt if they were wrong.</strong> Beneficiary, destination, deletion scope, blast radius. Not the name of the tool being called.</li>
+        </ul>
+        <p className="ep-reveal" style={{ ...styles.body, marginTop: 24, marginBottom: 0 }}>
+          When an action is both rare and severe, raise the tier rather than the frequency. Requiring quorum on the few actions that warrant it costs the team less attention than requiring a click on everything, and it produces a stronger record for the actions that matter.
+        </p>
+      </section>
+
+      <section style={{ ...styles.section, paddingTop: 0, paddingBottom: 72 }}>
+        <h2 className="ep-reveal" style={styles.h2}>Questions</h2>
+        <div className="ep-reveal" style={{ borderTop: `1px solid ${color.border}` }}>
+          {FAQ.map(f => (
+            <div key={f.q} style={{ padding: '22px 0', borderBottom: `1px solid ${color.border}` }}>
+              <h3 style={{ ...styles.h3, marginBottom: 8 }}>{f.q}</h3>
+              <p style={{ fontSize: 14.5, color: color.t2, lineHeight: 1.7, margin: 0 }}>{f.a}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="ep-reveal" style={{ ...styles.section, paddingTop: 0, paddingBottom: 96 }}>
+        <h2 style={styles.h2}>Wire it into your agent</h2>
+        <p style={styles.body}>
+          The quickstart takes an irreversible action in MCP, LangChain, CrewAI, AutoGen, or any Node service and puts this decision point in front of it.
+        </p>
+        <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginBottom: 24 }}>
+          <a href="/quickstart" className="ep-cta" style={cta.primary}>Open the quickstart</a>
+          <a href="/gate" className="ep-cta-secondary" style={cta.secondary}>How enforcement works</a>
+        </div>
+        <p style={{ ...styles.body, marginBottom: 0 }}>
+          For the record an approval leaves behind and what a reviewer does with it, see <a href="/ai-agent-audit-trail" style={{ color: color.gold, textDecoration: 'underline', textUnderlineOffset: 3 }}>AI agent audit trails</a>. For how this compares with a hand-rolled Slack approval, see <a href="/compare/human-in-the-loop" style={{ color: color.gold, textDecoration: 'underline', textUnderlineOffset: 3 }}>EMILIA vs DIY human-in-the-loop</a>.
+        </p>
+      </section>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/app/ai-agent-audit-trail/_content.ts
+++ b/app/ai-agent-audit-trail/_content.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared copy for /ai-agent-audit-trail.
+ *
+ * The FAQ lives here so the visible section (page.tsx, a client component) and
+ * the FAQPage JSON-LD (layout.tsx, a server component that needs the CSP nonce)
+ * are rendered from one array and can never drift apart.
+ *
+ * @license Apache-2.0
+ */
+
+export const PAGE_URL = 'https://www.emiliaprotocol.ai/ai-agent-audit-trail';
+
+export const FAQ = [
+  {
+    q: 'What is an AI agent audit trail?',
+    a: 'A per-action record of what an autonomous agent did and what authorized it. To be useful in a review it has to '
+      + 'carry the exact action parameters, the named human who approved that action, the assurance tier actually proven, '
+      + 'the policy pinned at request time, a one-time consumption key, and the outcome, including the case where the '
+      + 'outcome is unknown.',
+  },
+  {
+    q: 'Are application logs enough for an AI agent audit trail?',
+    a: 'Logs answer what your system says happened. They are written by the system whose conduct is under review, stored '
+      + 'where that system controls, and read back through an interface it provides. That is sound engineering telemetry '
+      + 'and a weak evidentiary position, because every step of the verification path runs through the party being '
+      + 'questioned.',
+  },
+  {
+    q: 'What does offline-verifiable mean here?',
+    a: 'An EMILIA authorization receipt is an Ed25519 signature over the canonical JSON of a claim, optionally anchored in '
+      + 'a sorted-pair Merkle tree. Checking it needs the receipt, the canonicalization rule, and the issuer public key the '
+      + 'checker pinned. It does not need the issuing system to be reachable, cooperative, or still in business.',
+  },
+  {
+    q: 'What happens when the provider never responds?',
+    a: 'The record says indeterminate. Once the executor has been entered, a thrown error is an indeterminate effect, not '
+      + 'proof that nothing happened. The authorization is burned rather than reopened, a blind retry on the same operation '
+      + 'is refused, and the entry stays unresolved until authenticated provider evidence bound to the same operation and '
+      + 'the same canonical action digest resolves it.',
+  },
+] as const;

--- a/app/ai-agent-audit-trail/layout.tsx
+++ b/app/ai-agent-audit-trail/layout.tsx
@@ -1,0 +1,84 @@
+import { headers } from 'next/headers';
+import type { Metadata } from 'next';
+import { FAQ, PAGE_URL } from './_content';
+
+const description =
+  'What an AI agent audit trail must contain to survive review: a signed, offline-verifiable '
+  + 'record per action, not logs written by the system under review.';
+
+export const metadata: Metadata = {
+  // Layout title template appends "| EMILIA", rendering
+  // "AI Agent Audit Trail: The Record That Survives Review | EMILIA".
+  title: 'AI Agent Audit Trail: The Record That Survives Review',
+  description,
+  alternates: { canonical: '/ai-agent-audit-trail' },
+  // Page-level openGraph REPLACES the layout default rather than merging into
+  // it, so images must be restated here or the social card silently drops.
+  openGraph: {
+    title: 'AI Agent Audit Trail: The Record That Survives Review',
+    description:
+      'Signed, offline-verifiable evidence per agent action, including the indeterminate outcome a log cannot express.',
+    url: PAGE_URL,
+    type: 'article',
+    images: ['/og-sequence.jpg'],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'AI Agent Audit Trail: The Record That Survives Review',
+    description,
+    images: ['/og-sequence.jpg'],
+  },
+  keywords: [
+    'AI agent audit trail',
+    'AI agent audit log',
+    'agent action evidence',
+    'offline-verifiable audit record',
+    'tamper-evident agent record',
+    'authorization receipt',
+    'indeterminate outcome',
+  ],
+};
+
+const ARTICLE_JSONLD = {
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'What an AI agent audit trail has to contain',
+  description,
+  about: 'Evidence requirements for autonomous agent actions',
+  url: PAGE_URL,
+  author: { '@type': 'Organization', name: 'EMILIA Protocol' },
+  publisher: { '@type': 'Organization', name: 'EMILIA Protocol', url: 'https://www.emiliaprotocol.ai' },
+  license: 'https://www.apache.org/licenses/LICENSE-2.0',
+};
+
+const FAQ_JSONLD = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: FAQ.map((f) => ({
+    '@type': 'Question',
+    name: f.q,
+    acceptedAnswer: { '@type': 'Answer', text: f.a },
+  })),
+};
+
+export default async function AiAgentAuditTrailLayout({ children }: { children: React.ReactNode }) {
+  const nonce = (await headers()).get('x-nonce') ?? '';
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(ARTICLE_JSONLD) }}
+        nonce={nonce}
+      />
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(FAQ_JSONLD) }}
+        nonce={nonce}
+      />
+      {children}
+    </>
+  );
+}

--- a/app/ai-agent-audit-trail/page.tsx
+++ b/app/ai-agent-audit-trail/page.tsx
@@ -1,0 +1,195 @@
+/**
+ * AI agent audit trail pillar page.
+ *
+ * The affirmative counterpart to /compare/audit-logs: that page argues against
+ * logs as a control, this one specifies the record that replaces them.
+ *
+ * @license Apache-2.0
+ */
+'use client';
+
+import { useEffect } from 'react';
+import SiteNav from '@/components/SiteNav';
+import SiteFooter from '@/components/SiteFooter';
+import { styles, cta, color, font, radius } from '@/lib/tokens';
+import proofStats from '@/lib/proof-stats.json';
+import { FAQ } from './_content';
+
+const CONFORMANCE_SUITES = String(proofStats.conformance.suites);
+const CONFORMANCE_VECTORS = String(proofStats.conformance.vectors);
+const TEST_CASES = Number(proofStats.tests.total).toLocaleString('en-US');
+
+// Each row is a field the record carries and the review question that field
+// closes. Ordered the way a reviewer works: what ran, who said yes, how the
+// yes was established, under what rule, was it reused, did it take effect.
+const FIELDS = [
+  {
+    field: 'The exact action, parameter by parameter',
+    closes: 'Was the thing that ran the thing that was approved? A record of the action type alone cannot answer that; the amount, the beneficiary, and the target are where substitution happens.',
+  },
+  {
+    field: 'The named approver, signing over that action',
+    closes: 'Who said yes? A session identifier names a login. It does not name a person who accepted a consequence.',
+  },
+  {
+    field: 'The assurance tier actually proven',
+    closes: 'How was the yes established? EMILIA ranks software below class_a (device signoff) below quorum (m-of-n). A receipt that merely claims the higher tier is graded down to software and refused.',
+  },
+  {
+    field: 'The policy pinned at request time',
+    closes: 'Under which rule? Pinning is what stops a later policy edit from retroactively legitimizing an action taken before it.',
+  },
+  {
+    field: 'A one-time consumption key',
+    closes: 'Was this approval used more than once? Reuse has to surface as an explicit refusal, not as a second successful action that looks identical to the first.',
+  },
+  {
+    field: 'The outcome, including "not established"',
+    closes: 'Did it actually take effect? A record that can only say success or failure will assert one of them when neither was observed.',
+  },
+];
+
+export default function AiAgentAuditTrailPage(): React.ReactElement {
+  useEffect(() => {
+    const els = document.querySelectorAll('.ep-reveal');
+    const obs = new IntersectionObserver(
+      entries => entries.forEach(e => { if (e.isIntersecting) { e.target.classList.add('is-visible'); obs.unobserve(e.target); } }),
+      { threshold: 0.12 }
+    );
+    els.forEach(el => obs.observe(el));
+    return () => obs.disconnect();
+  }, []);
+
+  return (
+    <div style={styles.page}>
+      <SiteNav activePage="" />
+
+      <section style={{ ...styles.section, paddingTop: 100, paddingBottom: 56 }}>
+        <div className="ep-tag ep-hero-badge" style={{ color: color.gold }}>Audit Trail / AI Agents</div>
+        <h1 className="ep-hero-text" style={styles.h1}>What an AI agent audit trail has to contain</h1>
+        <p className="ep-hero-text" style={{ ...styles.body, maxWidth: 640 }}>
+          A log tells a reviewer what your system says happened. An audit trail for autonomous actions has to answer a harder question: who authorized <em>this exact action</em>, under which policy, and can that be checked without asking you.
+        </p>
+      </section>
+
+      <section style={{ ...styles.section, paddingTop: 0, paddingBottom: 56 }}>
+        <h2 className="ep-reveal" style={styles.h2}>The question a reviewer is actually asking</h2>
+        <p className="ep-reveal" style={styles.body}>
+          Every review of an agent action converges on the same four questions. What exactly executed. Who authorized it. Under what rule, as the rule stood at the time. And what the record says when none of that can be established. A trail built for debugging answers the first question well and the other three badly.
+        </p>
+        <p className="ep-reveal" style={styles.body}>
+          The gap is not thoroughness. You can capture every field of every request and still not hold evidence, because the capture is a statement by the system whose behavior is in question.
+        </p>
+      </section>
+
+      <section className="ep-reveal" style={{ ...styles.section, paddingTop: 0, paddingBottom: 72 }}>
+        <h2 style={styles.h2}>What the record must carry</h2>
+        <div style={{ overflowX: 'auto', border: `1px solid ${color.border}`, borderRadius: radius.base }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontFamily: font.sans }}>
+            <thead>
+              <tr>
+                <th style={styles.tableHead}>Field</th>
+                <th style={styles.tableHead}>The review question it closes</th>
+              </tr>
+            </thead>
+            <tbody>
+              {FIELDS.map(f => (
+                <tr key={f.field}>
+                  <td style={{ ...styles.tableCell, color: color.t1, fontWeight: 600, minWidth: 220 }}>{f.field}</td>
+                  <td style={styles.tableCell}>{f.closes}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section style={{ ...styles.section, paddingTop: 0, paddingBottom: 72 }}>
+        <h2 className="ep-reveal" style={styles.h2}>Application logs are self-attested</h2>
+        <p className="ep-reveal" style={styles.body}>
+          Your application log is written by the system under review, into storage that system controls, and read back through an interface that system provides. Every step of the verification path runs through the party being questioned. Checking the record needs your database, your access grant, and your continued cooperation. When the system itself is what is in doubt, its record inherits the doubt.
+        </p>
+        <p className="ep-reveal" style={styles.body}>
+          That is not an argument against logging. Logs are the right instrument for operating a system and the wrong one for settling a dispute about an irreversible action, and the two jobs are usually assigned to the same file.
+        </p>
+        <p className="ep-reveal" style={{ ...styles.body, marginBottom: 0 }}>
+          <a href="/compare/audit-logs" style={{ color: color.gold, textDecoration: 'underline', textUnderlineOffset: 3 }}>The full argument, side by side: audit logs vs authorization receipts</a>
+        </p>
+      </section>
+
+      <section style={{ ...styles.section, paddingTop: 0, paddingBottom: 72 }}>
+        <h2 className="ep-reveal" style={styles.h2}>What a signed per-action record adds</h2>
+        <p className="ep-reveal" style={styles.body}>
+          An EMILIA authorization receipt is an Ed25519 signature over the canonical JSON of a claim, optionally anchored in a sorted-pair Merkle tree. Verifying one needs the receipt, the canonicalization rule, and the issuer public key the checker pinned. It does not need our servers, your database, or anyone&rsquo;s permission.
+        </p>
+        <ul className="ep-reveal" style={styles.list}>
+          <li><strong>It can be handed over.</strong> An auditor, an insurer, or a counterparty checks it themselves, with the Apache-2.0 reference verifiers for JavaScript and Python.</li>
+          <li><strong>It cannot be quietly amended.</strong> Any edit to a signed field breaks the signature, so a record that still verifies is the record that was issued.</li>
+          <li><strong>It outlives the issuer.</strong> The evidence does not depend on the issuing system still running, still being reachable, or still being on your side.</li>
+        </ul>
+        <p className="ep-reveal" style={{ ...styles.body, marginTop: 24 }}>
+          The receipt format is public and implementable in any language: see <a href="/spec/trust-receipt" style={{ color: color.gold, textDecoration: 'underline', textUnderlineOffset: 3 }}>EP-RECEIPT-v1</a>.
+        </p>
+      </section>
+
+      <section style={styles.sectionAlt}>
+        <div style={styles.section}>
+          <div className="ep-reveal ep-tag" style={{ color: color.gold }}>The hard case</div>
+          <h2 className="ep-reveal" style={styles.h2}>When the provider goes silent, the honest answer is INDETERMINATE</h2>
+          <p className="ep-reveal" style={styles.body}>
+            The hardest case in the design is not the attacker. It is the executor that stops answering. An action is authorized, the gate reserves it, the executor is invoked, and then the call throws: a timeout, a dropped connection, a 500 after the write. From where the caller stands, &ldquo;it fully executed&rdquo; and &ldquo;it never happened&rdquo; are indistinguishable.
+          </p>
+          <p className="ep-reveal" style={styles.body}>
+            A retry-shaped system resolves that by guessing. Treat it as failure and retry, and the effect may land twice. Treat it as success and the record now asserts an effect nobody observed. Either way the trail states something no one checked, and it states it with the same confidence as everything else in the file.
+          </p>
+          <p className="ep-reveal" style={styles.body}>
+            EMILIA records the third answer. Once the executor has been entered, a thrown error is an <em>indeterminate effect</em>, not proof that nothing happened. The authorization is burned rather than reopened, a blind retry on the same operation is refused before the provider can be re-entered, and the reserved budget is not silently restored. The entry stays indeterminate until authenticated provider evidence resolves it: signed by a pinned provider key, bound to the same operation identifier and the same canonical action digest. Evidence for a different destination, or with a broken signature, does not reconcile and never enters the ledger.
+          </p>
+          <pre className="ep-reveal" style={{ fontFamily: font.mono, fontSize: 12.5, lineHeight: 1.8, color: '#D6D3D1', background: '#1C1917', border: `1px solid ${color.border}`, borderRadius: radius.base, padding: '20px 22px', margin: '0 0 24px', overflowX: 'auto', whiteSpace: 'pre' }}>{`$ node examples/indeterminate-effect-reconciliation/demo.mjs
+
+1  PROVIDER COMMITTED     effects=1
+2  RESPONSE LOST          effect_indeterminate
+3  CAPABILITY FINALIZED   indeterminate
+4  BLIND RETRY            operation_already_committed
+5  AUTHENTICATED GET      executed
+6  PROVIDER EXECUTIONS    1`}</pre>
+          <p className="ep-reveal" style={{ ...styles.body, marginBottom: 0 }}>
+            That is what surviving review means in practice. The record is allowed to say it does not know, and it is not allowed to guess.
+          </p>
+        </div>
+      </section>
+
+      <section style={{ ...styles.section, paddingTop: 72, paddingBottom: 72 }}>
+        <h2 className="ep-reveal" style={styles.h2}>Where the mechanism is checked</h2>
+        <p className="ep-reveal" style={styles.body}>
+          The properties above are behaviors of code, so they are tested as behaviors: {CONFORMANCE_SUITES} conformance suites covering {CONFORMANCE_VECTORS} vectors, and {TEST_CASES} automated test cases, with the refusal paths tested as explicitly as the happy path. The full evidence index, including what each artifact does <em>not</em> establish, is on the engineering evidence page.
+        </p>
+      </section>
+
+      <section style={{ ...styles.section, paddingTop: 0, paddingBottom: 72 }}>
+        <h2 className="ep-reveal" style={styles.h2}>Questions</h2>
+        <div className="ep-reveal" style={{ borderTop: `1px solid ${color.border}` }}>
+          {FAQ.map(f => (
+            <div key={f.q} style={{ padding: '22px 0', borderBottom: `1px solid ${color.border}` }}>
+              <h3 style={{ ...styles.h3, marginBottom: 8 }}>{f.q}</h3>
+              <p style={{ fontSize: 14.5, color: color.t2, lineHeight: 1.7, margin: 0 }}>{f.a}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="ep-reveal" style={{ ...styles.section, paddingTop: 0, paddingBottom: 96 }}>
+        <h2 style={styles.h2}>Next</h2>
+        <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginBottom: 24 }}>
+          <a href="/proof" className="ep-cta" style={cta.primary}>Read the engineering evidence</a>
+          <a href="/compare/audit-logs" className="ep-cta-secondary" style={cta.secondary}>Audit logs vs receipts</a>
+        </div>
+        <p style={{ ...styles.body, marginBottom: 0 }}>
+          The record described here is what an approval leaves behind. For the workflow that produces it, see <a href="/ai-agent-approvals" style={{ color: color.gold, textDecoration: 'underline', textUnderlineOffset: 3 }}>AI agent approval workflows</a>.
+        </p>
+      </section>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -52,6 +52,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: '/sovereignty',           priority: 0.9, changeFrequency: 'monthly' },
     { path: '/quickstart',            priority: 0.85, changeFrequency: 'monthly' },
     { path: '/guides/require-receipt', priority: 0.85, changeFrequency: 'monthly' },
+    { path: '/ai-agent-audit-trail',  priority: 0.9,  changeFrequency: 'monthly' },
+    { path: '/ai-agent-approvals',    priority: 0.9,  changeFrequency: 'monthly' },
     { path: '/use-cases',             priority: 0.9, changeFrequency: 'monthly' },
     { path: '/use-cases/government',  priority: 0.85, changeFrequency: 'monthly' },
     { path: '/use-cases/financial',   priority: 0.85, changeFrequency: 'monthly' },


### PR DESCRIPTION
Two high-intent pages the marketing audit found missing.

- **/ai-agent-audit-trail** targets "AI agent audit trail". `/compare/audit-logs` argues against logs but nothing sold the replacement, so this is the affirmative page: what a record must contain to survive review, why application logs are self-attested by the system under review, and what an unresolved outcome looks like when a provider goes silent.
- **/ai-agent-approvals** targets "AI agent approval workflow". Equity was scattered across `/quickstart` and two compare pages with no pillar: approve routine work inside policy, escalate what falls outside, never let the agent widen its own authority, and the difference between an approval that is a message and one bound to the exact action.

Both reuse the existing design system (`/compare/*` and `/gate` patterns, existing tokens and components) rather than introducing a new one, and both set `openGraph` **and** `twitter` images explicitly, because a page-level `openGraph` block replaces the layout default and silently drops the social image. That was a real audit finding across the whole site.

No customer, adoption, certification, or RFC-status claims. Added to the sitemap alongside the comparable hand-built pages.

`npm run build` clean:
```
├ ƒ /ai-agent-approvals      5.13 kB   122 kB
├ ƒ /ai-agent-audit-trail    5.19 kB   122 kB
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)