### PR TITLE
docs: complete Receipts-11 IANA preparation

### DIFF
--- a/standards/iana/README.md
+++ b/standards/iana/README.md
@@ -16,8 +16,9 @@ revision backs it. Nothing here invents a name that contradicts posted text.
 
 - `http-problem-type-registration.md` — RFC 9457 registration template for
   the transport-neutral AE Challenge HTTP binding.
-- `media-type-registration.md` — the active RFC 6838 §5.6 template for
-  `application/ep-authorization-receipt+json`, plus the retired AE Challenge
+- `media-type-registration.md` — the active RFC 6838 §5.6 templates for
+  `application/ep-authorization-receipt+json` and
+  `application/ep-authorization-bundle+json`, plus the retired AE Challenge
   media-type request retained as process history.
 - `well-known-uri-registration.md` — RFC 8615 template for
   `agent-action-control.json`, which a published draft already requests.
@@ -32,11 +33,12 @@ revision backs it. Nothing here invents a name that contradicts posted text.
 | 1 | `agent-action-control.json` | Well-Known URIs | draft-schrock-agent-action-manifest-00 (§3, §9) | **Requests registration** (fields in §9) | READY-ON-POST | Draft live on datatracker [verify posting after the 2026-07-06 batch upload] |
 | 2 | `authorization-evidence-required` | HTTP Problem Types | draft-schrock-ae-challenge-05 (§3, §6; published 2026-08-10) | **Requests registration** under Specification Required; reuses `application/problem+json` | CARRIED-BY-DRAFT | Continue focused HTTP and Independent Stream review; do not file a conflicting direct request |
 | 3 | `application/ep-authorization-receipt+json` | Media Types (standards tree) | draft-schrock-ep-authorization-receipts-11 (§13) | **Requests registration** and carries the complete RFC 6838 template | CARRIED-BY-DRAFT | Process with the Standards Track document; do not file a conflicting direct request |
-| 4 | `Receipt-Required` | HTTP Field Names | draft-schrock-agent-action-manifest-00 (§5 + example control object) | Field *named*, not normatively defined; no registration request | PROPOSED, requires draft text in next rev | Next-rev field definition + IANA request |
-| 5 | `X-EMILIA-Receipt` | HTTP Field Names | draft-schrock-agent-action-manifest-00 (§5 + example control object) | Field *named*, not normatively defined; RFC 6648 disfavors permanent "X-" registrations | PROPOSED, requires draft text in next rev | Next-rev field definition; draft decides on any unprefixed successor |
-| 6 | `application/ep-aec+json` | Media Types | draft-schrock-ep-authorization-evidence-chain-01 (§10) | Illustrative only ("e.g.") | NOT PREPARED | Chain draft must pick and fix the string first |
-| 7 | `application/ep-eye-advisory+json` + SET event-type URI | Media Types / SET event URI | posted/draft-schrock-emilia-eye-00 | "may register" | NOT PREPARED | A revision committing to it |
-| 8 | JWT/CWT claim names | JWT Claims / CWT Claims | draft-schrock-human-authorization-binding-00 (§8) | "anticipated for a future revision, after host-format feedback" | NOT PREPARED | Host-format feedback, then next rev |
+| 4 | `application/ep-authorization-bundle+json` | Media Types (standards tree) | draft-schrock-ep-authorization-receipts-11 (§13) | **Requests registration** and carries the complete RFC 6838 template | CARRIED-BY-DRAFT | Process with the Standards Track document; do not file a conflicting direct request |
+| 5 | `Receipt-Required` | HTTP Field Names | draft-schrock-agent-action-manifest-00 (§5 + example control object) | Field *named*, not normatively defined; no registration request | PROPOSED, requires draft text in next rev | Next-rev field definition + IANA request |
+| 6 | `X-EMILIA-Receipt` | HTTP Field Names | draft-schrock-agent-action-manifest-00 (§5 + example control object) | Field *named*, not normatively defined; RFC 6648 disfavors permanent "X-" registrations | PROPOSED, requires draft text in next rev | Next-rev field definition; draft decides on any unprefixed successor |
+| 7 | `application/ep-aec+json` | Media Types | draft-schrock-ep-authorization-evidence-chain-01 (§10) | Illustrative only ("e.g.") | NOT PREPARED | Chain draft must pick and fix the string first |
+| 8 | `application/ep-eye-advisory+json` + SET event-type URI | Media Types / SET event URI | posted/draft-schrock-emilia-eye-00 | "may register" | NOT PREPARED | A revision committing to it |
+| 9 | JWT/CWT claim names | JWT Claims / CWT Claims | draft-schrock-human-authorization-binding-00 (§8) | "anticipated for a future revision, after host-format feedback" | NOT PREPARED | Host-format feedback, then next rev |
 
 Not IANA actions (no filing anywhere): the EP **profile registry** entries the
 drafts declare — `grid.curtailment` (draft-schrock-kintzele-grid-curtailment-00),
