### PR TITLE
chore(db): reconcile Works migration ledger

### DIFF
--- a/supabase/migration-history.v1.json
+++ b/supabase/migration-history.v1.json
@@ -1,17 +1,13 @@
 {
   "schema_version": "EP-MIGRATION-HISTORY-v1",
-  "as_of": "2026-08-08",
-  "remote_head": "20260808233000",
+  "as_of": "2026-08-09",
+  "remote_head": "20260809063111",
   "private_remote_versions": [
     "20260723192504"
   ],
   "retroactive_pending_versions": [],
-  "forward_pending_versions": [
-    "20260809063111"
-  ],
-  "deployment_sequence": [
-    "20260809063111"
-  ],
+  "forward_pending_versions": [],
+  "deployment_sequence": [],
   "requires_include_all": false,
   "remote_versions": [
     "001",
@@ -209,7 +205,8 @@
     "20260803231000",
     "20260805120000",
     "20260807010000",
-    "20260808233000"
+    "20260808233000",
+    "20260809063111"
   ],
   "public_files": {
     "001_emilia_core_schema.sql": "f5e3c6c40fdaf54fbfc7a986f1b7cb021bfa8bee21a81bac39fe2da15f654060",


### PR DESCRIPTION
Records the already-applied Works migration as remote after PR #543 merged. Clears the launch-time pending/deployment sequence and advances the remote head to 20260809063111.\n\nVerified locally:\n- npm run check:migration-history\n- npm run gov:db-contract (767 assertions)