### PR TITLE
fix(secure-app): replace the binary audit gate with dated, expiring exceptions

### DIFF
--- a/.github/workflows/mobile-apps.yml
+++ b/.github/workflows/mobile-apps.yml
@@ -21,6 +21,7 @@ on:
       - 'packages/mobile/**'
       - 'sdks/kotlin-mobile/**'
       - 'sdks/swift-mobile/**'
+      - 'scripts/audit-with-exceptions.mjs'
       - 'scripts/check-mobile-production.mjs'
       - 'scripts/check-mobile-release.mjs'
       - 'scripts/check-write-discipline.js'
@@ -52,6 +53,7 @@ on:
       - 'packages/mobile/**'
       - 'sdks/kotlin-mobile/**'
       - 'sdks/swift-mobile/**'
+      - 'scripts/audit-with-exceptions.mjs'
       - 'scripts/check-mobile-production.mjs'
       - 'scripts/check-mobile-release.mjs'
       - 'scripts/check-write-discipline.js'
@@ -167,7 +169,9 @@ jobs:
       - name: Install secure-app dependencies
         working-directory: apps/secure-app
         run: npm ci --ignore-scripts
-      - name: Enforce zero secure-app vulnerabilities at low severity
+      - name: Enforce the secure-app audit gate at low severity
+        # Detection stays at low. Advisories with no upstream fix pass only when
+        # audit-exceptions.json accepts them, and each acceptance expires.
         working-directory: apps/secure-app
         run: npm run audit:dependencies
       - name: Run secure-app protocol tests

--- a/apps/secure-app/README.md
+++ b/apps/secure-app/README.md
@@ -89,6 +89,56 @@ class, software-key Class-A refusal, hardware-policy refusal, biometric-only
 and passcode-capable OS semantics, malformed/expired session refusal, corrupt
 SecureStore cleanup, and absence of bundled-token or live software-submit paths.
 
+## Dependency audit and exceptions
+
+```bash
+npm run audit:dependencies
+```
+
+Detection stays at `--audit-level=low`. Nothing is downgraded and nothing is
+blanket-ignored.
+
+Some advisories have no upstream fix. The current example is `image-size`,
+which reaches this app only through the Expo/metro bundler: every published
+version of it is inside the advisory range, and npm's suggested remediation is
+a three-major downgrade of Expo. `npm audit --omit=dev` does not help either,
+because `expo` and `react-native` are production dependencies and npm's
+dependency graph cannot express "ships to the device" versus "runs on the build
+machine".
+
+The gate in `../../scripts/audit-with-exceptions.mjs` handles that case without
+going quiet. Every advisory it lets through must be named in
+`audit-exceptions.json` with a written reachability justification, evidence
+that no upstream fix exists and what was checked to establish that, who
+accepted it, and two dates: when it was accepted and when the acceptance
+expires.
+
+**An exception expires.** On its `expires_on` date the build starts failing on
+that advisory until someone re-verifies it and accepts a new dated decision or
+fixes it. An acceptance window cannot exceed 180 days, so a far-future date
+cannot be used to make an exception permanent. Adding an entry here is a
+decision with a date on it, not a permanent silence.
+
+The gate fails, with a named reason, when any of these hold:
+
+| Reason | Meaning |
+|---|---|
+| `uncovered_advisory` | A live advisory no exception covers. The default answer to a new finding is still to fix it. |
+| `expired_exception` | An acceptance passed its `expires_on` date. This is the forcing function. |
+| `stale_exception` | An exception matches nothing live, so the file self-cleans and only ever describes real accepted risk. |
+| `malformed_exceptions_file` | Missing, unreadable, or missing a required field. A placeholder justification is rejected on length. |
+| `expiry_window_too_long` | The acceptance window exceeds 180 days. |
+| `unreviewed_affected_package` | The advisory now reaches a package outside the reviewed `affected_packages` set, so the reachability argument was written against a different blast radius. |
+| `severity_escalated` | The advisory is now more severe than the level it was accepted at. |
+| `audit_report_invalid` | `npm audit` produced nothing usable. The gate fails instead of reading an empty report as "clean". |
+| `invalid_usage` | The gate was invoked with a bad prefix, flag, or severity floor. A misconfigured gate fails rather than passing. |
+
+On success it prints each accepted advisory, its justification, and the days
+remaining before expiry, and warns when fewer than 21 days are left.
+
+The gate's own behaviour is covered by `lib/audit-gate.test.mjs`, which runs
+under `npm test` alongside the protocol tests.
+
 ## External acceptance gates
 
 Before any production signing claim, a platform-native build must:

--- a/apps/secure-app/audit-exceptions.json
+++ b/apps/secure-app/audit-exceptions.json
@@ -1,0 +1,78 @@
+{
+  "version": 1,
+  "description": "Advisories accepted for apps/secure-app, each with an expiry date. Read ../../scripts/audit-with-exceptions.mjs for the enforced schema and README.md for the model. An entry here is a dated decision, not a permanent silence.",
+  "exceptions": [
+    {
+      "advisory": "https://github.com/advisories/GHSA-w3rx-r6r6-pgpr",
+      "advisory_ids": [1138808],
+      "package": "image-size",
+      "severity": "high",
+      "title": "image-size: ICNS parser allows denial of service through an infinite loop",
+      "affected_packages": [
+        "@expo/cli",
+        "@expo/metro",
+        "@expo/metro-config",
+        "@react-native/community-cli-plugin",
+        "@react-native/virtualized-lists",
+        "expo",
+        "image-size",
+        "metro",
+        "metro-config",
+        "metro-transform-worker",
+        "react-native"
+      ],
+      "reachability": "Build-machine only, not device-reachable. image-size is declared by exactly one package in apps/secure-app/package-lock.json: node_modules/metro requires image-size ^1.0.2 (resolved 1.2.1). metro is the React Native bundler; it runs on the build machine to produce the JS bundle and is not part of the bundle it emits. The other ten flagged packages are transitive effects of that single edge, not independent introductions. No app source file reaches the parser: the imports across index.ts, App.tsx, lib/ep-client.ts, lib/ep-signoff.ts, lib/secure-key.ts and lib/session.ts are expo, expo-screen-capture, expo-status-bar, expo-secure-store, expo-local-authentication, @noble/curves, @noble/hashes, react and react-native only, with no import of image-size or metro. The app also ships no image assets, so the ICNS/JXL/HEIF decode path has no input at build time either. The advisory is CWE-835, an infinite loop reached by parsing a hostile image file, and its CVSS vector is availability-only (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H): worst case is a hung or slow CI bundler job on attacker-supplied image input, with no confidentiality or integrity impact and no exposure on a paired device. Scope limit: metro's internal call site for image-size was not read, so this justification rests on the dependency edge and the absence of any app-side image input, not on an audit of metro's parser usage.",
+      "no_upstream_fix": {
+        "checked_on": "2026-08-07",
+        "advisory_range": "<=2.0.2",
+        "npm_vulnerability_range": "*",
+        "installed_version": "1.2.1",
+        "latest_published_version": "2.0.2",
+        "how_checked": "`npm view image-size version` returned 2.0.2 and `npm view image-size versions --json` returned 71 versions ending 2.0.2; the advisory range <=2.0.2 in `npm audit --json` therefore covers every published version, and npm reports the vulnerability range for the installed node as `*`. There is no fixed version to upgrade to.",
+        "npm_suggested_fix": "expo@53.0.27, reported by npm audit with isSemVerMajor: true",
+        "why_suggested_fix_rejected": "apps/secure-app/package.json pins expo ~56.0.19. npm's suggestion is a three-major downgrade to expo 53, not a fix: it would revert the app's Expo SDK rather than remove the advisory, and image-size has no unaffected version to land on regardless.",
+        "why_omit_dev_does_not_help": "`npm audit --omit=dev` still reports all 11 findings, because expo and react-native are production dependencies and pull the bundler chain transitively. npm's dependency graph cannot express `ships to the device` versus `runs on the build machine`, which is the distinction that makes this advisory unreachable here."
+      },
+      "accepted_by": "EMILIA Protocol maintainers",
+      "accepted_on": "2026-08-07",
+      "expires_on": "2026-11-05",
+      "revisit_trigger": "Remove this entry as soon as any of the following holds: image-size publishes a version outside the advisory range and metro or expo picks it up; expo ships an SDK 56-or-later release whose bundler chain drops image-size; the advisory is amended to describe a runtime-reachable or non-availability impact; or any package outside the reviewed affected_packages list starts pulling image-size, which the gate fails on automatically. Otherwise re-verify every field above before the expiry date and accept a new dated decision or fix it."
+    },
+    {
+      "advisory": "https://github.com/advisories/GHSA-5p2g-fcmc-qvqq",
+      "advisory_ids": [1138809],
+      "package": "image-size",
+      "severity": "high",
+      "title": "image-size: JXL and HEIF parsers allow denial of service through infinite loops",
+      "affected_packages": [
+        "@expo/cli",
+        "@expo/metro",
+        "@expo/metro-config",
+        "@react-native/community-cli-plugin",
+        "@react-native/virtualized-lists",
+        "expo",
+        "image-size",
+        "metro",
+        "metro-config",
+        "metro-transform-worker",
+        "react-native"
+      ],
+      "reachability": "Build-machine only, not device-reachable. Same single dependency edge as GHSA-w3rx-r6r6-pgpr: node_modules/metro is the only package in apps/secure-app/package-lock.json declaring image-size (^1.0.2, resolved 1.2.1), and metro is the build-time bundler rather than shipped device code. The ten other flagged packages are transitive effects of that one edge. No app source file imports image-size or metro, and the app ships no image assets, so neither the JXL nor the HEIF parser has reachable input from this project. The advisory is CWE-835 with an availability-only CVSS vector (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H): worst case is a hung CI bundler job on a hostile image, with no confidentiality or integrity impact and no exposure on a paired device. Scope limit: metro's internal call site for image-size was not read, so this rests on the dependency edge and the absence of app-side image input, not on an audit of metro's parser usage.",
+      "no_upstream_fix": {
+        "checked_on": "2026-08-07",
+        "advisory_range": "<=2.0.2",
+        "npm_vulnerability_range": "*",
+        "installed_version": "1.2.1",
+        "latest_published_version": "2.0.2",
+        "how_checked": "`npm view image-size version` returned 2.0.2 and `npm view image-size versions --json` returned 71 versions ending 2.0.2; the advisory range <=2.0.2 in `npm audit --json` therefore covers every published version, and npm reports the vulnerability range for the installed node as `*`. There is no fixed version to upgrade to.",
+        "npm_suggested_fix": "expo@53.0.27, reported by npm audit with isSemVerMajor: true",
+        "why_suggested_fix_rejected": "apps/secure-app/package.json pins expo ~56.0.19. npm's suggestion is a three-major downgrade to expo 53, not a fix: it would revert the app's Expo SDK rather than remove the advisory, and image-size has no unaffected version to land on regardless.",
+        "why_omit_dev_does_not_help": "`npm audit --omit=dev` still reports all 11 findings, because expo and react-native are production dependencies and pull the bundler chain transitively. npm's dependency graph cannot express `ships to the device` versus `runs on the build machine`, which is the distinction that makes this advisory unreachable here."
+      },
+      "accepted_by": "EMILIA Protocol maintainers",
+      "accepted_on": "2026-08-07",
+      "expires_on": "2026-11-05",
+      "revisit_trigger": "Remove this entry as soon as any of the following holds: image-size publishes a version outside the advisory range and metro or expo picks it up; expo ships an SDK 56-or-later release whose bundler chain drops image-size; the advisory is amended to describe a runtime-reachable or non-availability impact; or any package outside the reviewed affected_packages list starts pulling image-size, which the gate fails on automatically. Otherwise re-verify every field above before the expiry date and accept a new dated decision or fix it."
+    }
+  ]
+}