@@ -58,7 +60,7 @@ registry, not IANA's.
   registration with the Independent Stream document after focused HTTP
   review; do not reopen tickets #1456851 or #1456611.
 
-### Media types (entry 3)
+### Media types (entries 3-4)
 
 - **Registry pages:** <https://www.iana.org/assignments/media-types> and, where
   a provisional path is appropriate,
@@ -66,13 +68,14 @@ registry, not IANA's.
 - **Community review (RFC 6838 §5.1):** post the completed template to the
   **media-types@iana.org** mailing list for review before or alongside the
   request. For standards-tree names this review is expected.
-- **Receipt media type:** revision -11 requests
-  `application/ep-authorization-receipt+json` and carries the complete
-  template. Process it with the Standards Track document; do not revive the
-  older `application/ep-receipt+json` preparation or file a conflicting direct
-  request.
+- **Receipt media types:** revision -11 requests
+  `application/ep-authorization-receipt+json` and
+  `application/ep-authorization-bundle+json`, and carries complete templates
+  for both. Process them with the Standards Track document; do not revive the
+  older `application/ep-receipt+json` preparation or file conflicting direct
+  requests.
 
-### Well-known URIs (entries 1, 4)
+### Well-known URIs (entry 1)
 
 - **Registry page:** <https://www.iana.org/assignments/well-known-uris>.
 - **Policy:** Specification Required with designated-expert review
@@ -83,7 +86,7 @@ registry, not IANA's.
 - **Filing:** send the completed template to **iana@iana.org** referencing
   the Well-Known URIs registry; IANA routes it to the designated expert.
 
-### HTTP field names (entries 5, 6)
+### HTTP field names (entries 5-6)
 
 - **Registry page:** <https://www.iana.org/assignments/http-fields>
   (RFC 9110 §18.4; registration requirements in §16.3.1).
@@ -107,10 +110,12 @@ registry, not IANA's.
 3. **File entry 1** (`agent-action-control.json`) only after re-verifying its
    current backing-draft and registry state. Optional heads-up to
    wellknown-uri-review@ietf.org first.
-4. **Everything else waits for draft text.** When a revision commits to a
+4. Process entries 3 and 4 with Authorization Receipts through its Standards
+   Track publication path; do not file parallel direct requests.
+5. **Everything else waits for draft text.** When a revision commits to a
    PROPOSED entry, update its template here to cite the new revision, flip
    the tracker row, then file.
-5. After any filing, record the IANA ticket/outcome in the tracker row.
+6. After any filing, record the IANA ticket/outcome in the tracker row.
 
 ## Honesty register (applies to every template here)
 

--- a/standards/iana/media-type-registration.md
+++ b/standards/iana/media-type-registration.md
@@ -1,7 +1,7 @@
 # IANA media type registrations — EMILIA Protocol
 
 Registration templates per RFC 6838, Section 5.6. The current receipts draft
-carries the active standards-tree registration request. The former AE
+carries both active standards-tree registration requests. The former AE
 Challenge media-type request is retained below only as process history; current
 revision -05 retains the -03 withdrawal and uses RFC 9457
 `application/problem+json`.
@@ -154,6 +154,68 @@ Internet-Draft, not IETF-adopted or endorsed; intended status Standards Track).
 
 **Applications that use this media type:** Agent-action authorization systems,
 verifying executors, audit systems, and evidence exchange services.
+
+**Fragment identifier considerations:** none
+
+**Additional information:**
+
+- Magic number(s): none
+- File extension(s): none
+- Macintosh file type code(s): none
+
+**Person & email address to contact for further information:** Iman Schrock,
+team@emiliaprotocol.ai
+
+**Intended usage:** COMMON
+
+**Restrictions on usage:** none
+
+**Author:** Iman Schrock
+
+**Change controller:** IETF
+
+**Provisional registration? (standards tree only):** No
+
+---
+
+## 3. application/ep-authorization-bundle+json
+
+**Status: CARRIED BY CURRENT DRAFT.** The active
+`draft-schrock-ep-authorization-receipts-11`, Section 13, requests this media
+type and carries the complete registration template. Process the registration
+with the Standards Track document; do not file a conflicting direct request.
+
+### Registration template (RFC 6838 §5.6)
+
+**Type name:** application
+
+**Subtype name:** ep-authorization-bundle+json
+
+**Required parameters:** none
+
+**Optional parameters:** none
+
+**Encoding considerations:** binary; the representation is a JSON object
+encoded as UTF-8 according to RFC 8259.
+
+**Security considerations:** See the Security Considerations and bundle
+verification sections of draft-schrock-ep-authorization-receipts-11. A valid
+bundle is approval evidence, not an authorization grant, reservation,
+consumption record, execution receipt, proof of current external facts, or
+permission to retry an action with an uncertain effect.
+
+**Interoperability considerations:** The `EP-AUTHORIZATION-BUNDLE-v1` closed
+object and verification algorithm are defined by the draft. A consumer must
+independently pin the audience, policy, action mapping, approver directory,
+trust roots, and any required current status sources.
+
+**Published specification:** draft-schrock-ep-authorization-receipts-11,
+"Authorization Receipts for High-Risk Agent Actions" (an active individual
+Internet-Draft, not IETF-adopted or endorsed; intended status Standards Track).
+
+**Applications that use this media type:** Authorization servers, policy
+decision points, protected resources, verifying executors, and agent-action
+approval systems.
 
 **Fragment identifier considerations:** none
 

--- a/standards/staged/NEXT-AE-CHALLENGE-05/README.md
+++ b/standards/staged/NEXT-AE-CHALLENGE-05/README.md
@@ -1,8 +1,10 @@
-# AE Challenge revision 05 candidate
+# AE Challenge revision 05 publication-provenance packet
 
-This isolated candidate is derived from the published
-`draft-schrock-ae-challenge-04` source. Revision -04 remains unchanged. The
-upload source for the next revision is:
+This isolated packet preserves the exact source and review artifacts for
+`draft-schrock-ae-challenge-05`, published on 2026-08-10. It was derived from
+the immutable revision -04 source. It is not an upload candidate; the
+immutable IETF archive is authoritative. The submitted source retained for
+provenance is:
 
 `UPLOAD-THIS/draft-schrock-ae-challenge-05.xml`
 

--- a/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-11/README.md
+++ b/standards/staged/NEXT-AUTHORIZATION-RECEIPTS-11/README.md
@@ -1,9 +1,10 @@
-# Authorization Receipts -11 upload packet
+# Authorization Receipts -11 publication-provenance packet
 
-This is the isolated, unsubmitted candidate packet for
-`draft-schrock-ep-authorization-receipts-11`, prepared on 2026-08-09.
+This isolated packet preserves the exact source and review artifacts for
+`draft-schrock-ep-authorization-receipts-11`, published on 2026-08-10. It is
+not an upload candidate; the immutable IETF archive is authoritative.
 
-Submitted file:
+Submitted source retained for provenance:
 
 - `UPLOAD-THIS/draft-schrock-ep-authorization-receipts-11.xml`
 
@@ -30,5 +31,5 @@ Revision -11:
 - requests `application/ep-authorization-bundle+json` in addition to the
   receipt media type already requested by -10.
 
-The document remains an individual Internet-Draft. Submission would not make
+The document remains an individual Internet-Draft. Publication does not make
 it an RFC, a working-group document, IETF consensus, or IETF endorsement.


### PR DESCRIPTION
## Summary

- add the missing `application/ep-authorization-bundle+json` RFC 6838 preparation already requested normatively by Authorization Receipts-11
- correct IANA index numbering and submission-channel references
- relabel the published Receipts-11 and AE Challenge-05 staged packets as immutable publication provenance, not upload candidates

## Validation

- Authorization Receipts-11 checker: pass
- AE Challenge-05 checker: pass
- staged standards packet gate: pass
- authority claim guard: pass
- public conformance claims: pass
- generated LLM context freshness: pass

No new IANA request was sent. Both Receipts media types remain carried by the Standards Track draft.