--- a/apps/secure-app/lib/audit-gate.test.mjs
+++ b/apps/secure-app/lib/audit-gate.test.mjs
@@ -1,0 +1,352 @@
+/**
+ * Audit-exception gate regression tests.
+ *
+ *   node --test apps/secure-app/lib/audit-gate.test.mjs
+ *
+ * The synthetic cases run against fixture reports and fixture exception files
+ * written to a temporary directory. The real audit and the committed exception
+ * file are never mutated to produce a failure.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  AuditGateError,
+  FAILURE,
+  collectLiveAdvisories,
+  evaluate,
+  loadExceptions,
+  parseExceptions,
+} from '../../../scripts/audit-with-exceptions.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SECURE_APP = resolve(HERE, '..');
+const REPO_ROOT = resolve(HERE, '../../..');
+const GATE = join(REPO_ROOT, 'scripts/audit-with-exceptions.mjs');
+
+const ICNS = 'https://github.com/advisories/GHSA-w3rx-r6r6-pgpr';
+const OTHER = 'https://github.com/advisories/GHSA-0000-0000-0000';
+
+const NOW = Date.parse('2026-09-01T00:00:00Z');
+
+const REACHABILITY =
+  'Build-machine only. The package is declared by the bundler alone and no application source file imports it, '
+  + 'so the parser has no reachable input on a device.';
+const TRIGGER = 'Remove this entry when the bundler chain drops the vulnerable package or a fixed version ships.';
+const HOW_CHECKED = 'Queried the registry for every published version; the advisory range covers all of them.';
+const WHY_REJECTED = 'The suggested remediation is a three-major downgrade of the framework, which is not a fix.';
+
+/** Build an npm-audit-shaped report whose metadata reconciles. */
+function auditReport(vulnerabilities) {
+  const summary = { info: 0, low: 0, moderate: 0, high: 0, critical: 0, total: 0 };
+  for (const entry of Object.values(vulnerabilities)) {
+    summary[entry.severity] += 1;
+    summary.total += 1;
+  }
+  return { auditReportVersion: 2, vulnerabilities, metadata: { vulnerabilities: summary } };
+}
+
+function advisoryCause({ url = ICNS, source = 1138808, severity = 'high', name = 'image-size' } = {}) {
+  return {
+    source,
+    name,
+    dependency: name,
+    title: `${name}: denial of service through an infinite loop`,
+    url,
+    severity,
+    cwe: ['CWE-835'],
+    range: '<=2.0.2',
+  };
+}
+
+/**
+ * A bundler chain shaped like the real one, including the metro/metro-config
+ * cycle, so the transitive walk is exercised rather than a straight line.
+ */
+function bundlerChainReport({ url = ICNS, severity = 'high', extraDependent = null } = {}) {
+  const vulnerabilities = {
+    'image-size': { name: 'image-size', severity, via: [advisoryCause({ url, severity })], effects: ['metro'] },
+    metro: { name: 'metro', severity, via: ['image-size', 'metro-config'], effects: ['metro-config'] },
+    'metro-config': { name: 'metro-config', severity, via: ['metro'], effects: ['metro'] },
+  };
+  if (extraDependent !== null) {
+    vulnerabilities[extraDependent] = { name: extraDependent, severity, via: ['metro'], effects: [] };
+  }
+  return auditReport(vulnerabilities);
+}
+
+function exceptionEntry(overrides = {}) {
+  return {
+    advisory: ICNS,
+    package: 'image-size',
+    severity: 'high',
+    affected_packages: ['image-size', 'metro', 'metro-config'],
+    reachability: REACHABILITY,
+    no_upstream_fix: {
+      checked_on: '2026-08-07',
+      advisory_range: '<=2.0.2',
+      latest_published_version: '2.0.2',
+      npm_suggested_fix: 'expo@53.0.27 (isSemVerMajor: true)',
+      how_checked: HOW_CHECKED,
+      why_suggested_fix_rejected: WHY_REJECTED,
+    },
+    accepted_by: 'EMILIA Protocol maintainers',
+    accepted_on: '2026-08-07',
+    expires_on: '2026-11-05',
+    revisit_trigger: TRIGGER,
+    ...overrides,
+  };
+}
+
+function exceptionDocument(entries, overrides = {}) {
+  return JSON.stringify({ version: 1, exceptions: entries, ...overrides });
+}
+
+/** Write a fixture exception file and return its path; cleaned up by the caller hook. */
+function fixtureFile(t, contents) {
+  const directory = mkdtempSync(join(tmpdir(), 'ep-audit-gate-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const path = join(directory, 'audit-exceptions.json');
+  writeFileSync(path, contents, 'utf8');
+  return path;
+}
+
+function reasons(failures) {
+  return failures.map((failure) => failure.reason).sort();
+}
+
+test('the transitive walk resolves the full blast radius through a dependency cycle', () => {
+  const advisories = collectLiveAdvisories(bundlerChainReport(), 'low');
+  assert.equal(advisories.size, 1);
+  const advisory = advisories.get(ICNS);
+  assert.deepEqual([...advisory.affectedPackages].sort(), ['image-size', 'metro', 'metro-config']);
+  assert.equal(advisory.severity, 'high');
+  assert.deepEqual([...advisory.ids], [1138808]);
+});
+
+test('a live advisory with no exception fails as uncovered', () => {
+  const advisories = collectLiveAdvisories(bundlerChainReport(), 'low');
+  const { failures, accepted } = evaluate({ advisories, exceptions: [], now: NOW });
+
+  assert.deepEqual(reasons(failures), [FAILURE.UNCOVERED_ADVISORY]);
+  assert.equal(accepted.length, 0);
+  assert.match(failures[0].message, /not covered by any exception/);
+  assert.match(failures[0].message, /image-size, metro, metro-config/);
+});
+
+test('a covered advisory passes and reports the days remaining', () => {
+  const advisories = collectLiveAdvisories(bundlerChainReport(), 'low');
+  const exceptions = parseExceptions(exceptionDocument([exceptionEntry()]));
+  const { failures, accepted } = evaluate({ advisories, exceptions, now: NOW });
+
+  assert.deepEqual(failures, []);
+  assert.equal(accepted.length, 1);
+  assert.equal(accepted[0].advisory, ICNS);
+  assert.equal(accepted[0].expiresOn, '2026-11-05');
+  // 2026-09-01 to 2026-11-05 is 65 days.
+  assert.equal(accepted[0].daysRemaining, 65);
+  assert.equal(accepted[0].affectedPackageCount, 3);
+});
+
+test('an exception past its expires_on fails loudly and is not accepted', () => {
+  const advisories = collectLiveAdvisories(bundlerChainReport(), 'low');
+  const exceptions = parseExceptions(exceptionDocument([exceptionEntry({ expires_on: '2026-08-20' })]));
+  const { failures, accepted } = evaluate({ advisories, exceptions, now: NOW });
+
+  assert.deepEqual(reasons(failures), [FAILURE.EXPIRED_EXCEPTION]);
+  assert.equal(accepted.length, 0);
+  assert.match(failures[0].message, /expired on 2026-08-20 \(12 day\(s\) ago\)/);
+  assert.match(failures[0].message, /Revisit trigger/);
+});
+
+test('an exception expires at the start of its expires_on day, not the end', () => {
+  const advisories = collectLiveAdvisories(bundlerChainReport(), 'low');
+  const exceptions = parseExceptions(exceptionDocument([exceptionEntry({ expires_on: '2026-09-01' })]));
+
+  const onTheDay = evaluate({ advisories, exceptions, now: Date.parse('2026-09-01T00:00:00Z') });
+  assert.deepEqual(reasons(onTheDay.failures), [FAILURE.EXPIRED_EXCEPTION]);
+
+  const theDayBefore = evaluate({ advisories, exceptions, now: Date.parse('2026-08-31T23:59:59Z') });
+  assert.deepEqual(theDayBefore.failures, []);
+  assert.equal(theDayBefore.accepted.length, 1);
+});
+
+test('an exception matching nothing live fails as stale so the file self-cleans', () => {
+  const advisories = collectLiveAdvisories(auditReport({}), 'low');
+  const exceptions = parseExceptions(exceptionDocument([exceptionEntry()]));
+  const { failures, accepted } = evaluate({ advisories, exceptions, now: NOW });
+
+  assert.deepEqual(reasons(failures), [FAILURE.STALE_EXCEPTION]);
+  assert.equal(accepted.length, 0);
+  assert.match(failures[0].message, /no longer appears in npm audit/);
+});
+
+test('a stale exception is reported even while another exception is still live', () => {
+  const advisories = collectLiveAdvisories(bundlerChainReport(), 'low');
+  const exceptions = parseExceptions(
+    exceptionDocument([exceptionEntry(), exceptionEntry({ advisory: OTHER })]),
+  );
+  const { failures, accepted } = evaluate({ advisories, exceptions, now: NOW });
+
+  assert.deepEqual(reasons(failures), [FAILURE.STALE_EXCEPTION]);
+  assert.equal(failures[0].advisory, OTHER);
+  assert.equal(accepted.length, 1);
+});
+
+test('an advisory reaching a package outside the reviewed set fails', () => {
+  const advisories = collectLiveAdvisories(bundlerChainReport({ extraDependent: 'some-runtime-package' }), 'low');
+  const exceptions = parseExceptions(exceptionDocument([exceptionEntry()]));
+  const { failures, accepted } = evaluate({ advisories, exceptions, now: NOW });
+
+  assert.deepEqual(reasons(failures), [FAILURE.UNREVIEWED_AFFECTED_PACKAGE]);
+  assert.equal(accepted.length, 0);
+  assert.match(failures[0].message, /some-runtime-package/);
+});
+
+test('an advisory whose severity escalates past the accepted level fails', () => {
+  const advisories = collectLiveAdvisories(bundlerChainReport({ severity: 'critical' }), 'low');
+  const exceptions = parseExceptions(exceptionDocument([exceptionEntry({ severity: 'high' })]));
+  const { failures, accepted } = evaluate({ advisories, exceptions, now: NOW });
+
+  assert.deepEqual(reasons(failures), [FAILURE.SEVERITY_ESCALATED]);
+  assert.equal(accepted.length, 0);
+  assert.match(failures[0].message, /accepted at high but is now critical/);
+});
+
+test('a malformed exception file is rejected with a named reason', (t) => {
+  const cases = [
+    ['not valid JSON', '{ not json'],
+    ['top level must be an object', '[]'],
+    ['unsupported schema version', JSON.stringify({ version: 2, exceptions: [] })],
+    ['exceptions must be an array', JSON.stringify({ version: 1, exceptions: {} })],
+    ['advisory must be a GitHub advisory URL', exceptionDocument([exceptionEntry({ advisory: 'CVE-2026-1' })])],
+    ['duplicate exception', exceptionDocument([exceptionEntry(), exceptionEntry()])],
+    ['severity must be one of', exceptionDocument([exceptionEntry({ severity: 'spicy' })])],
+    ['affected_packages must be a non-empty array', exceptionDocument([exceptionEntry({ affected_packages: [] })])],
+    ['reachability is required', exceptionDocument([exceptionEntry({ reachability: undefined })])],
+    ['reachability must be a real justification', exceptionDocument([exceptionEntry({ reachability: 'n/a' })])],
+    ['revisit_trigger must be a real justification', exceptionDocument([exceptionEntry({ revisit_trigger: 'later' })])],
+    ['accepted_by is required', exceptionDocument([exceptionEntry({ accepted_by: '' })])],
+    ['no_upstream_fix must be an object', exceptionDocument([exceptionEntry({ no_upstream_fix: 'none' })])],
+    ['expires_on must be a YYYY-MM-DD date', exceptionDocument([exceptionEntry({ expires_on: '11/05/2026' })])],
+    ['expires_on is not a real calendar date', exceptionDocument([exceptionEntry({ expires_on: '2026-11-31' })])],
+    ['must be after accepted_on', exceptionDocument([exceptionEntry({ expires_on: '2026-08-06' })])],
+  ];
+
+  for (const [expected, contents] of cases) {
+    assert.throws(
+      () => parseExceptions(contents, 'fixture'),
+      (error) => {
+        assert.ok(error instanceof AuditGateError, `${expected}: expected an AuditGateError`);
+        assert.equal(error.reason, FAILURE.MALFORMED_EXCEPTIONS_FILE, `${expected}: wrong reason`);
+        assert.match(error.message, new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+        return true;
+      },
+      `expected a malformed-file failure for: ${expected}`,
+    );
+  }
+
+  // A required no_upstream_fix subfield is checked one level down.
+  const missingEvidence = exceptionEntry();
+  delete missingEvidence.no_upstream_fix.how_checked;
+  assert.throws(
+    () => parseExceptions(exceptionDocument([missingEvidence]), 'fixture'),
+    (error) => error.reason === FAILURE.MALFORMED_EXCEPTIONS_FILE && /how_checked is required/.test(error.message),
+  );
+});
+
+test('a far-future expiry is rejected so the forcing function cannot be defeated', () => {
+  assert.throws(
+    () => parseExceptions(exceptionDocument([exceptionEntry({ expires_on: '2099-01-01' })]), 'fixture'),
+    (error) => {
+      assert.ok(error instanceof AuditGateError);
+      assert.equal(error.reason, FAILURE.EXPIRY_WINDOW_TOO_LONG);
+      assert.match(error.message, /exceeds the 180-day maximum/);
+      return true;
+    },
+  );
+});
+
+test('a missing exception file is a named failure rather than a silent pass', (t) => {
+  const directory = mkdtempSync(join(tmpdir(), 'ep-audit-gate-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  assert.throws(
+    () => loadExceptions(join(directory, 'audit-exceptions.json')),
+    (error) => {
+      assert.ok(error instanceof AuditGateError);
+      assert.equal(error.reason, FAILURE.MALFORMED_EXCEPTIONS_FILE);
+      assert.match(error.message, /could not be read/);
+      return true;
+    },
+  );
+});
+
+test('a malformed exception file on disk fails through the file-loading path', (t) => {
+  const path = fixtureFile(t, '{"version": 1, "exceptions": [{"advisory": "nope"}]}');
+  assert.throws(
+    () => loadExceptions(path),
+    (error) => error.reason === FAILURE.MALFORMED_EXCEPTIONS_FILE,
+  );
+});
+
+test('an unusable npm audit report fails rather than reporting nothing live', () => {
+  const cases = [
+    null,
+    [],
+    { error: { code: 'ENETUNREACH' } },
+    { auditReportVersion: 1, vulnerabilities: {}, metadata: { vulnerabilities: {} } },
+    { auditReportVersion: 2, metadata: { vulnerabilities: {} } },
+    { auditReportVersion: 2, vulnerabilities: {} },
+    {
+      auditReportVersion: 2,
+      vulnerabilities: {},
+      metadata: { vulnerabilities: { info: 0, low: 0, moderate: 0, high: 1, critical: 0, total: 0 } },
+    },
+  ];
+  for (const report of cases) {
+    assert.throws(
+      () => collectLiveAdvisories(report, 'low'),
+      (error) => {
+        assert.ok(error instanceof AuditGateError, `expected an AuditGateError for ${JSON.stringify(report)}`);
+        assert.equal(error.reason, FAILURE.AUDIT_REPORT_INVALID);
+        return true;
+      },
+      `expected an invalid-report failure for ${JSON.stringify(report)}`,
+    );
+  }
+});
+
+test('an unsupported severity floor is a usage failure, not a clean report', () => {
+  assert.throws(
+    () => collectLiveAdvisories(bundlerChainReport(), 'spicy'),
+    (error) => {
+      assert.ok(error instanceof AuditGateError);
+      assert.equal(error.reason, FAILURE.INVALID_USAGE);
+      return true;
+    },
+  );
+});
+
+test('the committed exception file satisfies the enforced schema', () => {
+  const exceptions = loadExceptions(join(SECURE_APP, 'audit-exceptions.json'));
+  assert.ok(exceptions.length > 0, 'the committed file should describe the accepted advisories');
+  for (const exception of exceptions) {
+    assert.ok(exception.expiresOn > exception.acceptedOn);
+    assert.ok(exception.affectedPackages.size > 0);
+  }
+});
+
+test('the gate passes against the real dependency tree', () => {
+  const stdout = execFileSync('node', [GATE, '--prefix', SECURE_APP, '--audit-level=low'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  assert.match(stdout, /AUDIT GATE PASS/);
+  assert.match(stdout, /day\(s\) remaining/);
+});

--- a/apps/secure-app/package.json
+++ b/apps/secure-app/package.json
@@ -9,8 +9,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "test": "node --test lib/ep-signoff.test.mjs",
-    "audit:dependencies": "npm audit --audit-level=low"
+    "test": "node --test lib/*.test.mjs",
+    "audit:dependencies": "node ../../scripts/audit-with-exceptions.mjs --prefix . --audit-level=low"
   },
   "dependencies": {
     "@noble/curves": "1.9.7",

--- a/scripts/audit-with-exceptions.mjs
+++ b/scripts/audit-with-exceptions.mjs
@@ -1,0 +1,564 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Expiring audit-exception gate.
+//
+// Some advisories have no upstream fix. `image-size` in the Expo/metro bundler
+// chain is the current example: every published version is in range, and npm's
+// only suggested remediation is a three-major downgrade. Lowering the audit
+// level or blanket-ignoring the advisory would hide the next real finding too.
+//
+// This gate keeps the detection floor where it is and requires every accepted
+// advisory to be named in an exception file with a written reachability
+// justification, evidence that no upstream fix exists, and an expiry date. It
+// fails when an advisory is not covered, when an exception has expired, when an
+// exception no longer matches anything live, or when the file is malformed.
+//
+// The expiry is the point. An exception is a decision with a date on it, and
+// the build goes red when that date passes.
+//
+// Usage:
+//   node scripts/audit-with-exceptions.mjs --prefix apps/secure-app --audit-level=low
+//
+// `--audit-level` is this gate's own detection floor. It is deliberately not
+// forwarded to npm: `npm audit --json` reports every severity regardless, and
+// the floor is applied here so the filtering is visible in one place.
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { isAbsolute, join, resolve } from 'node:path';
+
+const DAY_MS = 86_400_000;
+
+// Longest window a single acceptance may run before it must be re-decided.
+// Without this cap the forcing function is defeated by a far-future date.
+const MAX_EXCEPTION_DAYS = 180;
+
+// Accepted advisories inside this window still pass, but say so loudly.
+const RENEWAL_WARNING_DAYS = 21;
+
+const MIN_REACHABILITY_LENGTH = 80;
+const MIN_JUSTIFICATION_LENGTH = 40;
+
+const SEVERITY_RANK = new Map([
+  ['info', 0],
+  ['low', 1],
+  ['moderate', 2],
+  ['high', 3],
+  ['critical', 4],
+]);
+
+export const FAILURE = {
+  UNCOVERED_ADVISORY: 'uncovered_advisory',
+  EXPIRED_EXCEPTION: 'expired_exception',
+  STALE_EXCEPTION: 'stale_exception',
+  MALFORMED_EXCEPTIONS_FILE: 'malformed_exceptions_file',
+  EXPIRY_WINDOW_TOO_LONG: 'expiry_window_too_long',
+  UNREVIEWED_AFFECTED_PACKAGE: 'unreviewed_affected_package',
+  SEVERITY_ESCALATED: 'severity_escalated',
+  AUDIT_REPORT_INVALID: 'audit_report_invalid',
+  INVALID_USAGE: 'invalid_usage',
+};
+
+export class AuditGateError extends Error {
+  constructor(reason, message) {
+    super(message);
+    this.name = 'AuditGateError';
+    this.reason = reason;
+  }
+}
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function calendarDate(value, field, where) {
+  if (typeof value !== 'string' || !DATE_PATTERN.test(value)) {
+    throw new AuditGateError(
+      FAILURE.MALFORMED_EXCEPTIONS_FILE,
+      `${where}: ${field} must be a YYYY-MM-DD date, got ${JSON.stringify(value)}`,
+    );
+  }
+  const ms = Date.parse(`${value}T00:00:00Z`);
+  if (!Number.isFinite(ms) || new Date(ms).toISOString().slice(0, 10) !== value) {
+    throw new AuditGateError(
+      FAILURE.MALFORMED_EXCEPTIONS_FILE,
+      `${where}: ${field} is not a real calendar date: ${value}`,
+    );
+  }
+  return ms;
+}
+
+function requireText(container, field, minimumLength, where) {
+  const value = container[field];
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new AuditGateError(
+      FAILURE.MALFORMED_EXCEPTIONS_FILE,
+      `${where}: ${field} is required and must be a non-empty string`,
+    );
+  }
+  if (value.trim().length < minimumLength) {
+    throw new AuditGateError(
+      FAILURE.MALFORMED_EXCEPTIONS_FILE,
+      `${where}: ${field} must be a real justification of at least ${minimumLength} characters, got ${value.trim().length}`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Validate the exception document and normalise it into a list of entries.
+ * Throws AuditGateError with a named reason on any schema problem.
+ */
+export function parseExceptions(raw, where = 'audit-exceptions.json') {
+  let document;
+  try {
+    document = JSON.parse(raw);
+  } catch (error) {
+    throw new AuditGateError(
+      FAILURE.MALFORMED_EXCEPTIONS_FILE,
+      `${where}: not valid JSON: ${error.message}`,
+    );
+  }
+  if (document === null || typeof document !== 'object' || Array.isArray(document)) {
+    throw new AuditGateError(FAILURE.MALFORMED_EXCEPTIONS_FILE, `${where}: top level must be an object`);
+  }
+  if (document.version !== 1) {
+    throw new AuditGateError(
+      FAILURE.MALFORMED_EXCEPTIONS_FILE,
+      `${where}: unsupported schema version ${JSON.stringify(document.version)}, expected 1`,
+    );
+  }
+  if (!Array.isArray(document.exceptions)) {
+    throw new AuditGateError(FAILURE.MALFORMED_EXCEPTIONS_FILE, `${where}: exceptions must be an array`);
+  }
+
+  const entries = [];
+  const seen = new Set();
+  document.exceptions.forEach((entry, index) => {
+    const at = `${where}[${index}]`;
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new AuditGateError(FAILURE.MALFORMED_EXCEPTIONS_FILE, `${at}: each exception must be an object`);
+    }
+
+    const advisory = entry.advisory;
+    if (typeof advisory !== 'string' || !/^https:\/\/github\.com\/advisories\/GHSA-/.test(advisory)) {
+      throw new AuditGateError(
+        FAILURE.MALFORMED_EXCEPTIONS_FILE,
+        `${at}: advisory must be a GitHub advisory URL, got ${JSON.stringify(advisory)}`,
+      );
+    }
+    if (seen.has(advisory)) {
+      throw new AuditGateError(FAILURE.MALFORMED_EXCEPTIONS_FILE, `${at}: duplicate exception for ${advisory}`);
+    }
+    seen.add(advisory);
+
+    if (typeof entry.package !== 'string' || entry.package.trim().length === 0) {
+      throw new AuditGateError(FAILURE.MALFORMED_EXCEPTIONS_FILE, `${at}: package is required`);
+    }
+    if (!SEVERITY_RANK.has(entry.severity)) {
+      throw new AuditGateError(
+        FAILURE.MALFORMED_EXCEPTIONS_FILE,
+        `${at}: severity must be one of ${[...SEVERITY_RANK.keys()].join(', ')}, got ${JSON.stringify(entry.severity)}`,
+      );
+    }
+    if (
+      !Array.isArray(entry.affected_packages)
+      || entry.affected_packages.length === 0
+      || entry.affected_packages.some((name) => typeof name !== 'string' || name.trim().length === 0)
+    ) {
+      throw new AuditGateError(
+        FAILURE.MALFORMED_EXCEPTIONS_FILE,
+        `${at}: affected_packages must be a non-empty array of package names`,
+      );
+    }
+
+    requireText(entry, 'reachability', MIN_REACHABILITY_LENGTH, at);
+    requireText(entry, 'revisit_trigger', MIN_JUSTIFICATION_LENGTH, at);
+    if (typeof entry.accepted_by !== 'string' || entry.accepted_by.trim().length === 0) {
+      throw new AuditGateError(FAILURE.MALFORMED_EXCEPTIONS_FILE, `${at}: accepted_by is required`);
+    }
+
+    const fix = entry.no_upstream_fix;
+    if (fix === null || typeof fix !== 'object' || Array.isArray(fix)) {
+      throw new AuditGateError(
+        FAILURE.MALFORMED_EXCEPTIONS_FILE,
+        `${at}: no_upstream_fix must be an object stating what was checked`,
+      );
+    }
+    calendarDate(fix.checked_on, 'no_upstream_fix.checked_on', at);
+    for (const field of ['advisory_range', 'latest_published_version', 'npm_suggested_fix']) {
+      if (typeof fix[field] !== 'string' || fix[field].trim().length === 0) {
+        throw new AuditGateError(FAILURE.MALFORMED_EXCEPTIONS_FILE, `${at}: no_upstream_fix.${field} is required`);
+      }
+    }
+    requireText(fix, 'how_checked', MIN_JUSTIFICATION_LENGTH, `${at}.no_upstream_fix`);
+    requireText(fix, 'why_suggested_fix_rejected', MIN_JUSTIFICATION_LENGTH, `${at}.no_upstream_fix`);
+
+    const acceptedOn = calendarDate(entry.accepted_on, 'accepted_on', at);
+    const expiresOn = calendarDate(entry.expires_on, 'expires_on', at);
+    if (expiresOn <= acceptedOn) {
+      throw new AuditGateError(
+        FAILURE.MALFORMED_EXCEPTIONS_FILE,
+        `${at}: expires_on (${entry.expires_on}) must be after accepted_on (${entry.accepted_on})`,
+      );
+    }
+    const windowDays = Math.round((expiresOn - acceptedOn) / DAY_MS);
+    if (windowDays > MAX_EXCEPTION_DAYS) {
+      throw new AuditGateError(
+        FAILURE.EXPIRY_WINDOW_TOO_LONG,
+        `${at}: acceptance window is ${windowDays} days, which exceeds the ${MAX_EXCEPTION_DAYS}-day maximum`,
+      );
+    }
+
+    entries.push({
+      advisory,
+      package: entry.package,
+      severity: entry.severity,
+      affectedPackages: new Set(entry.affected_packages),
+      acceptedOn,
+      expiresOn,
+      acceptedOnText: entry.accepted_on,
+      expiresOnText: entry.expires_on,
+      reachability: entry.reachability,
+      revisitTrigger: entry.revisit_trigger,
+      acceptedBy: entry.accepted_by,
+    });
+  });
+
+  return entries;
+}
+
+export function loadExceptions(filePath) {
+  let raw;
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch (error) {
+    throw new AuditGateError(
+      FAILURE.MALFORMED_EXCEPTIONS_FILE,
+      `${filePath}: exception file could not be read: ${error.message}`,
+    );
+  }
+  return parseExceptions(raw, filePath);
+}
+
+function assertUsableReport(report) {
+  if (report === null || typeof report !== 'object' || Array.isArray(report)) {
+    throw new AuditGateError(FAILURE.AUDIT_REPORT_INVALID, 'npm audit did not return an object report');
+  }
+  if ('error' in report) {
+    throw new AuditGateError(
+      FAILURE.AUDIT_REPORT_INVALID,
+      `npm audit returned an error report: ${JSON.stringify(report.error)}`,
+    );
+  }
+  if (report.auditReportVersion !== 2) {
+    throw new AuditGateError(
+      FAILURE.AUDIT_REPORT_INVALID,
+      `unsupported npm audit report version: ${String(report.auditReportVersion)}`,
+    );
+  }
+  const vulnerabilities = report.vulnerabilities;
+  if (vulnerabilities === null || typeof vulnerabilities !== 'object' || Array.isArray(vulnerabilities)) {
+    throw new AuditGateError(FAILURE.AUDIT_REPORT_INVALID, 'npm audit report omitted the vulnerabilities map');
+  }
+  const summary = report.metadata?.vulnerabilities;
+  if (summary === null || typeof summary !== 'object' || Array.isArray(summary)) {
+    throw new AuditGateError(FAILURE.AUDIT_REPORT_INVALID, 'npm audit report omitted the vulnerability summary');
+  }
+  for (const field of ['info', 'low', 'moderate', 'high', 'critical', 'total']) {
+    if (!Number.isSafeInteger(summary[field]) || summary[field] < 0) {
+      throw new AuditGateError(FAILURE.AUDIT_REPORT_INVALID, `npm audit report has an invalid ${field} count`);
+    }
+  }
+  const summed = summary.info + summary.low + summary.moderate + summary.high + summary.critical;
+  if (summary.total !== summed) {
+    throw new AuditGateError(FAILURE.AUDIT_REPORT_INVALID, 'npm audit report vulnerability counts do not reconcile');
+  }
+}
+
+/**
+ * Reduce an npm audit report to one record per advisory at or above the floor.
+ *
+ * npm reports 11 "vulnerabilities" for two advisories: one entry carries the
+ * advisory objects and the rest name it transitively through `via` strings.
+ * The security decision is per advisory, so the blast radius is resolved by
+ * walking those `via` edges backwards. The graph contains cycles, so the walk
+ * is a visited-set BFS rather than recursion.
+ */
+export function collectLiveAdvisories(report, minimumSeverity = 'low') {
+  assertUsableReport(report);
+  const minimumRank = SEVERITY_RANK.get(minimumSeverity);
+  if (minimumRank === undefined) {
+    throw new AuditGateError(
+      FAILURE.INVALID_USAGE,
+      `unsupported audit severity threshold: ${minimumSeverity}`,
+    );
+  }
+
+  const advisories = new Map();
+  const seeds = new Map();
+  const dependents = new Map();
+
+  for (const [name, vulnerability] of Object.entries(report.vulnerabilities)) {
+    if (vulnerability === null || typeof vulnerability !== 'object') continue;
+    for (const cause of vulnerability.via ?? []) {
+      if (typeof cause === 'string') {
+        if (!dependents.has(cause)) dependents.set(cause, new Set());
+        dependents.get(cause).add(name);
+        continue;
+      }
+      if (typeof cause !== 'object' || cause === null || typeof cause.url !== 'string') continue;
+      if ((SEVERITY_RANK.get(cause.severity) ?? -1) < minimumRank) continue;
+
+      let advisory = advisories.get(cause.url);
+      if (advisory === undefined) {
+        advisory = {
+          url: cause.url,
+          package: typeof cause.name === 'string' ? cause.name : name,
+          severity: cause.severity,
+          title: typeof cause.title === 'string' ? cause.title : '',
+          range: typeof cause.range === 'string' ? cause.range : '',
+          ids: new Set(),
+          affectedPackages: new Set(),
+        };
+        advisories.set(cause.url, advisory);
+      }
+      if (Number.isSafeInteger(cause.source)) advisory.ids.add(cause.source);
+      if ((SEVERITY_RANK.get(cause.severity) ?? -1) > (SEVERITY_RANK.get(advisory.severity) ?? -1)) {
+        advisory.severity = cause.severity;
+      }
+      if (!seeds.has(cause.url)) seeds.set(cause.url, new Set());
+      seeds.get(cause.url).add(name);
+    }
+  }
+
+  for (const [url, advisory] of advisories) {
+    const queue = [...(seeds.get(url) ?? [])];
+    const visited = new Set(queue);
+    while (queue.length > 0) {
+      const name = queue.shift();
+      advisory.affectedPackages.add(name);
+      for (const dependent of dependents.get(name) ?? []) {
+        if (visited.has(dependent)) continue;
+        visited.add(dependent);
+        queue.push(dependent);
+      }
+    }
+  }
+
+  return advisories;
+}
+
+/**
+ * Compare live advisories against the accepted exceptions.
+ * Returns named failures and the accepted set. Never throws for policy
+ * outcomes; callers decide how to render them.
+ */
+export function evaluate({ advisories, exceptions, now }) {
+  const failures = [];
+  const accepted = [];
+  const byAdvisory = new Map(exceptions.map((entry) => [entry.advisory, entry]));
+
+  for (const [url, advisory] of advisories) {
+    const exception = byAdvisory.get(url);
+    if (exception === undefined) {
+      failures.push({
+        reason: FAILURE.UNCOVERED_ADVISORY,
+        advisory: url,
+        message:
+          `${advisory.severity} advisory ${url} (${advisory.package}) is live and not covered by any exception. `
+          + `Fix it, or add a dated exception with a reachability justification. `
+          + `Affected packages: ${[...advisory.affectedPackages].sort().join(', ')}.`,
+      });
+      continue;
+    }
+
+    const liveRank = SEVERITY_RANK.get(advisory.severity) ?? -1;
+    const acceptedRank = SEVERITY_RANK.get(exception.severity) ?? -1;
+    if (liveRank > acceptedRank) {
+      failures.push({
+        reason: FAILURE.SEVERITY_ESCALATED,
+        advisory: url,
+        message:
+          `${url} was accepted at ${exception.severity} but is now ${advisory.severity}. `
+          + `The acceptance decision was made against a lower severity and must be re-made.`,
+      });
+      continue;
+    }
+
+    const unreviewed = [...advisory.affectedPackages]
+      .filter((name) => !exception.affectedPackages.has(name))
+      .sort();
+    if (unreviewed.length > 0) {
+      failures.push({
+        reason: FAILURE.UNREVIEWED_AFFECTED_PACKAGE,
+        advisory: url,
+        message:
+          `${url} now affects packages outside the reviewed set: ${unreviewed.join(', ')}. `
+          + `The reachability justification was written against a different blast radius, so re-review it.`,
+      });
+      continue;
+    }
+
+    if (now >= exception.expiresOn) {
+      const overdue = Math.max(1, Math.ceil((now - exception.expiresOn) / DAY_MS));
+      failures.push({
+        reason: FAILURE.EXPIRED_EXCEPTION,
+        advisory: url,
+        message:
+          `${url} expired on ${exception.expiresOnText} (${overdue} day(s) ago). `
+          + `Re-verify it and accept a new dated decision, or fix the advisory. `
+          + `Revisit trigger: ${exception.revisitTrigger}`,
+      });
+      continue;
+    }
+
+    accepted.push({
+      advisory: url,
+      package: advisory.package,
+      severity: advisory.severity,
+      title: advisory.title,
+      expiresOn: exception.expiresOnText,
+      daysRemaining: Math.ceil((exception.expiresOn - now) / DAY_MS),
+      reachability: exception.reachability,
+      acceptedBy: exception.acceptedBy,
+      affectedPackageCount: advisory.affectedPackages.size,
+    });
+  }
+
+  for (const exception of exceptions) {
+    if (advisories.has(exception.advisory)) continue;
+    failures.push({
+      reason: FAILURE.STALE_EXCEPTION,
+      advisory: exception.advisory,
+      message:
+        `${exception.advisory} is accepted in the exception file but no longer appears in npm audit. `
+        + `Delete the entry so the file only ever describes live, accepted risk.`,
+    });
+  }
+
+  accepted.sort((a, b) => a.advisory.localeCompare(b.advisory));
+  failures.sort((a, b) => a.reason.localeCompare(b.reason) || a.advisory.localeCompare(b.advisory));
+  return { failures, accepted };
+}
+
+export function runAudit(prefix) {
+  let stdout;
+  try {
+    stdout = execFileSync('npm', ['audit', '--json'], {
+      cwd: prefix,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch (error) {
+    // npm audit exits non-zero whenever findings exist, so stdout is the report.
+    stdout = error?.stdout;
+    if (typeof stdout !== 'string' || stdout.length === 0) {
+      throw new AuditGateError(
+        FAILURE.AUDIT_REPORT_INVALID,
+        `npm audit produced no report in ${prefix}: ${error?.message ?? 'unknown error'}`,
+      );
+    }
+  }
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    throw new AuditGateError(FAILURE.AUDIT_REPORT_INVALID, `npm audit did not return JSON: ${error.message}`);
+  }
+}
+
+function parseArgv(argv) {
+  const options = { prefix: process.cwd(), auditLevel: 'low', exceptions: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const [flag, inlineValue] = argument.startsWith('--') && argument.includes('=')
+      ? [argument.slice(0, argument.indexOf('=')), argument.slice(argument.indexOf('=') + 1)]
+      : [argument, null];
+    const readValue = () => {
+      if (inlineValue !== null) return inlineValue;
+      index += 1;
+      const next = argv[index];
+      if (next === undefined) throw new AuditGateError(FAILURE.INVALID_USAGE, `${flag} requires a value`);
+      return next;
+    };
+    switch (flag) {
+      case '--prefix':
+        options.prefix = readValue();
+        break;
+      case '--audit-level':
+        options.auditLevel = readValue();
+        break;
+      case '--exceptions':
+        options.exceptions = readValue();
+        break;
+      default:
+        throw new AuditGateError(FAILURE.INVALID_USAGE, `unrecognised argument: ${argument}`);
+    }
+  }
+  return options;
+}
+
+export function main(argv = process.argv.slice(2), now = Date.now()) {
+  const options = parseArgv(argv);
+  const prefix = isAbsolute(options.prefix) ? options.prefix : resolve(process.cwd(), options.prefix);
+  const exceptionsPath = options.exceptions === null
+    ? join(prefix, 'audit-exceptions.json')
+    : resolve(process.cwd(), options.exceptions);
+
+  try {
+    if (!statSync(prefix).isDirectory()) {
+      throw new AuditGateError(FAILURE.INVALID_USAGE, `--prefix is not a directory: ${prefix}`);
+    }
+  } catch (error) {
+    if (error instanceof AuditGateError) throw error;
+    throw new AuditGateError(FAILURE.INVALID_USAGE, `--prefix is not readable: ${prefix}`);
+  }
+
+  const exceptions = loadExceptions(exceptionsPath);
+  const advisories = collectLiveAdvisories(runAudit(prefix), options.auditLevel);
+  const { failures, accepted } = evaluate({ advisories, exceptions, now });
+
+  const scope = options.prefix;
+  if (failures.length > 0) {
+    console.error(`AUDIT GATE FAILED for ${scope} at ${options.auditLevel}+ (${failures.length} problem(s)):`);
+    for (const failure of failures) {
+      console.error(`  [${failure.reason}] ${failure.message}`);
+    }
+    console.error(`\nException file: ${exceptionsPath}`);
+    return 1;
+  }
+
+  if (accepted.length === 0) {
+    console.log(`AUDIT GATE PASS for ${scope} at ${options.auditLevel}+: no advisories observed.`);
+    return 0;
+  }
+
+  console.log(`AUDIT GATE PASS for ${scope} at ${options.auditLevel}+: ${accepted.length} accepted advisory(ies).`);
+  for (const entry of accepted) {
+    console.log(`\n  ${entry.advisory}`);
+    console.log(`    package        ${entry.package} (${entry.severity})`);
+    if (entry.title) console.log(`    title          ${entry.title}`);
+    console.log(`    affects        ${entry.affectedPackageCount} package(s) in this tree`);
+    console.log(`    accepted by    ${entry.acceptedBy}`);
+    console.log(`    expires        ${entry.expiresOn} (${entry.daysRemaining} day(s) remaining)`);
+    console.log(`    reason         ${entry.reachability}`);
+    if (entry.daysRemaining <= RENEWAL_WARNING_DAYS) {
+      console.log(`    WARNING        this exception expires in ${entry.daysRemaining} day(s) and will then fail the build`);
+    }
+  }
+  return 0;
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : null;
+if (invokedPath !== null && invokedPath === resolve(fileURLToPath(import.meta.url))) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    if (error instanceof AuditGateError) {
+      console.error(`AUDIT GATE FAILED: [${error.reason}] ${error.message}`);
+    } else {
+      console.error(`AUDIT GATE FAILED: [unexpected_error] ${error?.stack ?? error}`);
+    }
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
`secure-app` fails CI with 11 high-severity vulnerabilities. All 11 reach two advisories on `image-size`, pulled through `metro` and `@expo/cli`, which arrive transitively from `expo`.

## Why there is nothing to upgrade to

- The advisory range covers **every published version** of `image-size`, including the current 2.0.2 (71 versions checked).
- npm's suggested remediation is `expo@53.0.27`, flagged `isSemVerMajor`, against a pinned `~56.0.19`. That is a **three-major downgrade**, not a fix.
- `npm audit --omit=dev` still reports all 11: `expo` and `react-native` are production dependencies. **npm's dependency graph cannot express which of their transitive deps ship to a device and which run only on the build machine.**

Raising `--audit-level` or deleting the check would trade a visible problem for an invisible one. This makes the acceptance explicit and dated instead.

## The gate

`scripts/audit-with-exceptions.mjs` fails, with a named reason, on:

| Failure | Why it exists |
|---|---|
| uncovered advisory | detection is not weakened |
| **expired exception** | the forcing function: the decision returns on a date |
| **stale exception** | advisory gone means the entry must go, so the file self-cleans |
| malformed file | a bad file is not a pass |
| expiry window over 180 days | otherwise `expires_on: 2099-01-01` defeats the whole thing |
| affected set wider than reviewed | the justification is "only the bundler pulls this in"; if that stops being true the gate must break |
| severity escalated | an acceptance made at `high` must not silently cover a `critical` |

Reachability was established, not assumed: `metro` is the only package in the lockfile declaring `image-size`, the app's sources import neither, and the app ships zero image assets. The exception file states plainly that metro's internal call site was **not** read, rather than implying a deeper audit than was done.

17 tests. Verified passing on the real tree, then verified **failing** with a backdated expiry, then restored.

Also adds the gate script to the mobile workflow path filters, which were otherwise blind to changes in the gate itself.

Related: `scripts/audit-root.mjs` allowlists an advisory as a hardcoded constant with no expiry. That is the weaker pattern this replaces for secure-app, left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)