### PR TITLE
standards: AE Challenge 06 cap-first refusal

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ preserves **8 deliberately weakened variants that produce concrete
 attack traces when load-bearing checks are removed**. The live same-team conformance corpus contains **21 suites and
 331 current vectors**. Separately, an externally authored Rust verifier is pinned to the frozen
 **16-suite/164-vector** bundle and a **359-case hostility campaign**. The broader suite contains
-**8,862 automated tests across 532 files**.
+**8,865 automated tests across 533 files**.
 
 Production JavaScript and JSDoc surfaces are compiler-checked with TypeScript
 `checkJs`; the secure app has its own compatibility compiler project, while

--- a/scripts/check-ae-challenge-06.mjs
+++ b/scripts/check-ae-challenge-06.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto';
+import { readFileSync, readdirSync } from 'node:fs';
+
+const root = new URL('../standards/staged/NEXT-AE-CHALLENGE-06/', import.meta.url);
+const basename = 'draft-schrock-ae-challenge-06';
+const published05 = new URL('../standards/posted/draft-schrock-ae-challenge-05.xml', import.meta.url);
+const published05Sha256 = '77fce83124c69fbd1cd5b45fb13aba64d00a2ffdd4f17c4610f6ace895a8106b';
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(`AE Challenge -06 packet: ${message}`);
+}
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+invariant(
+  JSON.stringify(readdirSync(new URL('UPLOAD-THIS/', root)).sort())
+    === JSON.stringify([`${basename}.xml`]),
+  'UPLOAD-THIS must contain exactly the -06 XML source',
+);
+invariant(
+  JSON.stringify(readdirSync(new URL('RENDERS/', root)).sort())
+    === JSON.stringify([`${basename}.html`, `${basename}.txt`]),
+  'RENDERS must contain exactly the -06 HTML and TXT files',
+);
+
+const xml = readFileSync(new URL(`UPLOAD-THIS/${basename}.xml`, root), 'utf8');
+const txt = readFileSync(new URL(`RENDERS/${basename}.txt`, root), 'utf8');
+const flatXml = xml.replace(/\s+/g, ' ');
+const flatTxt = txt.replace(/\s+/g, ' ');
+
+for (const required of [
+  `docName="${basename}"`,
+  `value="${basename}"`,
+  '<date year="2026" month="August" day="10"/>',
+  'Transport-Neutral Core Data Model',
+  'HTTP Binding',
+  'Boundary with OAuth Transaction Authorization',
+  'OAuth Non-Substitution Conformance Case',
+  'transaction_authorization_required',
+  'Satisfying AE-CHALLENGE never satisfies a native OAuth grant requirement',
+  'single-use property in this document applies only to one evidence-presentation attempt',
+  'draft-rosomakho-oauth-txn-challenge-00',
+  'draft-klrc-aiagent-auth-03',
+  'draft-schrock-ep-authorization-receipts-11',
+  '403 Forbidden',
+  'application/problem+json',
+  'Informative DMSC Gateway Profile',
+  'does not authorize the action or transfer admission ownership',
+  'does not prevent Gateway A and Gateway B',
+  'retry_timing',
+  'not_before',
+  'jitter_sec',
+  'MUST NOT appear in <tt>critical</tt>',
+  'not a promise of capacity, evidence sufficiency, admission, or execution',
+  'Retry-After',
+  'recipient-specific or challenge-specific retry schedules',
+  'MUST NOT be issued solely to signal overload',
+  'MUST be an absolute URI',
+  'action agreement; expiry; authoritative routing; binding capacity reservation; atomic nonce claim',
+  'whether that first evaluation is still in flight or has completed',
+  'State Bounds and Exhaustion',
+  'finite aggregate upper bound',
+  'per-presenter and per-audience bounds',
+  'administrative bound per tenant',
+  'self-describing issuance',
+  'authoritative replay domain',
+  'MUST NOT evict a live in-flight or consumed nonce',
+  'State Exhaustion Conformance Cases',
+  'read-only capacity check followed by unreserved evaluation does not satisfy this requirement',
+  'capacity response wins',
+  'stateless list of remaining requirements',
+  'route the claim to the owner before classifying the nonce',
+  'Only an authoritative owner result that the exact registered body was already claimed is a replay result',
+  'temporary unavailability, not replay',
+  'owner timeout, partition, or uncertain response',
+  'Two verifier replicas concurrently receiving the same nonce',
+  'MUST NOT include <tt>evidence_challenge</tt>',
+  'committed capacity is not over-allocated under any interleaving',
+  'structured refusal or error payload',
+  'does not preserve one action binding across hops',
+  'Capability discovery',
+  'determine sufficiency using its authenticated local policy',
+  'Sumit P. Ahuja',
+  'Guigui Wang',
+  'Henri Sirkkavaara',
+  'Changes since -05',
+  'https://iana.org/assignments/http-problem-types#ae-required',
+  'Deployment Scenarios and Gap Analysis for AI Agent Gateway',
+  'The Action Evidence Boundary for Consequential Agent Effects',
+  'HTTP Problem Types',
+  'Specification Required',
+  'withdraws the earlier request',
+]) {
+  invariant(flatXml.includes(required), `XML is missing required -06 text: ${required}`);
+}
+for (const required of [
+  'Expires: 11 February 2027',
+  'Transport-Neutral Core Data Model',
+  'HTTP Binding',
+  'Boundary with OAuth Transaction Authorization',
+  'OAuth Non-Substitution Conformance Case',
+  'transaction_authorization_required',
+  'never satisfies a native OAuth grant requirement',
+  'one evidence-presentation attempt',
+  '403 Forbidden',
+  'application/problem+json',
+  'Informative DMSC Gateway Profile',
+  'transfer admission ownership',
+  'double-admission',
+  'retry_timing',
+  'Retry-After',
+  'Retry synchronization and load amplification',
+  'not a promise of capacity, evidence sufficiency, admission, or execution',
+  'State Bounds and Exhaustion',
+  'finite aggregate upper bound',
+  'self-describing issuance',
+  'authoritative replay domain',
+  'State Exhaustion Conformance Cases',
+  'read-only capacity check followed by unreserved evaluation',
+  'capacity response wins',
+  'stateless list of remaining requirements',
+  'route the claim to the owner before classifying the nonce',
+  'temporary unavailability, not replay',
+  'owner timeout, partition, or uncertain response',
+  'absolute URI',
+  'first evaluation is still in flight',
+  'committed capacity is not over-allocated',
+  'structured refusal or error payload',
+  'does not preserve one action binding across hops',
+  'Capability discovery',
+  'Sumit P. Ahuja',
+  'Guigui Wang',
+  'Henri Sirkkavaara',
+  'Changes since -05',
+  'Specification Required',
+]) {
+  invariant(flatTxt.includes(required), `TXT rendering is stale or missing: ${required}`);
+}
+
+const implementation = readFileSync(new URL('../lib/negotiate/evidence-challenge.ts', import.meta.url), 'utf8');
+for (const required of [
+  'selectAuthorizationChallengeMechanism',
+  "primary: 'oauth-transaction-authorization'",
+  'substitution_allowed: false',
+  'explicit_composition_profile',
+]) invariant(implementation.includes(required), `implementation is missing OAuth boundary guard: ${required}`);
+for (const forbidden of [
+  'application/authorization-evidence-challenge+json in the standards tree',
+  'with status 428',
+  'EP-APPROVAL-v1',
+  '<authorization-evidence-required problem type URI>',
+  'AI Agent Gateway Scenarios and Gap Analysis',
+  'Action Evidence Boundary for High-Risk Agent Actions',
+  'docName="draft-schrock-ae-challenge-05"',
+  '<name>Changes since -04</name>',
+  'MUST include <tt>retry_timing</tt> in <tt>critical</tt>',
+  'Durable body-bound nonce registration is required before challenge exposure',
+  '2026-08-08T',
+]) {
+  invariant(!flatXml.includes(forbidden), `retired protocol or revision text survived: ${forbidden}`);
+  invariant(!flatTxt.includes(forbidden), `retired rendered text survived: ${forbidden}`);
+}
+
+invariant(
+  sha256(readFileSync(published05)) === published05Sha256,
+  'immutable published -05 XML changed',
+);
+
+const manifest = readFileSync(new URL('SHA256SUMS.txt', root), 'utf8').trim().split('\n');
+const expectedPaths = [
+  `UPLOAD-THIS/${basename}.xml`,
+  `RENDERS/${basename}.html`,
+  `RENDERS/${basename}.txt`,
+];
+invariant(manifest.length === expectedPaths.length, 'checksum manifest must contain exactly three rows');
+for (const [index, relative] of expectedPaths.entries()) {
+  const match = /^([a-f0-9]{64})  (.+)$/.exec(manifest[index]);
+  invariant(match !== null && match[2] === relative, `malformed checksum row for ${relative}`);
+  if (match !== null) {
+    invariant(sha256(readFileSync(new URL(relative, root))) === match[1], `checksum mismatch for ${relative}`);
+  }
+}
+
+console.log('AE Challenge -06: cap-first refusal, no-policy-oracle behavior, authoritative owner replay, renders, checksums, and immutable -05 PASS.');

--- a/standards/staged/NEXT-AE-CHALLENGE-06/README.md
+++ b/standards/staged/NEXT-AE-CHALLENGE-06/README.md
@@ -1,0 +1,34 @@
+# AE Challenge revision 06 upload packet
+
+Upload exactly:
+
+`UPLOAD-THIS/draft-schrock-ae-challenge-06.xml`
+
+Revision -06 closes three connected refusal-path findings raised by Sumit P.
+Ahuja after publication of -05.
+
+First, every applicable hard state cap now binds through an atomic reservation
+or debit before native evidence verification and local policy evaluation. A
+read-only capacity check followed by expensive evaluation is insufficient
+because capacity can race between the check and the later allocation.
+
+Second, a binding capacity refusal controls the response even when evidence is
+also missing, stale, or unverifiable. The relying party performs no native
+evidence verification and returns no follow-up challenge, stateless requirement
+list, obtain hint, or other evidence-sufficiency detail. This prevents overload
+handling from becoming a policy-discovery oracle.
+
+Third, deterministic replay sharding now has an explicit classification rule.
+The owner is derived from issuer-protected challenge state. Only the
+authoritative owner's already-claimed result is replay. A timeout, partition,
+uncertain result, or failure to reach that owner is temporary unavailability,
+not attacker replay, and never falls back to local state.
+
+The HTTP binding maps binding capacity exhaustion and replay-owner
+unavailability to 503 without `evidence_challenge` or policy hints. It can
+include `Retry-After` without disclosing authorization requirements.
+
+The packet preserves the existing OAuth non-substitution, DMSC ownership,
+retry-pacing, and bounded-state boundaries from -05. The implementation-status
+appendix states that the new -06 requirements are not yet implemented and makes
+no independent-implementation claim.

--- a/standards/staged/NEXT-AE-CHALLENGE-06/RENDERS/draft-schrock-ae-challenge-06.html
+++ b/standards/staged/NEXT-AE-CHALLENGE-06/RENDERS/draft-schrock-ae-challenge-06.html
@@ -1,0 +1,2447 @@
+<!DOCTYPE html>
+<html lang="en" class="Internet-Draft">
+<head>
+<meta charset="utf-8">
+<meta content="Common,Latin" name="scripts">
+<meta content="initial-scale=1.0" name="viewport">
+<title>An Authorization Evidence Challenge for High-Risk Agent Actions</title>
+<meta content="Iman Schrock" name="author">
+<meta content="
+       When a relying party refuses a consequential agent action because
+      authorization evidence is missing, stale, or unverifiable, the agent
+      needs a machine-readable description of what remains necessary. This
+      document defines a transport-neutral Authorization Evidence Challenge
+      data model bound to the relying party's exact action. The challenge
+      identifies outstanding evidence requirements, freshness and status
+      constraints, acceptable presentation profiles, and retry state. It
+      authorizes nothing, transfers no admission ownership, and provides no
+      promise that a later request will execute. 
+       The document also defines an HTTP binding using 403 Forbidden and
+      RFC 9457 Problem Details, and describes an informative gateway-handoff
+      profile for DMSC-style federation. The gateway profile communicates
+      evidence requirements; it does not solve conserved admission or
+      double-admission across independently operated gateways. 
+       A challenge can synchronize corrected retries and amplify load. The
+      core therefore defines optional retry timing with per-challenge jitter,
+      and the HTTP binding maps its lower bound to Retry-After. Retry timing
+      controls presentation attempts only; it does not authorize the action
+      or make an uncertain action safe to repeat. 
+       Single-use processing also places state on the refusal path. The core
+      therefore requires bounded outstanding and replay state, fail-closed
+      behavior when state cannot be claimed, and retention of live replay
+      records until they are no longer security-relevant. Capacity MUST be
+      reserved before native evidence verification, and a binding capacity
+      refusal reveals no remaining evidence requirements. In a sharded replay
+      domain, only the authoritative owner can classify a nonce as already
+      claimed; inability to reach that owner is unavailability, not replay. 
+    " name="description">
+<meta content="xml2rfc 3.34.0" name="generator">
+<meta content="AI agents" name="keyword">
+<meta content="evidence" name="keyword">
+<meta content="challenge" name="keyword">
+<meta content="step-up" name="keyword">
+<meta content="draft-schrock-ae-challenge-06" name="ietf.draft">
+<!-- Generator version information:
+  xml2rfc 3.34.0
+    Python 3.14.5
+    ConfigArgParse 1.7.5
+    google-i18n-address 3.1.1
+    intervaltree 3.2.1
+    Jinja2 3.1.6
+    lxml 6.1.1
+    natsort 8.4.0
+    platformdirs 4.10.0
+    pycountry 26.2.16
+    PyYAML 6.0.3
+    requests 2.34.2
+    wcwidth 0.8.1
+-->
+<link href="draft-schrock-ae-challenge-06.xml" rel="alternate" type="application/rfc+xml">
+<link href="#copyright" rel="license">
+<style type="text/css">/*
+
+  NOTE: Changes at the bottom of this file overrides some earlier settings.
+
+  Once the style has stabilized and has been adopted as an official RFC style,
+  this can be consolidated so that style settings occur only in one place, but
+  for now the contents of this file consists first of the initial CSS work as
+  provided to the RFC Formatter (xml2rfc) work, followed by itemized and
+  commented changes found necessary during the development of the v3
+  formatters.
+
+*/
+
+/* fonts */
+@import url('https://static.ietf.org/fonts/noto-sans/import.css'); /* Sans-serif */
+@import url('https://static.ietf.org/fonts/noto-serif/import.css'); /* Serif (print) */
+@import url('https://static.ietf.org/fonts/roboto-mono/import.css'); /* Monospace */
+
+:root {
+  --font-sans: 'Noto Sans', Arial, Helvetica, sans-serif;
+  --font-serif: 'Noto Serif', 'Times', 'Times New Roman', serif;
+  --font-mono: 'Roboto Mono', Courier, 'Courier New', monospace;
+}
+
+@viewport {
+  zoom: 1.0;
+}
+@-ms-viewport {
+  width: extend-to-zoom;
+  zoom: 1.0;
+}
+/* general and mobile first */
+html {
+}
+body {
+  max-width: 90%;
+  margin: 1.5em auto;
+  color: #222;
+  background-color: #fff;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  line-height: 1.6;
+  scroll-behavior: smooth;
+  overflow-wrap: break-word;
+}
+.ears {
+  display: none;
+}
+
+/* headings */
+#title, h1, h2, h3, h4, h5, h6 {
+  margin: 1em 0 0.5em;
+  font-weight: bold;
+  line-height: 1.3;
+}
+#title {
+  clear: both;
+  border-bottom: 1px solid #ddd;
+  margin: 0 0 0.5em 0;
+  padding: 1em 0 0.5em;
+}
+.author {
+  padding-bottom: 4px;
+}
+h1 {
+  font-size: 26px;
+  margin: 1em 0;
+}
+h2 {
+  font-size: 22px;
+  margin-top: -20px;  /* provide offset for in-page anchors */
+  padding-top: 33px;
+}
+h3 {
+  font-size: 18px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h4 {
+  font-size: 16px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h5, h6 {
+  font-size: 14px;
+}
+#n-copyright-notice {
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 1em;
+  margin-bottom: 1em;
+}
+/* general structure */
+p {
+  padding: 0;
+  margin: 0 0 1em 0;
+  text-align: left;
+}
+div, span {
+  position: relative;
+}
+div {
+  margin: 0;
+}
+.alignRight.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignRight.art-text pre {
+  padding: 0;
+}
+.alignRight {
+  margin: 1em 0;
+}
+.alignRight > *:first-child {
+  border: none;
+  margin: 0;
+  float: right;
+  clear: both;
+}
+.alignRight > *:nth-child(2) {
+  clear: both;
+  display: block;
+  border: none;
+}
+svg {
+  display: block;
+}
+@media print {
+  svg {
+    max-height: 850px;
+    max-width: 660px;
+  }
+}
+svg[font-family~="serif" i], svg [font-family~="serif" i] {
+  font-family: var(--font-serif);
+}
+svg[font-family~="sans-serif" i], svg [font-family~="sans-serif" i] {
+  font-family: var(--font-sans);
+}
+svg[font-family~="monospace" i], svg [font-family~="monospace" i] {
+  font-family: var(--font-mono);
+}
+.alignCenter.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignCenter.art-text pre {
+  padding: 0;
+}
+.alignCenter {
+  margin: 1em 0;
+}
+.alignCenter > *:first-child {
+  display: table;
+  border: none;
+  margin: 0 auto;
+}
+
+/* lists */
+ol, ul {
+  padding: 0;
+  margin: 0 0 1em 2em;
+}
+ol ol, ul ul, ol ul, ul ol {
+  margin-left: 1em;
+}
+li {
+  margin: 0 0 0.25em 0;
+}
+.ulCompact li {
+  margin: 0;
+}
+ul.empty, .ulEmpty {
+  list-style-type: none;
+}
+ul.empty li, .ulEmpty li {
+  margin-top: 0.5em;
+}
+ul.ulBare, li.ulBare {
+  margin-left: 0em !important;
+}
+ul.compact, .ulCompact,
+ol.compact, .olCompact {
+  line-height: 100%;
+  margin: 0 0 0 2em;
+}
+
+/* definition lists */
+dl {
+}
+dl > dt {
+  float: left;
+  margin-right: 1em;
+}
+/* 
+dl.nohang > dt {
+  float: none;
+}
+*/
+dl > dd {
+  margin-bottom: .8em;
+  min-height: 1.3em;
+}
+dl.compact > dd, .dlCompact > dd {
+  margin-bottom: 0em;
+}
+dl > dd > dl {
+  margin-top: 0.5em;
+  margin-bottom: 0em;
+}
+
+/* links */
+a {
+  text-decoration: none;
+}
+a[href] {
+  color: #22e; /* Arlen: WCAG 2019 */
+}
+a[href]:hover {
+  background-color: #f2f2f2;
+}
+figcaption a[href],
+a[href].selfRef {
+  color: #222;
+}
+/* XXX probably not this:
+a.selfRef:hover {
+  background-color: transparent;
+  cursor: default;
+} */
+
+/* Figures */
+tt, code, pre {
+  background-color: #f9f9f9;
+  font-family: var(--font-mono);
+}
+pre {
+  border: 1px solid #eee;
+  margin: 0;
+  padding: 1em;
+}
+img {
+  max-width: 100%;
+}
+figure {
+  margin: 0;
+}
+figure blockquote {
+  margin: 0.8em 0.4em 0.4em;
+}
+figcaption {
+  font-style: italic;
+  margin: 0 0 1em 0;
+}
+@media screen {
+  pre {
+    overflow-x: auto;
+    max-width: 100%;
+    max-width: calc(100% - 22px);
+  }
+}
+
+/* aside, blockquote */
+aside, blockquote {
+  margin-left: 0;
+  padding: 1.2em 2em;
+}
+blockquote {
+  background-color: #f9f9f9;
+  color: #111; /* Arlen: WCAG 2019 */
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  margin: 1em 0;
+}
+blockquote > *:last-child {
+  margin-bottom: 0;
+}
+cite {
+  display: block;
+  text-align: right;
+  font-style: italic;
+}
+.xref {
+  overflow-wrap: normal;
+}
+
+/* tables */
+table {
+  width: 100%;
+  margin: 0 0 1em;
+  border-collapse: collapse;
+  border: 1px solid #eee;
+}
+th, td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.5em 0.75em;
+}
+th {
+  text-align: left;
+  background-color: #e9e9e9;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f5f5f5;
+}
+table caption {
+  font-style: italic;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+}
+table p {
+  /* XXX to avoid bottom margin on table row signifiers. If paragraphs should
+     be allowed within tables more generally, it would be far better to select on a class. */
+  margin: 0;
+}
+
+/* pilcrow */
+a.pilcrow {
+  color: #666; /* Arlen: AHDJ 2019 */
+  text-decoration: none;
+  visibility: hidden;
+  user-select: none;
+  -ms-user-select: none;
+  -o-user-select:none;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+@media screen {
+  aside:hover > a.pilcrow,
+  p:hover > a.pilcrow,
+  blockquote:hover > a.pilcrow,
+  div:hover > a.pilcrow,
+  li:hover > a.pilcrow,
+  pre:hover > a.pilcrow {
+    visibility: visible;
+  }
+  a.pilcrow:hover {
+    background-color: transparent;
+  }
+}
+
+/* misc */
+hr {
+  border: 0;
+  border-top: 1px solid #eee;
+}
+.bcp14 {
+  font-variant: small-caps;
+}
+
+.role {
+  font-variant: all-small-caps;
+}
+
+/* info block */
+#identifiers {
+  margin: 0;
+  font-size: 0.9em;
+}
+#identifiers dt {
+  width: 3em;
+  clear: left;
+}
+#identifiers dd {
+  float: left;
+  margin-bottom: 0;
+}
+/* Fix PDF info block run off issue */
+@media print {
+  #identifiers dd {
+    max-width: 100%;
+  }
+}
+#identifiers .authors .author {
+  display: inline-block;
+  margin-right: 1.5em;
+}
+#identifiers .authors .org {
+  font-style: italic;
+}
+
+/* The prepared/rendered info at the very bottom of the page */
+.docInfo {
+  color: #666; /* Arlen: WCAG 2019 */
+  font-size: 0.9em;
+  font-style: italic;
+  margin-top: 2em;
+}
+.docInfo .prepared {
+  float: left;
+}
+.docInfo .prepared {
+  float: right;
+}
+
+/* table of contents */
+#toc  {
+  padding: 0.75em 0 2em 0;
+  margin-bottom: 1em;
+}
+nav.toc ul {
+  margin: 0 0.5em 0 0;
+  padding: 0;
+  list-style: none;
+}
+nav.toc li {
+  line-height: 1.3em;
+  margin: 0.75em 0;
+  padding-left: 1.2em;
+  text-indent: -1.2em;
+}
+/* references */
+.references dt {
+  text-align: right;
+  font-weight: bold;
+  min-width: 7em;
+}
+.references dd {
+  margin-left: 8em;
+  overflow: auto;
+}
+
+.refInstance {
+  margin-bottom: 1.25em;
+}
+
+.refSubseries {
+  margin-bottom: 1.25em;
+}
+
+.references .ascii {
+  margin-bottom: 0.25em;
+}
+
+/* index */
+.index ul {
+  margin: 0 0 0 1em;
+  padding: 0;
+  list-style: none;
+}
+.index ul ul {
+  margin: 0;
+}
+.index li {
+  margin: 0;
+  text-indent: -2em;
+  padding-left: 2em;
+  padding-bottom: 5px;
+}
+.indexIndex {
+  margin: 0.5em 0 1em;
+}
+.index a {
+  font-weight: 700;
+}
+/* make the index two-column on all but the smallest screens */
+@media (min-width: 600px) {
+  .index ul {
+    -moz-column-count: 2;
+    -moz-column-gap: 20px;
+  }
+  .index ul ul {
+    -moz-column-count: 1;
+    -moz-column-gap: 0;
+  }
+}
+
+/* authors */
+address.vcard {
+  font-style: normal;
+  margin: 1em 0;
+}
+
+address.vcard .nameRole {
+  font-weight: 700;
+  margin-left: 0;
+}
+address.vcard .label {
+  font-family: var(--font-sans);
+  margin: 0.5em 0;
+}
+address.vcard .type {
+  display: none;
+}
+.alternative-contact {
+  margin: 1.5em 0 1em;
+}
+hr.addr {
+  border-top: 1px dashed;
+  margin: 0;
+  color: #ddd;
+  max-width: calc(100% - 16px);
+}
+
+/* temporary notes */
+.rfcEditorRemove::before {
+  position: absolute;
+  top: 0.2em;
+  right: 0.2em;
+  padding: 0.2em;
+  content: "The RFC Editor will remove this note";
+  color: #9e2a00; /* Arlen: WCAG 2019 */
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+}
+.rfcEditorRemove {
+  position: relative;
+  padding-top: 1.8em;
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  border-radius: 3px;
+}
+.cref {
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  padding: 2px 4px;
+}
+.crefSource {
+  font-style: italic;
+}
+/* alternative layout for smaller screens */
+@media screen and (max-width: 1023px) {
+  body {
+    padding-top: 2em;
+  }
+  #title {
+    padding: 1em 0;
+  }
+  h1 {
+    font-size: 24px;
+  }
+  h2 {
+    font-size: 20px;
+    margin-top: -18px;  /* provide offset for in-page anchors */
+    padding-top: 38px;
+  }
+  #identifiers dd {
+    max-width: 60%;
+  }
+  #toc {
+    position: fixed;
+    z-index: 2;
+    top: 0;
+    right: 0;
+    padding: 0;
+    margin: 0;
+    background-color: inherit;
+    border-bottom: 1px solid #ccc;
+  }
+  #toc h2 {
+    margin: -1px 0 0 0;
+    padding: 4px 0 4px 6px;
+    padding-right: 1em;
+    min-width: 190px;
+    font-size: 1.1em;
+    text-align: right;
+    background-color: #444;
+    color: white;
+    cursor: pointer;
+  }
+  #toc h2::before { /* css hamburger */
+    float: right;
+    position: relative;
+    width: 1em;
+    height: 1px;
+    left: -164px;
+    margin: 6px 0 0 0;
+    background: white none repeat scroll 0 0;
+    box-shadow: 0 4px 0 0 white, 0 8px 0 0 white;
+    content: "";
+  }
+  #toc nav {
+    display: none;
+    padding: 0.5em 1em 1em;
+    overflow: auto;
+    height: calc(100vh - 48px);
+    border-left: 1px solid #ddd;
+  }
+}
+
+/* alternative layout for wide screens */
+@media screen and (min-width: 1024px) {
+  body {
+    max-width: 724px;
+    margin: 42px auto;
+    padding-left: 1.5em;
+    padding-right: 29em;
+  }
+  #toc {
+    position: fixed;
+    top: 42px;
+    right: 42px;
+    width: 25%;
+    margin: 0;
+    padding: 0 1em;
+    z-index: 1;
+  }
+  #toc h2 {
+    border-top: none;
+    border-bottom: 1px solid #ddd;
+    font-size: 1em;
+    font-weight: normal;
+    margin: 0;
+    padding: 0.25em 1em 1em 0;
+  }
+  #toc nav {
+    display: block;
+    height: calc(90vh - 84px);
+    bottom: 0;
+    padding: 0.5em 0 0;
+    overflow: auto;
+  }
+  img { /* future proofing */
+    max-width: 100%;
+    height: auto;
+  }
+}
+
+/* pagination */
+@media print {
+  body {
+    width: 100%;
+  }
+  p {
+    orphans: 3;
+    widows: 3;
+  }
+  #n-copyright-notice {
+    border-bottom: none;
+  }
+  #toc, #n-introduction {
+    page-break-before: always;
+  }
+  #toc {
+    border-top: none;
+    padding-top: 0;
+  }
+  figure, pre {
+    page-break-inside: avoid;
+  }
+  figure {
+    overflow: scroll;
+  }
+  .breakable pre {
+    break-inside: auto;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    page-break-after: avoid;
+  }
+  h2+*, h3+*, h4+*, h5+*, h6+* {
+    page-break-before: avoid;
+  }
+  pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-size: 10pt;
+  }
+  table {
+    border: 1px solid #ddd;
+  }
+  td {
+    border-top: 1px solid #ddd;
+  }
+}
+
+/* This is commented out here, as the string-set: doesn't
+   pass W3C validation currently */
+/*
+.ears thead .left {
+  string-set: ears-top-left content();
+}
+
+.ears thead .center {
+  string-set: ears-top-center content();
+}
+
+.ears thead .right {
+  string-set: ears-top-right content();
+}
+
+.ears tfoot .left {
+  string-set: ears-bottom-left content();
+}
+
+.ears tfoot .center {
+  string-set: ears-bottom-center content();
+}
+
+.ears tfoot .right {
+  string-set: ears-bottom-right content();
+}
+*/
+
+@page :first {
+  padding-top: 0;
+  @top-left {
+    content: normal;
+    border: none;
+  }
+  @top-center {
+    content: normal;
+    border: none;
+  }
+  @top-right {
+    content: normal;
+    border: none;
+  }
+}
+
+@page {
+  size: A4;
+  margin-bottom: 45mm;
+  padding-top: 20px;
+  /* The following is commented out here, but set appropriately by in code, as
+     the content depends on the document */
+  /*
+  @top-left {
+    content: 'Internet-Draft';
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-left {
+    content: string(ears-top-left);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-center {
+    content: string(ears-top-center);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-right {
+    content: string(ears-top-right);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @bottom-left {
+    content: string(ears-bottom-left);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-center {
+    content: string(ears-bottom-center);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-right {
+      content: '[Page ' counter(page) ']';
+      vertical-align: top;
+      border-top: solid 1px #ccc;
+  }
+  */
+
+}
+
+/* Changes introduced to fix issues found during implementation */
+/* Make sure links are clickable even if overlapped by following H* */
+a {
+  z-index: 2;
+}
+/* Separate body from document info even without intervening H1 */
+section {
+  clear: both;
+}
+
+
+/* Top align author divs, to avoid names without organization dropping level with org names */
+.author {
+  vertical-align: top;
+}
+
+/* Leave room in document info to show Internet-Draft on one line */
+#identifiers dt {
+  width: 8em;
+}
+
+/* Don't waste quite as much whitespace between label and value in doc info */
+#identifiers dd {
+  margin-left: 1em;
+}
+
+/* Give floating toc a background color (needed when it's a div inside section */
+#toc {
+  background-color: white;
+}
+
+/* Make the collapsed ToC header render white on gray also when it's a link */
+@media screen and (max-width: 1023px) {
+  #toc h2 a,
+  #toc h2 a:link,
+  #toc h2 a:focus,
+  #toc h2 a:hover,
+  #toc a.toplink,
+  #toc a.toplink:hover {
+    color: white;
+    background-color: #444;
+    text-decoration: none;
+  }
+}
+
+/* Give the bottom of the ToC some whitespace */
+@media screen and (min-width: 1024px) {
+  #toc {
+    padding: 0 0 1em 1em;
+  }
+}
+
+/* Style section numbers with more space between number and title */
+.section-number {
+  padding-right: 0.5em;
+}
+
+/* prevent monospace from becoming overly large */
+tt, code, pre {
+  font-size: 95%;
+}
+
+/* Fix the height/width aspect for ascii art*/
+.sourcecode pre,
+.art-text pre {
+  line-height: 1.12;
+}
+
+
+/* Add styling for a link in the ToC that points to the top of the document */
+a.toplink {
+  float: right;
+  margin-right: 0.5em;
+}
+
+/* Fix the dl styling to match the RFC 7992 attributes */
+dl > dt,
+dl.dlParallel > dt {
+  float: left;
+  margin-right: 1em;
+}
+dl.dlNewline > dt {
+  float: none;
+}
+
+/* Provide styling for table cell text alignment */
+table td.text-left,
+table th.text-left {
+  text-align: left;
+}
+table td.text-center,
+table th.text-center {
+  text-align: center;
+}
+table td.text-right,
+table th.text-right {
+  text-align: right;
+}
+
+/* Make the alternative author contact information look less like just another
+   author, and group it closer with the primary author contact information */
+.alternative-contact {
+  margin: 0.5em 0 0.25em 0;
+}
+address .non-ascii {
+  margin: 0 0 0 2em;
+}
+
+/* With it being possible to set tables with alignment
+  left, center, and right, { width: 100%; } does not make sense */
+table {
+  width: auto;
+}
+
+/* Avoid reference text that sits in a block with very wide left margin,
+   because of a long floating dt label.*/
+.references dd {
+  overflow: visible;
+}
+
+/* Control caption placement */
+caption {
+  caption-side: bottom;
+}
+
+/* Limit the width of the author address vcard, so names in right-to-left
+   script don't end up on the other side of the page. */
+
+address.vcard {
+  max-width: 30em;
+  margin-right: auto;
+}
+
+/* For address alignment dependent on LTR or RTL scripts */
+address div.left {
+  text-align: left;
+}
+address div.right {
+  text-align: right;
+}
+
+/* Provide table alignment support.  We can't use the alignX classes above
+   since they do unwanted things with caption and other styling. */
+table.right {
+ margin-left: auto;
+ margin-right: 0;
+}
+table.center {
+ margin-left: auto;
+ margin-right: auto;
+}
+table.left {
+ margin-left: 0;
+ margin-right: auto;
+}
+
+/* Give the table caption label the same styling as the figcaption */
+caption a[href] {
+  color: #222;
+}
+
+@media print {
+  .toplink {
+    display: none;
+  }
+
+  /* avoid overwriting the top border line with the ToC header */
+  #toc {
+    padding-top: 1px;
+  }
+
+  /* Avoid page breaks inside dl and author address entries */
+  .vcard {
+    page-break-inside: avoid;
+  }
+
+}
+/* Tweak the bcp14 keyword presentation */
+.bcp14 {
+  font-variant: small-caps;
+  font-weight: bold;
+  font-size: 0.9em;
+}
+/* Tweak the invisible space above H* in order not to overlay links in text above */
+ h2 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 31px;
+ }
+ h3 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+ h4 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+/* Float artwork pilcrow to the right */
+@media screen {
+  .artwork a.pilcrow {
+    display: block;
+    line-height: 0.7;
+    margin-top: 0.15em;
+  }
+}
+/* Make pilcrows on dd visible */
+@media screen {
+  dd:hover > a.pilcrow {
+    visibility: visible;
+  }
+}
+/* Make the placement of figcaption match that of a table's caption
+   by removing the figure's added bottom margin */
+.alignLeft.art-text,
+.alignCenter.art-text,
+.alignRight.art-text {
+   margin-bottom: 0;
+}
+.alignLeft,
+.alignCenter,
+.alignRight {
+  margin: 1em 0 0 0;
+}
+/* In print, the pilcrow won't show on hover, so prevent it from taking up space,
+   possibly even requiring a new line */
+@media print {
+  a.pilcrow {
+    display: none;
+  }
+}
+/* Styling for the external metadata */
+div#external-metadata {
+  background-color: #eee;
+  padding: 0.5em;
+  margin-bottom: 0.5em;
+  display: none;
+}
+div#internal-metadata {
+  padding: 0.5em;                       /* to match the external-metadata padding */
+}
+/* Styling for title RFC Number */
+h1#rfcnum {
+  clear: both;
+  margin: 0 0 -1em;
+  padding: 1em 0 0 0;
+}
+/* Make .olPercent look the same as <ol><li> */
+dl.olPercent > dd {
+  margin-bottom: 0.25em;
+  min-height: initial;
+}
+/* Give aside some styling to set it apart */
+aside {
+  border-left: 1px solid #ddd;
+  margin: 1em 0 1em 2em;
+  padding: 0.2em 2em;
+}
+aside > dl,
+aside > ol,
+aside > ul,
+aside > table,
+aside > p {
+  margin-bottom: 0.5em;
+}
+/* Additional page break settings */
+@media print {
+  figcaption, table caption {
+    page-break-before: avoid;
+  }
+}
+/* Font size adjustments for print */
+@media print {
+  body  { font-size: 10pt;      line-height: normal; max-width: 96%; }
+  h1    { font-size: 1.72em;    padding-top: 1.5em; } /* 1*1.2*1.2*1.2 */
+  h2    { font-size: 1.44em;    padding-top: 1.5em; } /* 1*1.2*1.2 */
+  h3    { font-size: 1.2em;     padding-top: 1.5em; } /* 1*1.2 */
+  h4    { font-size: 1em;       padding-top: 1.5em; }
+  h5, h6 { font-size: 1em;      margin: initial; padding: 0.5em 0 0.3em; }
+}
+/* Sourcecode margin in print, when there's no pilcrow */
+@media print {
+  .artwork,
+  .artwork > pre,
+  .sourcecode {
+    margin-bottom: 1em;
+  }
+}
+/* Avoid narrow tables forcing too narrow table captions, which may render badly */
+table {
+  min-width: 20em;
+}
+/* ol type a */
+ol.type-a { list-style-type: lower-alpha; }
+ol.type-A { list-style-type: upper-alpha; }
+ol.type-i { list-style-type: lower-roman; }
+ol.type-I { list-style-type: upper-roman; }
+/* Apply the print table and row borders in general, on request from the RPC,
+and increase the contrast between border and odd row background slightly */
+table {
+  border: 1px solid #ddd;
+}
+td {
+  border-top: 1px solid #ddd;
+}
+tr {
+  break-inside: avoid;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f8f8f8;
+}
+/* Use style rules to govern display of the TOC. */
+@media screen and (max-width: 1023px) {
+  #toc nav { display: none; }
+  #toc.active nav { display: block; }
+}
+/* Add support for keepWithNext */
+.keepWithNext {
+  break-after: avoid-page;
+  break-after: avoid-page;
+}
+/* Add support for keepWithPrevious */
+.keepWithPrevious {
+  break-before: avoid-page;
+}
+/* Change the approach to avoiding breaks inside artwork etc. */
+figure, pre, table, .artwork, .sourcecode  {
+  break-before: auto;
+  break-after: auto;
+}
+/* Avoid breaks between <dt> and <dd> */
+dl {
+  break-before: auto;
+  break-inside: auto;
+}
+dt {
+  break-before: auto;
+  break-after: avoid-page;
+}
+dd {
+  break-before: avoid-page;
+  break-after: auto;
+  orphans: 3;
+  widows: 3
+}
+span.break, dd.break {
+  margin-bottom: 0;
+  min-height: 0;
+  break-before: auto;
+  break-inside: auto;
+  break-after: auto;
+}
+/* Undo break-before ToC */
+@media print {
+  #toc {
+    break-before: auto;
+  }
+}
+/* Text in compact lists should not get extra bottom margin space,
+   since that would makes the list not compact */
+ul.compact p, .ulCompact p,
+ol.compact p, .olCompact p {
+ margin: 0;
+}
+/* But the list as a whole needs the extra space at the end */
+section ul.compact,
+section .ulCompact,
+section ol.compact,
+section .olCompact {
+  margin-bottom: 1em;                    /* same as p not within ul.compact etc. */
+}
+/* The tt and code background above interferes with for instance table cell
+   backgrounds.  Changed to something a bit more selective. */
+tt, code {
+  background-color: transparent;
+}
+p tt, p code, li tt, li code, dt tt, dt code {
+  background-color: #f8f8f8;
+}
+/* Tweak the pre margin -- 0px doesn't come out well */
+pre {
+   margin-top: 0.5px;
+}
+/* Tweak the compact list text */
+ul.compact, .ulCompact,
+ol.compact, .olCompact,
+dl.compact, .dlCompact {
+  line-height: normal;
+}
+/* Don't add top margin for nested lists */
+li > ul, li > ol, li > dl,
+dd > ul, dd > ol, dd > dl,
+dl > dd > dl {
+  margin-top: initial;
+}
+/* Elements that should not be rendered on the same line as a <dt> */
+/* This should match the element list in writer.text.TextWriter.render_dl() */
+dd > div.artwork:first-child,
+dd > aside:first-child,
+dd > blockquote:first-child,
+dd > figure:first-child,
+dd > ol:first-child,
+dd > div.sourcecode:first-child,
+dd > table:first-child,
+dd > ul:first-child {
+  clear: left;
+}
+/* fix for weird browser behaviour when <dd/> is empty */
+dt+dd:empty::before{
+  content: "\00a0";
+}
+/* Make paragraph spacing inside <li> smaller than in body text, to fit better within the list */
+li > p {
+  margin-bottom: 0.5em
+}
+/* Don't let p margin spill out from inside list items */
+li > p:last-of-type:only-child {
+  margin-bottom: 0;
+}
+</style>
+<link href="rfc-local.css" rel="stylesheet" type="text/css">
+<script type="application/javascript">async function addMetadata(){try{const e=document.styleSheets[0].cssRules;for(let t=0;t<e.length;t++)if(/#identifiers/.exec(e[t].selectorText)){const a=e[t].cssText.replace("#identifiers","#external-updates");document.styleSheets[0].insertRule(a,document.styleSheets[0].cssRules.length)}}catch(e){console.log(e)}const e=document.getElementById("external-metadata");if(e)try{var t,a="",o=function(e){const t=document.getElementsByTagName("meta");for(let a=0;a<t.length;a++)if(t[a].getAttribute("name")===e)return t[a].getAttribute("content");return""}("rfc.number");if(o){t="https://www.rfc-editor.org/rfc/rfc"+o+".json";try{const e=await fetch(t);a=await e.json()}catch(e){t=document.URL.indexOf("html")>=0?document.URL.replace(/html$/,"json"):document.URL+".json";const o=await fetch(t);a=await o.json()}}if(!a)return;e.style.display="block";const s="",d="https://datatracker.ietf.org/doc",n="https://datatracker.ietf.org/ipr/search",c="https://www.rfc-editor.org/info",l=a.doc_id.toLowerCase(),i=a.doc_id.slice(0,3).toLowerCase(),f=a.doc_id.slice(3).replace(/^0+/,""),u={status:"Status",obsoletes:"Obsoletes",obsoleted_by:"Obsoleted By",updates:"Updates",updated_by:"Updated By",see_also:"See Also",errata_url:"Errata"};let h="<dl style='overflow:hidden' id='external-updates'>";["status","obsoletes","obsoleted_by","updates","updated_by","see_also","errata_url"].forEach(e=>{if("status"==e){a[e]=a[e].toLowerCase();var t=a[e].split(" "),o=t.length,w="",p=1;for(let e=0;e<o;e++)p<o?w=w+r(t[e])+" ":w+=r(t[e]),p++;a[e]=w}else if("obsoletes"==e||"obsoleted_by"==e||"updates"==e||"updated_by"==e){var g,m="",b=1;g=a[e].length;for(let t=0;t<g;t++)a[e][t]&&(a[e][t]=String(a[e][t]).toLowerCase(),m=b<g?m+"<a href='"+s+"/rfc/".concat(a[e][t])+"'>"+a[e][t].slice(3)+"</a>, ":m+"<a href='"+s+"/rfc/".concat(a[e][t])+"'>"+a[e][t].slice(3)+"</a>",b++);a[e]=m}else if("see_also"==e){var y,L="",C=1;y=a[e].length;for(let t=0;t<y;t++)if(a[e][t]){a[e][t]=String(a[e][t]);var _=a[e][t].slice(0,3),v=a[e][t].slice(3).replace(/^0+/,"");L=C<y?"RFC"!=_?L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+_+" "+v+"</a>, ":L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+v+"</a>, ":"RFC"!=_?L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+_+" "+v+"</a>":L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+v+"</a>",C++}a[e]=L}else if("errata_url"==e){var R="";R=a[e]?R+"<a href='"+a[e]+"'>Errata exist</a> | <a href='"+d+"/"+l+"'>Datatracker</a>| <a href='"+n+"/?"+i+"="+f+"&submit="+i+"'>IPR</a> | <a href='"+c+"/"+l+"'>Info page</a>":"<a href='"+d+"/"+l+"'>Datatracker</a> | <a href='"+n+"/?"+i+"="+f+"&submit="+i+"'>IPR</a> | <a href='"+c+"/"+l+"'>Info page</a>",a[e]=R}""!=a[e]?"Errata"==u[e]?h+=`<dt>More info:</dt><dd>${a[e]}</dd>`:h+=`<dt>${u[e]}:</dt><dd>${a[e]}</dd>`:"Errata"==u[e]&&(h+=`<dt>More info:</dt><dd>${a[e]}</dd>`)}),h+="</dl>",e.innerHTML=h}catch(e){console.log(e)}else console.log("Could not locate metadata <div> element");function r(e){return e.charAt(0).toUpperCase()+e.slice(1)}}window.removeEventListener("load",addMetadata),window.addEventListener("load",addMetadata);</script>
+</head>
+<body class="xml2rfc">
+<table class="ears">
+<thead><tr>
+<td class="left">Internet-Draft</td>
+<td class="center">Evidence Challenge</td>
+<td class="right">August 2026</td>
+</tr></thead>
+<tfoot><tr>
+<td class="left">Schrock</td>
+<td class="center">Expires 11 February 2027</td>
+<td class="right">[Page]</td>
+</tr></tfoot>
+</table>
+<div id="external-metadata" class="document-information"></div>
+<div id="internal-metadata" class="document-information">
+<dl id="identifiers">
+<dt class="label-workgroup">Workgroup:</dt>
+<dd class="workgroup">Network Working Group</dd>
+<dt class="label-internet-draft">Internet-Draft:</dt>
+<dd class="internet-draft">draft-schrock-ae-challenge-06</dd>
+<dt class="label-published">Published:</dt>
+<dd class="published">
+<time datetime="2026-08-10" class="published">10 August 2026</time>
+    </dd>
+<dt class="label-intended-status">Intended Status:</dt>
+<dd class="intended-status">Informational</dd>
+<dt class="label-expires">Expires:</dt>
+<dd class="expires"><time datetime="2027-02-11">11 February 2027</time></dd>
+<dt class="label-authors">Author:</dt>
+<dd class="authors">
+<div class="author">
+      <div class="author-name">I. Schrock</div>
+<div class="org">EMILIA Protocol, Inc.</div>
+</div>
+</dd>
+</dl>
+</div>
+<h1 id="title">An Authorization Evidence Challenge for High-Risk Agent Actions</h1>
+<section id="section-abstract">
+      <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
+<p id="section-abstract-1">When a relying party refuses a consequential agent action because
+      authorization evidence is missing, stale, or unverifiable, the agent
+      needs a machine-readable description of what remains necessary. This
+      document defines a transport-neutral Authorization Evidence Challenge
+      data model bound to the relying party's exact action. The challenge
+      identifies outstanding evidence requirements, freshness and status
+      constraints, acceptable presentation profiles, and retry state. It
+      authorizes nothing, transfers no admission ownership, and provides no
+      promise that a later request will execute.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
+<p id="section-abstract-2">The document also defines an HTTP binding using 403 Forbidden and
+      RFC 9457 Problem Details, and describes an informative gateway-handoff
+      profile for DMSC-style federation. The gateway profile communicates
+      evidence requirements; it does not solve conserved admission or
+      double-admission across independently operated gateways.<a href="#section-abstract-2" class="pilcrow">¶</a></p>
+<p id="section-abstract-3">A challenge can synchronize corrected retries and amplify load. The
+      core therefore defines optional retry timing with per-challenge jitter,
+      and the HTTP binding maps its lower bound to Retry-After. Retry timing
+      controls presentation attempts only; it does not authorize the action
+      or make an uncertain action safe to repeat.<a href="#section-abstract-3" class="pilcrow">¶</a></p>
+<p id="section-abstract-4">Single-use processing also places state on the refusal path. The core
+      therefore requires bounded outstanding and replay state, fail-closed
+      behavior when state cannot be claimed, and retention of live replay
+      records until they are no longer security-relevant. Capacity MUST be
+      reserved before native evidence verification, and a binding capacity
+      refusal reveals no remaining evidence requirements. In a sharded replay
+      domain, only the authoritative owner can classify a nonce as already
+      claimed; inability to reach that owner is unavailability, not replay.<a href="#section-abstract-4" class="pilcrow">¶</a></p>
+</section>
+<div id="status-of-memo">
+<section id="section-boilerplate.1">
+        <h2 id="name-status-of-this-memo">
+<a href="#name-status-of-this-memo" class="section-name selfRef">Status of This Memo</a>
+        </h2>
+<p id="section-boilerplate.1-1">
+        This Internet-Draft is submitted in full conformance with the
+        provisions of BCP 78 and BCP 79.<a href="#section-boilerplate.1-1" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-2">
+        Internet-Drafts are working documents of the Internet Engineering Task
+        Force (IETF). Note that other groups may also distribute working
+        documents as Internet-Drafts. The list of current Internet-Drafts is
+        at <span><a href="https://datatracker.ietf.org/drafts/current/">https://datatracker.ietf.org/drafts/current/</a></span>.<a href="#section-boilerplate.1-2" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-3">
+        Internet-Drafts are draft documents valid for a maximum of six months
+        and may be updated, replaced, or obsoleted by other documents at any
+        time. It is inappropriate to use Internet-Drafts as reference
+        material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-4">
+        This Internet-Draft will expire on 11 February 2027.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="copyright">
+<section id="section-boilerplate.2">
+        <h2 id="name-copyright-notice">
+<a href="#name-copyright-notice" class="section-name selfRef">Copyright Notice</a>
+        </h2>
+<p id="section-boilerplate.2-1">
+            Copyright (c) 2026 IETF Trust and the persons identified as the
+            document authors. All rights reserved.<a href="#section-boilerplate.2-1" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.2-2">
+            This document is subject to BCP 78 and the IETF Trust's Legal
+            Provisions Relating to IETF Documents
+            (<span><a href="https://trustee.ietf.org/license-info">https://trustee.ietf.org/license-info</a></span>) in effect on the date of
+            publication of this document. Please review these documents
+            carefully, as they describe your rights and restrictions with
+            respect to this document.<a href="#section-boilerplate.2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="toc">
+<section id="section-toc.1">
+        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
+<a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
+        </h2>
+<nav class="toc"><ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1">
+            <p id="section-toc.1-1.1.1"><a href="#section-1" class="auto internal xref">1</a>.  <a href="#name-introduction" class="internal xref">Introduction</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1.2.1">
+                <p id="section-toc.1-1.1.2.1.1" class="keepWithNext"><a href="#section-1.1" class="auto internal xref">1.1</a>.  <a href="#name-boundary-with-oauth-transac" class="internal xref">Boundary with OAuth Transaction Authorization</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1.2.2">
+                <p id="section-toc.1-1.1.2.2.1" class="keepWithNext"><a href="#section-1.2" class="auto internal xref">1.2</a>.  <a href="#name-requirements-language" class="internal xref">Requirements Language</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1.2.3">
+                <p id="section-toc.1-1.1.2.3.1" class="keepWithNext"><a href="#section-1.3" class="auto internal xref">1.3</a>.  <a href="#name-terminology" class="internal xref">Terminology</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2">
+            <p id="section-toc.1-1.2.1"><a href="#section-2" class="auto internal xref">2</a>.  <a href="#name-transport-neutral-core-data" class="internal xref">Transport-Neutral Core Data Model</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.1">
+                <p id="section-toc.1-1.2.2.1.1"><a href="#section-2.1" class="auto internal xref">2.1</a>.  <a href="#name-action-and-policy-binding" class="internal xref">Action and Policy Binding</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.2">
+                <p id="section-toc.1-1.2.2.2.1"><a href="#section-2.2" class="auto internal xref">2.2</a>.  <a href="#name-evidence-requirements-and-p" class="internal xref">Evidence Requirements and Presentation</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.3">
+                <p id="section-toc.1-1.2.2.3.1"><a href="#section-2.3" class="auto internal xref">2.3</a>.  <a href="#name-lifecycle-replay-and-retry" class="internal xref">Lifecycle, Replay, and Retry</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.4">
+                <p id="section-toc.1-1.2.2.4.1"><a href="#section-2.4" class="auto internal xref">2.4</a>.  <a href="#name-state-bounds-and-exhaustion" class="internal xref">State Bounds and Exhaustion</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.4.2.1">
+                    <p id="section-toc.1-1.2.2.4.2.1.1"><a href="#section-2.4.1" class="auto internal xref">2.4.1</a>.  <a href="#name-state-exhaustion-conformanc" class="internal xref">State Exhaustion Conformance Cases</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.5">
+                <p id="section-toc.1-1.2.2.5.1"><a href="#section-2.5" class="auto internal xref">2.5</a>.  <a href="#name-extensibility" class="internal xref">Extensibility</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.6">
+                <p id="section-toc.1-1.2.2.6.1"><a href="#section-2.6" class="auto internal xref">2.6</a>.  <a href="#name-carrier-semantics" class="internal xref">Carrier Semantics</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3">
+            <p id="section-toc.1-1.3.1"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-http-binding" class="internal xref">HTTP Binding</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3.2.1">
+                <p id="section-toc.1-1.3.2.1.1"><a href="#section-3.1" class="auto internal xref">3.1</a>.  <a href="#name-oauth-non-substitution-conf" class="internal xref">OAuth Non-Substitution Conformance Case</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="auto internal xref">4</a>.  <a href="#name-informative-dmsc-gateway-pr" class="internal xref">Informative DMSC Gateway Profile</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.1">
+                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="auto internal xref">4.1</a>.  <a href="#name-gateway-conformance-case" class="internal xref">Gateway Conformance Case</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="auto internal xref">5</a>.  <a href="#name-security-considerations" class="internal xref">Security Considerations</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-iana-considerations" class="internal xref">IANA Considerations</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="auto internal xref">7</a>.  <a href="#name-interoperability-questions-" class="internal xref">Interoperability Questions for Review</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="auto internal xref">8</a>.  <a href="#name-acknowledgments" class="internal xref">Acknowledgments</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="auto internal xref">9</a>.  <a href="#name-changes-since-05" class="internal xref">Changes since -05</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
+            <p id="section-toc.1-1.10.1"><a href="#section-10" class="auto internal xref">10</a>. <a href="#name-normative-references" class="internal xref">Normative References</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
+            <p id="section-toc.1-1.11.1"><a href="#section-11" class="auto internal xref">11</a>. <a href="#name-informative-references" class="internal xref">Informative References</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
+            <p id="section-toc.1-1.12.1"><a href="#appendix-A" class="auto internal xref">Appendix A</a>.  <a href="#name-relationship-to-existing-me" class="internal xref">Relationship to Existing Mechanisms</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13">
+            <p id="section-toc.1-1.13.1"><a href="#appendix-B" class="auto internal xref">Appendix B</a>.  <a href="#name-implementation-status" class="internal xref">Implementation Status</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14">
+            <p id="section-toc.1-1.14.1"><a href="#appendix-C" class="auto internal xref"></a><a href="#name-authors-address" class="internal xref">Author's Address</a></p>
+</li>
+        </ul>
+</nav>
+</section>
+</div>
+<div id="intro">
+<section id="section-1">
+      <h2 id="name-introduction">
+<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction" class="section-name selfRef">Introduction</a>
+      </h2>
+<p id="section-1-1">Evidence formats describe artifacts such as receipts, permits,
+      attestations, and logs. They do not by themselves define the live
+      interaction that follows when a relying party finds the presented
+      evidence insufficient. Without a common challenge, each agent protocol
+      invents its own vocabulary for missing evidence, acceptable
+      presentations, freshness, status checking, and retry.<a href="#section-1-1" class="pilcrow">¶</a></p>
+<p id="section-1-2">This document defines the challenge as an application data model,
+      independent of HTTP, a particular agent protocol, and any one evidence
+      format. OAuth step-up authentication <span>[<a href="#RFC9470" class="cite xref">RFC9470</a>]</span> lets a
+      resource identify stronger authentication requirements. OAuth
+      Transaction Authorization Challenge
+      <span>[<a href="#OAUTH-TXN-CHALLENGE" class="cite xref">OAUTH-TXN-CHALLENGE</a>]</span> defines a signed, OAuth-specific
+      challenge that an authorization server turns into a transaction-bound
+      access token after obtaining any required approval. AE-CHALLENGE does
+      not replace either mechanism. It describes missing authorization
+      evidence for an exact proposed action when an application needs a
+      transport-neutral evidence-negotiation object.<a href="#section-1-2" class="pilcrow">¶</a></p>
+<p id="section-1-3">A challenge is a refusal with information. It is not an
+      authorization decision, reservation, capability, ownership transfer,
+      or promise of execution. Satisfying it causes the relying party to
+      evaluate a new presentation under its live local policy.<a href="#section-1-3" class="pilcrow">¶</a></p>
+<div id="oauth-boundary">
+<section id="section-1.1">
+        <h3 id="name-boundary-with-oauth-transac">
+<a href="#section-1.1" class="section-number selfRef">1.1. </a><a href="#name-boundary-with-oauth-transac" class="section-name selfRef">Boundary with OAuth Transaction Authorization</a>
+        </h3>
+<p id="section-1.1-1">When the required next step is issuance of a transaction-specific
+        OAuth grant, an implementation <span class="bcp14">SHOULD</span> use OAuth
+        Transaction Authorization Challenge. It <span class="bcp14">MUST NOT</span>
+        substitute an AE-CHALLENGE, its nonce, or a successfully presented
+        evidence object for that signed OAuth challenge, its transaction
+        identifier, the authorization-server decision, or the resulting
+        access token. Satisfying AE-CHALLENGE never satisfies a native OAuth
+        grant requirement.<a href="#section-1.1-1" class="pilcrow">¶</a></p>
+<p id="section-1.1-2">AE-CHALLENGE remains applicable outside OAuth and when a relying
+        party needs evidence that a native authorization protocol does not
+        itself negotiate, such as a current status proof, quorum receipt,
+        hardware attestation, or separately verified policy artifact. An
+        OAuth application profile <span class="bcp14">MAY</span> carry or reference both
+        mechanisms, but that profile <span class="bcp14">MUST</span> define their exact
+        action and audience join, which challenge is primary for each
+        refusal, and how native grant state remains separate from
+        AE-CHALLENGE replay state. Without such a profile, the mechanisms are
+        separate and neither is silently converted into the other.<a href="#section-1.1-2" class="pilcrow">¶</a></p>
+<p id="section-1.1-3">The single-use property in this document applies only to one
+        evidence-presentation attempt under an AE-CHALLENGE nonce. It does not
+        consume an OAuth transaction, invalidate an access token, reserve an
+        action, or establish one-time admission at an executor.<a href="#section-1.1-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="requirements-language">
+<section id="section-1.2">
+        <h3 id="name-requirements-language">
+<a href="#section-1.2" class="section-number selfRef">1.2. </a><a href="#name-requirements-language" class="section-name selfRef">Requirements Language</a>
+        </h3>
+<p id="section-1.2-1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL",
+        "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT
+        RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+        interpreted as described in BCP 14 <span>[<a href="#RFC2119" class="cite xref">RFC2119</a>]</span>
+          <span>[<a href="#RFC8174" class="cite xref">RFC8174</a>]</span> when, and only when, they appear in all
+        capitals, as shown here.<a href="#section-1.2-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="terms">
+<section id="section-1.3">
+        <h3 id="name-terminology">
+<a href="#section-1.3" class="section-number selfRef">1.3. </a><a href="#name-terminology" class="section-name selfRef">Terminology</a>
+        </h3>
+<span class="break"></span><dl class="dlParallel" id="section-1.3-1">
+          <dt id="section-1.3-1.1">Relying party:</dt>
+          <dd style="margin-left: 1.5em" id="section-1.3-1.2">The component that decides whether evidence satisfies its
+          requirements for a proposed action.<a href="#section-1.3-1.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-1.3-1.3">Presenter:</dt>
+          <dd style="margin-left: 1.5em" id="section-1.3-1.4">The agent, gateway, or other component that receives a
+          challenge and may later present evidence.<a href="#section-1.3-1.4" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-1.3-1.5">Exact action:</dt>
+          <dd style="margin-left: 1.5em" id="section-1.3-1.6">The relying-party-derived material action that would be
+          admitted, including every field its selected action profile treats
+          as consequential.<a href="#section-1.3-1.6" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-1.3-1.7">Challenge:</dt>
+          <dd style="margin-left: 1.5em" id="section-1.3-1.8">A single-use, expiring description of evidence still required
+          for one exact action.<a href="#section-1.3-1.8" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+</section>
+</div>
+</section>
+</div>
+<div id="core">
+<section id="section-2">
+      <h2 id="name-transport-neutral-core-data">
+<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-transport-neutral-core-data" class="section-name selfRef">Transport-Neutral Core Data Model</a>
+      </h2>
+<p id="section-2-1">The AE-CHALLENGE-v1 data model is independent of its carrier. A
+      transport binding MUST preserve every member that the relying party
+      uses when registering or reconstructing and later consuming the
+      challenge. A binding MUST
+      also provide authenticated integrity and peer identification, or carry
+      the challenge in an authenticated envelope that provides those
+      properties.<a href="#section-2-1" class="pilcrow">¶</a></p>
+<p id="section-2-2">The JSON format defined by <span>[<a href="#RFC8259" class="cite xref">RFC8259</a>]</span> is the reference
+      serialization of the core model. A non-JSON binding MUST define an
+      unambiguous mapping to the same members and value types.<a href="#section-2-2" class="pilcrow">¶</a></p>
+<div class="lang-json sourcecode" id="section-2-3">
+<pre>
+{
+  "@version": "AE-CHALLENGE-v1",
+  "challenge_id": "7a3120d1-...",
+  "nonce": "&lt;single-use unpredictable value&gt;",
+  "action_digest": "sha256:&lt;relying-party-derived digest&gt;",
+  "action_profile": "https://example.net/action/payment-v3",
+  "audience": "https://gateway-b.example",
+  "policy_id": "https://gateway-b.example/policies/high-risk-v4",
+  "policy_digest": "sha256:&lt;relying-party policy digest&gt;",
+  "required_evidence": [
+    {
+      "requirement_id": "human-approval",
+      "type": "https://example.net/e/authorization-receipt",
+      "profiles": ["https://example.net/profiles/receipt-v1"],
+      "max_age_sec": 300,
+      "status": "current"
+    }
+  ],
+  "present_as": ["https://example.net/p/ep-aec-v1"],
+  "obtain_hints": [
+    {
+      "requirement_id": "human-approval",
+      "mechanism": "https://example.net/flows/approval-v1",
+      "uri": "https://approver.example/tasks/123"
+    }
+  ],
+  "retry_timing": {
+    "not_before": "2026-08-09T23:50:30Z",
+    "jitter_sec": 20
+  },
+  "expires_at": "2026-08-10T00:05:00Z"
+}
+</pre><a href="#section-2-3" class="pilcrow">¶</a>
+</div>
+<div id="core-binding">
+<section id="section-2.1">
+        <h3 id="name-action-and-policy-binding">
+<a href="#section-2.1" class="section-number selfRef">2.1. </a><a href="#name-action-and-policy-binding" class="section-name selfRef">Action and Policy Binding</a>
+        </h3>
+<p id="section-2.1-1"><code>@version</code> MUST equal <code>AE-CHALLENGE-v1</code>. A
+        recipient that does not implement this version MUST refuse automated
+        processing.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
+<p id="section-2.1-2"><code>challenge_id</code> is an opaque correlation identifier.
+        Authorization decisions MUST NOT depend on its global uniqueness.
+        <code>nonce</code> MUST be unpredictable, non-empty, and single-use.
+        Before exposing a challenge, the relying party MUST either register a
+        durable record that binds the nonce to the complete challenge body,
+        or protect the complete body with an issuer-authenticated,
+        self-describing mechanism defined by the applicable profile. The
+        latter mechanism MUST let the relying party reconstruct and validate
+        the exact body without trusting presenter-supplied fields. A bare
+        challenge body carried only under a transport session is not a
+        self-describing mechanism after that session ends.<a href="#section-2.1-2" class="pilcrow">¶</a></p>
+<p id="section-2.1-3">Self-describing issuance can avoid retaining one record for every
+        unanswered challenge. It does not remove single-use state. On the
+        first returned presentation, the relying party still MUST atomically
+        claim the nonce in its authoritative replay store before evidence
+        evaluation.<a href="#section-2.1-3" class="pilcrow">¶</a></p>
+<p id="section-2.1-4"><code>action_digest</code> MUST be computed by the relying party from
+        the exact action it would admit. It MUST NOT be copied from the
+        presenter or from presented evidence. <code>action_profile</code> MUST be
+        present, MUST be an absolute URI as defined by
+        <span>[<a href="#RFC3986" class="cite xref">RFC3986</a>]</span>, and identifies the canonicalization or
+        mapping profile used to derive the digest. It is descriptive to the
+        presenter; it does not let the presenter select or weaken that
+        profile. If two parties cannot
+        establish the same material action under an understood profile, the
+        challenge cannot repair the disagreement and the relying party MUST
+        refuse automated admission.<a href="#section-2.1-4" class="pilcrow">¶</a></p>
+<p id="section-2.1-5"><code>audience</code> identifies the component that is expected to
+        answer the challenge. A binding or authenticated envelope MUST let the
+        presenter establish the challenge issuer. A relying party processing
+        a returned challenge MUST verify the issuer and audience before using
+        any obtain hint or disclosing evidence.<a href="#section-2.1-5" class="pilcrow">¶</a></p>
+<p id="section-2.1-6"><code>policy_id</code> and <code>policy_digest</code> identify the local
+        policy state from which the requirements were derived. They do not
+        transfer policy authority to the presenter. At evaluation time the
+        relying party MUST use its authenticated live policy and MUST NOT use
+        a policy supplied in the response.<a href="#section-2.1-6" class="pilcrow">¶</a></p>
+<p id="section-2.1-7">Delegation, translation, or task rewriting does not preserve one
+        action binding across hops. Each receiving relying party MUST
+        re-evaluate the action it is asked to admit under its own policy and
+        action profile. If that relying party issues a challenge, it MUST
+        derive a new <code>action_digest</code> and register its own challenge
+        binding. A prior hop's challenge or decision record MAY be presented
+        as evidence or context, but it MUST NOT substitute for the receiving
+        relying party's binding to a rewritten action. A chain of per-hop
+        records does not by itself prove that the actions at different hops
+        are semantically equivalent.<a href="#section-2.1-7" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="core-requirements">
+<section id="section-2.2">
+        <h3 id="name-evidence-requirements-and-p">
+<a href="#section-2.2" class="section-number selfRef">2.2. </a><a href="#name-evidence-requirements-and-p" class="section-name selfRef">Evidence Requirements and Presentation</a>
+        </h3>
+<p id="section-2.2-1">Each <code>required_evidence</code> entry MUST contain a
+        <code>requirement_id</code> and <code>type</code>. Requirement identifiers
+        are unique within one challenge and correlate requirements with
+        acquisition hints and diagnostics. Every evidence <code>type</code>,
+        evidence <code>profiles</code> entry, and <code>present_as</code> entry MUST
+        be an absolute URI as defined by <span>[<a href="#RFC3986" class="cite xref">RFC3986</a>]</span> so that the
+        same identifier has portable meaning across transport protocols and
+        conformance corpora. Unless the defining specification says
+        otherwise, these identifiers are compared as exact strings. A
+        recipient MUST NOT infer security semantics from URI prefixes or
+        substring matches; it uses only locally configured semantics for the
+        complete identifier.<a href="#section-2.2-1" class="pilcrow">¶</a></p>
+<p id="section-2.2-2">An entry MAY contain <code>profiles</code>,
+        <code>proof_predicates</code>, <code>max_age_sec</code>, and
+        <code>status</code>. Profiles are alternatives acceptable for that
+        requirement. <code>max_age_sec</code> is measured at the relying party's
+        evaluation time using the issuance or observation time defined by the
+        selected evidence profile. <code>status</code> equal to
+        <code>current</code> requires a separately authenticated status result
+        satisfying the relying party's freshness policy; it does not mean
+        that absence from an unauthenticated revocation list is sufficient.<a href="#section-2.2-2" class="pilcrow">¶</a></p>
+<p id="section-2.2-3"><code>present_as</code> lists alternative presentation profiles. The
+        order expresses the relying party's preference, not a security
+        ranking. Supporting a presentation profile does not imply support for
+        every evidence type named by the challenge. The presenter selects one
+        mutually supported profile and includes enough information for the
+        relying party to match every component to a requirement.<a href="#section-2.2-3" class="pilcrow">¶</a></p>
+<p id="section-2.2-4"><code>obtain_hints</code> are untrusted routing hints. Following a
+        hint, authenticating to its URI, or receiving an "approved" response
+        confers no authority at the relying party. Evidence obtained through
+        a hint remains subject to native verification, exact-action matching,
+        freshness and status checks, policy evaluation, and one-time
+        consumption. Unknown transports MAY omit obtain hints entirely.<a href="#section-2.2-4" class="pilcrow">¶</a></p>
+<p id="section-2.2-5">Capability discovery MAY advertise evidence types, presentation
+        profiles, or acquisition mechanisms that an implementation supports.
+        Such discovery is not an authorization decision and does not establish
+        that any advertised choice is sufficient for a particular action.
+        The relying party MUST determine sufficiency using its authenticated
+        local policy at evaluation time. A cached discovery response, a
+        mutually supported profile, or a successful acquisition flow MUST NOT
+        waive an unsatisfied local requirement.<a href="#section-2.2-5" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="core-lifecycle">
+<section id="section-2.3">
+        <h3 id="name-lifecycle-replay-and-retry">
+<a href="#section-2.3" class="section-number selfRef">2.3. </a><a href="#name-lifecycle-replay-and-retry" class="section-name selfRef">Lifecycle, Replay, and Retry</a>
+        </h3>
+<p id="section-2.3-1"><code>expires_at</code> MUST be an absolute timestamp. The relying
+        party MUST refuse an expired challenge before evidence or policy
+        evaluation.
+        Challenge expiry does not extend the validity of any evidence and
+        evidence expiry does not extend the challenge.<a href="#section-2.3-1" class="pilcrow">¶</a></p>
+<p id="section-2.3-2">Evaluation is ordered: version and structure; authenticated issuer
+        and audience; validation of the registered or self-describing body;
+        action agreement; expiry; authoritative routing; binding capacity
+        reservation; atomic nonce claim; native evidence verification; and local
+        policy evaluation. Malformed input that
+        cannot be associated with a registered body or a valid
+        issuer-protected self-describing body, or a presentation that does not
+        agree with the registered exact action, is refused without claiming a
+        nonce. Once structural and action matching succeed, the nonce MUST be
+        claimed atomically before evidence evaluation. Section 2.4 defines the
+        capacity reservation that also precedes evidence evaluation.<a href="#section-2.3-2" class="pilcrow">¶</a></p>
+<p id="section-2.3-3">A concurrent duplicate that arrives after another presentation has
+        consumed the nonce, whether that first evaluation is still in flight
+        or has completed, MUST be refused as a replay. It MUST NOT receive a
+        second evidence evaluation, an indeterminate result merely because the
+        first evaluation is in flight, or a second admission. An
+        implementation MAY distinguish in-flight from completed consumption
+        internally for operations and audit, but that distinction does not
+        reopen the challenge.<a href="#section-2.3-3" class="pilcrow">¶</a></p>
+<p id="section-2.3-4">Every verifier instance that accepts presentations for one
+        challenge issuer MUST use the same authoritative replay domain, or a
+        deterministic partition in which exactly one authoritative shard owns
+        each nonce. A process-local cache or eventually consistent replica
+        does not satisfy atomic nonce claim. If the authoritative replay
+        domain is unavailable or its result is uncertain, the relying party
+        MUST refuse without evidence evaluation or admission; it MUST NOT fall
+        back to fresh local state.<a href="#section-2.3-4" class="pilcrow">¶</a></p>
+<p id="section-2.3-5">A profile using deterministic partitioning MUST define how the
+        authoritative owner is derived from issuer-protected challenge state.
+        A presenter-controlled routing value outside the authenticated
+        challenge body MUST NOT select the owner. A front end or non-owning
+        shard MUST route the claim to the owner before classifying the nonce.
+        Only an authoritative owner result that the exact registered body was
+        already claimed is a replay result. Failure, timeout, partition, or an
+        uncertain result while reaching the owner is temporary unavailability,
+        not replay, and MUST NOT be reported as an already-claimed nonce.<a href="#section-2.3-5" class="pilcrow">¶</a></p>
+<p id="section-2.3-6">If evidence remains missing, stale, or unverifiable, the relying
+        party MAY issue a follow-up challenge. A follow-up MUST use a fresh
+        challenge identifier and nonce, MUST remain bound to the same locally
+        derived action digest and action profile, and SHOULD list only the
+        requirements that remain unsatisfied. It is a new refusal, not a
+        continuation of the consumed nonce.<a href="#section-2.3-6" class="pilcrow">¶</a></p>
+<p id="section-2.3-7"><code>retry_timing</code> is OPTIONAL. When present, it MUST contain a
+        <code>not_before</code> Internet timestamp as defined by
+        <span>[<a href="#RFC3339" class="cite xref">RFC3339</a>]</span> and MAY contain a non-negative integer
+        <code>jitter_sec</code>. A presenter that processes this member MUST NOT
+        send the challenge response before <code>not_before</code>. When
+        <code>jitter_sec</code> is greater than zero, the presenter SHOULD add an
+        independently selected delay between zero and that many seconds. The
+        selected delay SHOULD vary for each challenge and MUST NOT be treated
+        as extending <code>expires_at</code>. The <code>not_before</code> value is only
+        the earliest time to present corrected evidence. It is not a promise
+        of capacity, evidence sufficiency, admission, or execution. After
+        waiting, the presenter can receive the same refusal, a different
+        refusal, or an overload response.<a href="#section-2.3-7" class="pilcrow">¶</a></p>
+<p id="section-2.3-8">A relying party that expects many correlated refusals SHOULD issue
+        recipient-specific or challenge-specific retry schedules rather than
+        one common retry instant. It SHOULD provide a jitter interval wide
+        enough for its expected population and recovery capacity. A presenter
+        remains responsible for its own backoff and rate limits when timing is
+        absent. A challenge MUST NOT be issued solely to signal overload when
+        the carrying protocol has a distinct overload response. If evidence
+        insufficiency and load pressure coexist, retry timing can pace the new
+        evidence presentation without changing the refusal semantics. The
+        presenter can therefore spend effort acquiring third-party evidence
+        and still be refused or shed after the lower bound; timing guidance
+        does not assert which constraint will be decisive later.<a href="#section-2.3-8" class="pilcrow">¶</a></p>
+<p id="section-2.3-9">Ignoring <code>retry_timing</code> does not make evidence sufficient or
+        authorize an action, but it can defeat the issuer's load-control goal.
+        It does not change the semantic meaning of the challenge and therefore
+        MUST NOT appear in <code>critical</code>. An issuer that needs to enforce
+        pacing uses carrier-level overload handling, admission control, rate
+        limiting, or refusal. A presenter that cannot establish whether
+        <code>not_before</code> has passed MUST NOT infer permission to send early;
+        it uses its local backoff policy or declines automated retry.<a href="#section-2.3-9" class="pilcrow">¶</a></p>
+<p id="section-2.3-10">Unknown acquisition status, timeout, transport failure, or an
+        unverifiable response is indeterminate. It MUST NOT be interpreted as
+        evidence satisfaction or permission to retry an action whose effect
+        may already have occurred.<a href="#section-2.3-10" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="state-bounds">
+<section id="section-2.4">
+        <h3 id="name-state-bounds-and-exhaustion">
+<a href="#section-2.4" class="section-number selfRef">2.4. </a><a href="#name-state-bounds-and-exhaustion" class="section-name selfRef">State Bounds and Exhaustion</a>
+        </h3>
+<p id="section-2.4-1">A relying party MUST configure a finite aggregate upper bound on
+        challenge state retained in one authoritative replay domain. The
+        bound MUST account for outstanding stateful challenges and in-flight
+        or consumed replay records. Where a presenter is authenticated before
+        challenge issuance, the relying party SHOULD also apply per-presenter
+        and per-audience bounds. Multi-tenant deployments SHOULD apply an
+        administrative bound per tenant so one tenant cannot consume the
+        aggregate allowance.<a href="#section-2.4-1" class="pilcrow">¶</a></p>
+<p id="section-2.4-2">Admission control for a stateful challenge MUST occur before the
+        challenge is exposed. If the relying party cannot allocate the
+        required outstanding record, it MUST NOT issue that challenge. It
+        returns a carrier-appropriate overload or generic refusal without an
+        authorization-evidence challenge.<a href="#section-2.4-2" class="pilcrow">¶</a></p>
+<p id="section-2.4-3">For self-describing issuance, the relying party MUST enforce the
+        replay-state bound when the first returned presentation attempts to
+        claim the nonce. If it cannot durably and atomically claim replay
+        state, it MUST refuse without native evidence verification, policy
+        evaluation, or admission. It MUST NOT issue a replacement stateful
+        challenge on that path. Self-describing issuance reduces unanswered
+        outstanding state; it does not make replay processing stateless.<a href="#section-2.4-3" class="pilcrow">¶</a></p>
+<p id="section-2.4-4">A relying party that knows its authoritative replay-state bound is
+        currently exhausted MUST NOT issue a self-describing challenge whose
+        return cannot be claimed. It uses the carrier's overload or generic
+        refusal path until capacity is available.<a href="#section-2.4-4" class="pilcrow">¶</a></p>
+<p id="section-2.4-5">An implementation MUST NOT evict a live in-flight or consumed nonce
+        record to admit a newer challenge. Such a record MUST remain in the
+        authoritative replay domain until the later of <code>expires_at</code> and
+        completion of the in-flight evaluation. Expired unconsumed records
+        MAY be removed. Longer retention for audit or abuse detection is a
+        deployment choice.<a href="#section-2.4-5" class="pilcrow">¶</a></p>
+<p id="section-2.4-6">Challenge lifetimes SHOULD be no longer than the expected evidence-
+        acquisition workflow requires. Rate limiting, authentication where
+        available, self-describing issuance, and short lifetimes can reduce
+        state pressure, but none permits fail-open nonce handling.<a href="#section-2.4-6" class="pilcrow">¶</a></p>
+<p id="section-2.4-7">For a returned presentation, every applicable aggregate,
+        per-presenter, per-audience, and per-tenant hard cap MUST bind before
+        native evidence verification or local policy evaluation. A read-only
+        capacity check followed by unreserved evaluation does not satisfy this
+        requirement. The implementation MUST atomically reserve or debit enough
+        capacity for the maximum refusal-path state that the evaluation can
+        create, including a follow-up challenge where supported. It commits that
+        reservation to the resulting state or releases it only after proving
+        that no such state was created. Capacity uncertainty fails closed.<a href="#section-2.4-7" class="pilcrow">¶</a></p>
+<p id="section-2.4-8">When a hard cap is binding, capacity handling controls the response
+        even if the supplied evidence is also missing, stale, or unverifiable.
+        The relying party MUST NOT perform native evidence verification or
+        local policy evaluation, and MUST NOT return a follow-up challenge, a
+        stateless list of remaining requirements, obtain hints, or any other
+        evidence-sufficiency detail. Withholding those details prevents an
+        unauthenticated or weakly authenticated load probe from using exhaustion
+        handling as a policy-discovery oracle.<a href="#section-2.4-8" class="pilcrow">¶</a></p>
+<div id="state-conformance">
+<section id="section-2.4.1">
+          <h4 id="name-state-exhaustion-conformanc">
+<a href="#section-2.4.1" class="section-number selfRef">2.4.1. </a><a href="#name-state-exhaustion-conformanc" class="section-name selfRef">State Exhaustion Conformance Cases</a>
+          </h4>
+<p id="section-2.4.1-1">A conforming implementation demonstrates all of the following:<a href="#section-2.4.1-1" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-2.4.1-2.1">At the outstanding-state cap, a stateful issuer returns no new
+            challenge and allocates no additional outstanding record.<a href="#section-2.4.1-2.1" class="pilcrow">¶</a>
+</li>
+            <li class="normal" id="section-2.4.1-2.2">At the replay-state cap, a returned self-describing challenge
+            receives no evidence evaluation, no admission, and no requirements
+            or obtain hints.<a href="#section-2.4.1-2.2" class="pilcrow">¶</a>
+</li>
+            <li class="normal" id="section-2.4.1-2.3">When evidence is insufficient and a hard cap is also binding,
+            the capacity response wins: native verifiers and local policy are
+            not invoked and no follow-up or stateless requirements hint is
+            returned.<a href="#section-2.4.1-2.3" class="pilcrow">¶</a>
+</li>
+            <li class="normal" id="section-2.4.1-2.4">Two verifier replicas concurrently receiving the same nonce
+            produce one successful atomic claim and one replay refusal.<a href="#section-2.4.1-2.4" class="pilcrow">¶</a>
+</li>
+            <li class="normal" id="section-2.4.1-2.5">A front end that reaches the authoritative owner and receives
+            an already-claimed result reports replay. The same front end, given
+            an owner timeout, partition, or uncertain response, reports
+            unavailability and does not report replay or evaluate evidence.<a href="#section-2.4.1-2.5" class="pilcrow">¶</a>
+</li>
+            <li class="normal" id="section-2.4.1-2.6">Allocating a new challenge never evicts an in-flight or
+            unexpired consumed nonce.<a href="#section-2.4.1-2.6" class="pilcrow">¶</a>
+</li>
+          </ul>
+</section>
+</div>
+</section>
+</div>
+<div id="core-extensibility">
+<section id="section-2.5">
+        <h3 id="name-extensibility">
+<a href="#section-2.5" class="section-number selfRef">2.5. </a><a href="#name-extensibility" class="section-name selfRef">Extensibility</a>
+        </h3>
+<p id="section-2.5-1">Recipients MUST ignore an unknown member unless its name appears
+        in the optional <code>critical</code> array. A recipient that does not
+        understand every member named by <code>critical</code> MUST refuse
+        automated processing. A specification defining an extension MUST
+        state whether that extension is safe to ignore and how it is bound to
+        the registered challenge body. The core <code>retry_timing</code> member
+        is safe to ignore for challenge semantics and MUST NOT be named by
+        <code>critical</code>.<a href="#section-2.5-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="carrier-semantics">
+<section id="section-2.6">
+        <h3 id="name-carrier-semantics">
+<a href="#section-2.6" class="section-number selfRef">2.6. </a><a href="#name-carrier-semantics" class="section-name selfRef">Carrier Semantics</a>
+        </h3>
+<p id="section-2.6-1">A transport binding SHOULD carry a challenge as a structured
+        refusal or error payload when the carrying protocol provides such a
+        facility. A binding that uses a message part, task-state extension, or
+        other carrier MUST preserve the same refusal semantics and scope the
+        challenge to the identified attempt. It MUST NOT represent the
+        challenge as a successful task result, output artifact, authorization,
+        or durable state that silently applies to later attempts. These rules
+        constrain carrier semantics without requiring every transport to use
+        the same envelope.<a href="#section-2.6-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="http-binding">
+<section id="section-3">
+      <h2 id="name-http-binding">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-http-binding" class="section-name selfRef">HTTP Binding</a>
+      </h2>
+<p id="section-3-1">This 403 Problem Details binding is not the OAuth transaction-
+      authorization response. When a protected resource requires the native
+      transaction-specific OAuth grant defined by
+      <span>[<a href="#OAUTH-TXN-CHALLENGE" class="cite xref">OAUTH-TXN-CHALLENGE</a>]</span>, it uses that specification's
+      <code>transaction_authorization_required</code> response and signed
+      <code>transaction_challenge</code>, normally carried with
+      <code>WWW-Authenticate</code> and status 401. It <span class="bcp14">MUST NOT</span>
+      return only this document's 403 response and then accept AE evidence as
+      a substitute for the missing OAuth grant.<a href="#section-3-1" class="pilcrow">¶</a></p>
+<p id="section-3-2">An HTTP origin server that refuses an action because authorization
+      evidence is missing, stale, or unverifiable SHOULD return
+      <code>403 Forbidden</code> as defined by <span>[<a href="#RFC9110" class="cite xref">RFC9110</a>]</span>. The
+      response body MUST be an <code>application/problem+json</code> Problem
+      Details object as defined by <span>[<a href="#RFC9457" class="cite xref">RFC9457</a>]</span>. Status 428 is not
+      used: it is defined for requests that the origin server requires to be
+      conditional, not for authorization-evidence negotiation.<a href="#section-3-2" class="pilcrow">¶</a></p>
+<p id="section-3-3">If temporary overload is the sole reason for refusal, the origin
+      server MUST NOT fabricate an authorization-evidence challenge. It uses
+      <code>503 Service Unavailable</code>, or another response appropriate to the
+      actual failure, and MAY use <code>Retry-After</code> as defined by
+      <span>[<a href="#RFC9110" class="cite xref">RFC9110</a>]</span>. A 403 AE-CHALLENGE is appropriate when
+      evidence is actually insufficient and no applicable hard cap is binding;
+      non-binding load pressure can still make pacing the corrected
+      presentation necessary. If a hard cap is binding, or the server cannot
+      allocate, reserve, route to, or claim the state required by Section 2.4,
+      it uses 503 and MUST NOT include <code>evidence_challenge</code>, remaining
+      requirements, obtain hints, or other evidence-sufficiency details. This
+      rule applies even when the server suspects that evidence is also
+      insufficient. The server MAY include <code>Retry-After</code> without
+      disclosing authorization policy.<a href="#section-3-3" class="pilcrow">¶</a></p>
+<div class="lang-http sourcecode" id="section-3-4">
+<pre>
+HTTP/1.1 403 Forbidden
+Content-Type: application/problem+json
+Cache-Control: no-store
+Date: Sun, 09 Aug 2026 23:50:00 GMT
+Retry-After: 30
+
+{
+"type":"https://iana.org/assignments/http-problem-types#ae-required",
+  "title": "Authorization Evidence Required",
+  "status": 403,
+  "detail": "Required evidence is unavailable.",
+  "evidence_challenge": {
+    "@version": "AE-CHALLENGE-v1",
+    "challenge_id": "7a3120d1-...",
+    "nonce": "...",
+    "action_digest": "sha256:...",
+    "action_profile": "https://example.net/action/payment-v3",
+    "audience": "https://agent.example",
+    "policy_id": "https://resource.example/policies/high-risk-v4",
+    "policy_digest": "sha256:...",
+    "required_evidence": [
+      { "requirement_id": "human-approval",
+        "type": "https://example.net/e/authorization-receipt",
+        "max_age_sec": 300,
+        "status": "current" }
+    ],
+    "present_as": ["https://example.net/p/ep-aec-v1"],
+    "obtain_hints": [],
+    "retry_timing": {
+      "not_before": "2026-08-09T23:50:30Z",
+      "jitter_sec": 20
+    },
+    "expires_at": "2026-08-10T00:05:00Z"
+  }
+}
+</pre><a href="#section-3-4" class="pilcrow">¶</a>
+</div>
+<p id="section-3-5">The Problem Details <code>type</code> and <code>title</code> MUST have the
+      values shown above. The HTTP status code and the optional
+      <code>status</code> member MUST both be 403. The core challenge MUST appear
+      in the <code>evidence_challenge</code> extension member. Human-readable
+      <code>detail</code> text is advisory and MUST NOT be parsed for protocol
+      semantics.<a href="#section-3-5" class="pilcrow">¶</a></p>
+<p id="section-3-6">The origin server MUST send <code>Cache-Control: no-store</code>. A
+      generic intermediary can still transform an HTTP response, so a client
+      MUST validate the Problem Details object and the authenticated origin
+      before acting on hints or presenting evidence.<a href="#section-3-6" class="pilcrow">¶</a></p>
+<p id="section-3-7">When the core challenge contains <code>retry_timing</code>, the origin
+      server SHOULD send a <code>Retry-After</code> field as defined by
+      <span>[<a href="#RFC9110" class="cite xref">RFC9110</a>]</span>. Its HTTP-date or delay-seconds value MUST NOT
+      permit a follow-up request earlier than <code>not_before</code>. If the
+      header and core member identify different lower bounds, a client MUST
+      use the later bound and then apply <code>jitter_sec</code>. Retry-After does
+      not carry the jitter value and does not change the challenge expiry,
+      authorize the action, promise capacity or acceptance, or make a retry
+      safe after an uncertain effect.<a href="#section-3-7" class="pilcrow">¶</a></p>
+<div id="oauth-non-substitution-case">
+<section id="section-3.1">
+        <h3 id="name-oauth-non-substitution-conf">
+<a href="#section-3.1" class="section-number selfRef">3.1. </a><a href="#name-oauth-non-substitution-conf" class="section-name selfRef">OAuth Non-Substitution Conformance Case</a>
+        </h3>
+<p id="section-3.1-1">A protected resource requires a transaction-specific OAuth grant.
+        The presenter supplies a valid AE-CHALLENGE response but no native
+        transaction-bound access token. The protected resource
+        <span class="bcp14">MUST</span> refuse the action. It <span class="bcp14">MUST NOT</span> treat
+        the AE challenge identifier or nonce as the OAuth transaction
+        identifier, and it <span class="bcp14">MUST NOT</span> report the evidence
+        presentation as satisfying the native grant requirement. The case
+        passes only when the protected resource continues the native OAuth
+        flow or refuses.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="dmsc-profile">
+<section id="section-4">
+      <h2 id="name-informative-dmsc-gateway-pr">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-informative-dmsc-gateway-pr" class="section-name selfRef">Informative DMSC Gateway Profile</a>
+      </h2>
+<p id="section-4-1">Agent gateways can carry the transport-neutral challenge during
+      federation or handoff. The receiving gateway is the relying party: it
+      derives the exact action, applies its own trust anchors and policy, and
+      issues a challenge when evidence is missing, stale, or unverifiable.
+      The sending gateway or agent can obtain evidence and return a new
+      presentation using a DMSC-defined extension point or error carrier.<a href="#section-4-1" class="pilcrow">¶</a></p>
+<p id="section-4-2">If the receiving gateway's required next step is a native OAuth
+      transaction grant, the DMSC carrier preserves that native challenge
+      rather than wrapping it as AE-CHALLENGE. A DMSC application profile can
+      carry both only under the explicit composition rules in
+      <a href="#oauth-boundary" class="auto internal xref">Section 1.1</a>.<a href="#section-4-2" class="pilcrow">¶</a></p>
+<p id="section-4-3">If a gateway rewrites or translates the proposed action, the next
+      gateway re-evaluates that locally derived action and, when necessary,
+      issues its own binding. The prior gateway's action digest does not
+      survive the rewrite as the receiving gateway's binding. Any claim that
+      the two actions are equivalent requires a separately defined mapping or
+      transformation proof.<a href="#section-4-3" class="pilcrow">¶</a></p>
+<p id="section-4-4">When a receiving gateway refuses an action because required
+      authorization evidence is missing, stale, or unverifiable, it may
+      return a structured evidence challenge identifying the exact action,
+      outstanding evidence requirements, applicable freshness or status
+      constraints, and supported presentation profiles. The challenge does
+      not authorize the action or transfer admission ownership; conserved
+      admission across gateway boundaries remains the separate requirement
+      described in Section 7.8 of the proposed next revision of
+      <span>[<a href="#DMSC-GAPS" class="cite xref">DMSC-GAPS</a>]</span>.<a href="#section-4-4" class="pilcrow">¶</a></p>
+<p id="section-4-5">In particular, AE-CHALLENGE does not prevent Gateway A and Gateway B
+      from admitting the same single-use right. It does not copy, fence, or
+      relinquish consumption state and does not establish which gateway owns
+      admission during a partition. The separate handoff property is not a
+      race to decide which gateway admitted first; it is an invariant that
+      committed capacity is not over-allocated under any interleaving of
+      admissions and releases. A DMSC handoff profile MUST solve that property
+      separately. If the receiving gateway cannot establish the
+      required exclusivity, its safe result is refusal or indeterminate, not
+      acceptance based on the challenge.<a href="#section-4-5" class="pilcrow">¶</a></p>
+<div id="dmsc-case">
+<section id="section-4.1">
+        <h3 id="name-gateway-conformance-case">
+<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-gateway-conformance-case" class="section-name selfRef">Gateway Conformance Case</a>
+        </h3>
+<p id="section-4.1-1">Gateway A forwards a proposed action to Gateway B. Gateway B derives
+        the exact action under its pinned action profile and refuses because a
+        current approval artifact is missing. B returns an AE-CHALLENGE bound
+        to B's action digest and local evidence requirement. A obtains and
+        presents the artifact. B verifies it under B's trust anchors, matches
+        it to the same action, and reevaluates B's policy. The case passes only
+        if A never treats the challenge as authorization and B refuses an
+        action-digest mismatch, stale status, replayed nonce, or unsupported
+        presentation profile.<a href="#section-4.1-1" class="pilcrow">¶</a></p>
+<p id="section-4.1-2">A second case attempts concurrent admission of one single-use right
+        at both gateways. AE-CHALLENGE alone MUST NOT be reported as passing
+        that case. The case passes only when a separate conserved-admission
+        mechanism establishes exclusivity, or when the receiving gateway
+        refuses or returns indeterminate because exclusivity cannot be
+        established.<a href="#section-4.1-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="security">
+<section id="section-5">
+      <h2 id="name-security-considerations">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+      </h2>
+<p id="section-5-1"><strong>Challenge forgery and evidence exfiltration.</strong> A
+      forged challenge cannot authorize an action, but it can redirect a
+      presenter, induce unnecessary approval work, or solicit sensitive
+      evidence. Presenters MUST authenticate the relying party and audience
+      before following obtain hints or disclosing evidence. A bare JSON object
+      copied outside its authenticated carrier has no origin authenticity.<a href="#section-5-1" class="pilcrow">¶</a></p>
+<p id="section-5-2"><strong>Action substitution.</strong> The relying party computes the
+      challenge action digest from the action it would execute and recomputes
+      that binding before admission. A digest supplied by the presenter or an
+      action profile selected by the presenter defeats the purpose of the
+      protocol.<a href="#section-5-2" class="pilcrow">¶</a></p>
+<p id="section-5-3"><strong>Replay and state exhaustion.</strong> Stateful issuance binds
+      the complete body before exposure; self-describing issuance defers
+      storage but still requires an atomic replay claim before evidence
+      evaluation. An attacker can provoke refusals cheaply or consume a
+      structurally valid challenge. Aggregate and scoped bounds, short
+      expiries, authentication where available, and rate limits are therefore
+      required operational controls. Exhaustion or replay-store uncertainty
+      fails closed. Live replay state is never evicted to make room for new
+      work. Hard-cap capacity is reserved before evidence verification so an
+      attacker cannot force expensive signature or status work after the state
+      budget is exhausted.<a href="#section-5-3" class="pilcrow">¶</a></p>
+<p id="section-5-4"><strong>Replica consistency.</strong> Per-process replay caches permit
+      two verifier replicas to accept the same nonce. Verifiers for one issuer
+      need one atomic replay domain or an exclusive deterministic shard.
+      During partition or store failure they refuse rather than create local
+      replacement state. Only the owning shard's authoritative already-claimed
+      result is replay; routing failure is unavailability and is not relabeled
+      as attacker replay.<a href="#section-5-4" class="pilcrow">¶</a></p>
+<p id="section-5-5"><strong>Retry synchronization and load amplification.</strong> A
+      precise challenge tells a presenter how to correct a request, so a
+      population receiving similar refusals can retry in a synchronized burst.
+      An issuer under pressure SHOULD combine recipient-specific retry timing,
+      a non-zero jitter interval, admission control, and rate limiting. A
+      presenter SHOULD retain exponential backoff or equivalent local load
+      control even when a challenge supplies a lower bound. Timing guidance
+      paces only a new evidence presentation and MUST NOT be interpreted as
+      evidence satisfaction, authorization, or a promise that capacity or
+      admission will exist after <code>not_before</code>.<a href="#section-5-5" class="pilcrow">¶</a></p>
+<p id="section-5-6"><strong>Information disclosure.</strong> Evidence requirements,
+      policy identifiers, action profiles, and obtain hints can reveal
+      sensitive policy structure. A relying party SHOULD disclose only the
+      minimum information needed for remediation. The HTTP binding requires
+      <code>Cache-Control: no-store</code>. When a hard cap is binding, the relying
+      party discloses no requirements, obtain hints, or evidence-sufficiency
+      details. Returning a stateless hint in that state would turn overload
+      handling into a policy oracle.<a href="#section-5-6" class="pilcrow">¶</a></p>
+<p id="section-5-7"><strong>Stale facts and uncertain effects.</strong> A satisfied
+      challenge proves only that the relying party's evidence requirement was
+      met at evaluation time. It does not prove that external facts remain
+      true, that an action executed, or that an uncertain action is safe to
+      retry. Status rechecking, execution custody, effect observation, and
+      reconciliation remain separate controls.<a href="#section-5-7" class="pilcrow">¶</a></p>
+<p id="section-5-8"><strong>Gateway split brain.</strong> An authenticated challenge from
+      a receiving gateway does not transfer a single-use authorization or its
+      consumption ledger. Implementations MUST NOT claim cross-gateway
+      double-admission prevention merely because both gateways implement this
+      challenge.<a href="#section-5-8" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="iana">
+<section id="section-6">
+      <h2 id="name-iana-considerations">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+      </h2>
+<p id="section-6-1">IANA is requested to add the following entry to the "HTTP Problem
+      Types" registry established by <span>[<a href="#RFC9457" class="cite xref">RFC9457</a>]</span>. That registry
+      uses the Specification Required policy defined by
+      <span>[<a href="#RFC8126" class="cite xref">RFC8126</a>]</span>; this request does not require IETF Review or
+      Standards Action.<a href="#section-6-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="section-6-2">
+        <dt id="section-6-2.1">Type URI:</dt>
+        <dd style="margin-left: 1.5em" id="section-6-2.2">https://iana.org/assignments/http-problem-types#ae-required<a href="#section-6-2.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-6-2.3">Title:</dt>
+        <dd style="margin-left: 1.5em" id="section-6-2.4">Authorization Evidence Required<a href="#section-6-2.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-6-2.5">Recommended HTTP status code:</dt>
+        <dd style="margin-left: 1.5em" id="section-6-2.6">403<a href="#section-6-2.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-6-2.7">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="section-6-2.8">This document.<a href="#section-6-2.8" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<p id="section-6-3">This revision withdraws the earlier request for a new
+      <code>application/authorization-evidence-challenge+json</code> media type.
+      The HTTP binding reuses the registered
+      <code>application/problem+json</code> media type. Non-HTTP bindings define
+      their own carriage without changing the core data model.<a href="#section-6-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="open-questions">
+<section id="section-7">
+      <h2 id="name-interoperability-questions-">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-interoperability-questions-" class="section-name selfRef">Interoperability Questions for Review</a>
+      </h2>
+<p id="section-7-1">This revision resolves the transport layering, HTTP status and media
+      type, gateway-ownership boundary, acquisition-protocol coupling, retry
+      synchronization, retry criticality, bounded replay state, and per-hop
+      binding questions raised through revision -05. It also resolves the
+      ordering of hard-cap enforcement before evidence evaluation and the
+      distinction between authoritative replay and owner unavailability.
+      Review is requested on
+      the following remaining choices:<a href="#section-7-1" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-7-2.1">Which Agent2Agent and AgentProto error carriers can preserve the
+        complete challenge, authenticated issuer, audience, and retry timing,
+        and whether either protocol needs an additional attempt identifier.<a href="#section-7-2.1" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-7-2.2">Whether a DMSC gateway profile should carry the core object
+        directly or reference it by an authenticated, digest-bound URI.<a href="#section-7-2.2" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-7-2.3">Which application profiles, if any, need both a native OAuth
+        transaction challenge and an AE-CHALLENGE, and how those profiles
+        should expose the two independent replay domains.<a href="#section-7-2.3" class="pilcrow">¶</a>
+</li>
+      </ul>
+</section>
+</div>
+<div id="acknowledgments">
+<section id="section-8">
+      <h2 id="name-acknowledgments">
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-acknowledgments" class="section-name selfRef">Acknowledgments</a>
+      </h2>
+<p id="section-8-1">Thanks to Sumit P. Ahuja for identifying synchronized retry and load
+      amplification as a consequence of precise challenge guidance, for
+      correcting retry criticality and non-promissory timing semantics, and
+      for identifying refusal-path state exhaustion, cap-before-verification
+      ordering, policy-oracle risk under load, and the distinction between an
+      authoritative replay result and failure to reach the owning shard.
+      Thanks to Guigui Wang for
+      implementation feedback on structured error payloads, per-hop action
+      rebinding, and the separation of capability discovery from local
+      authority. Thanks to Henri Sirkkavaara for review of replay ordering,
+      concurrent-presentation behavior, diagnostic ordering, and portable
+      identifier semantics.<a href="#section-8-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="changes">
+<section id="section-9">
+      <h2 id="name-changes-since-05">
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-changes-since-05" class="section-name selfRef">Changes since -05</a>
+      </h2>
+<ul class="normal">
+<li class="normal" id="section-9-1.1">Requires every applicable hard cap to bind through an atomic
+        reservation or debit before native evidence verification and local
+        policy evaluation.<a href="#section-9-1.1" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-9-1.2">Makes a binding capacity refusal dominant over evidence
+        insufficiency and prohibits follow-up challenges, stateless requirement
+        lists, obtain hints, and other policy detail on that path.<a href="#section-9-1.2" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-9-1.3">Requires deterministic-shard profiles to derive the owning replay
+        shard from issuer-protected challenge state.<a href="#section-9-1.3" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-9-1.4">Restricts replay classification to an authoritative owner result
+        that the exact registered body was already claimed; owner routing
+        failure or uncertainty is temporary unavailability.<a href="#section-9-1.4" class="pilcrow">¶</a>
+</li>
+        <li class="normal" id="section-9-1.5">Adds cap-first, no-policy-oracle, and owner-routing conformance
+        cases, and tightens the HTTP 503 mapping accordingly.<a href="#section-9-1.5" class="pilcrow">¶</a>
+</li>
+      </ul>
+</section>
+</div>
+<section id="section-10">
+      <h2 id="name-normative-references">
+<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+      </h2>
+<dl class="references">
+<dt id="RFC2119">[RFC2119]</dt>
+      <dd>
+<span class="refAuthor">Bradner, S.</span>, <span class="refTitle">"Key words for use in RFCs to Indicate Requirement Levels"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 2119</span>, <span class="seriesInfo">DOI 10.17487/RFC2119</span>, <time datetime="1997-03" class="refDate">March 1997</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc2119">https://www.rfc-editor.org/info/rfc2119</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC3339">[RFC3339]</dt>
+      <dd>
+<span class="refAuthor">Klyne, G.</span> and <span class="refAuthor">C. Newman</span>, <span class="refTitle">"Date and Time on the Internet: Timestamps"</span>, <span class="seriesInfo">RFC 3339</span>, <span class="seriesInfo">DOI 10.17487/RFC3339</span>, <time datetime="2002-07" class="refDate">July 2002</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc3339">https://www.rfc-editor.org/info/rfc3339</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC3986">[RFC3986]</dt>
+      <dd>
+<span class="refAuthor">Berners-Lee, T.</span>, <span class="refAuthor">Fielding, R. T.</span>, and <span class="refAuthor">L. Masinter</span>, <span class="refTitle">"Uniform Resource Identifier (URI): Generic Syntax"</span>, <span class="seriesInfo">STD 66</span>, <span class="seriesInfo">RFC 3986</span>, <span class="seriesInfo">DOI 10.17487/RFC3986</span>, <time datetime="2005-01" class="refDate">January 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc3986">https://www.rfc-editor.org/info/rfc3986</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8126">[RFC8126]</dt>
+      <dd>
+<span class="refAuthor">Cotton, M.</span>, <span class="refAuthor">Leiba, B.</span>, and <span class="refAuthor">T. Narten</span>, <span class="refTitle">"Guidelines for Writing an IANA Considerations Section in RFCs"</span>, <span class="seriesInfo">BCP 26</span>, <span class="seriesInfo">RFC 8126</span>, <span class="seriesInfo">DOI 10.17487/RFC8126</span>, <time datetime="2017-06" class="refDate">June 2017</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8126">https://www.rfc-editor.org/info/rfc8126</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8174">[RFC8174]</dt>
+      <dd>
+<span class="refAuthor">Leiba, B.</span>, <span class="refTitle">"Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 8174</span>, <span class="seriesInfo">DOI 10.17487/RFC8174</span>, <time datetime="2017-05" class="refDate">May 2017</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8174">https://www.rfc-editor.org/info/rfc8174</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8259">[RFC8259]</dt>
+      <dd>
+<span class="refAuthor">Bray, T., Ed.</span>, <span class="refTitle">"The JavaScript Object Notation (JSON) Data Interchange Format"</span>, <span class="seriesInfo">STD 90</span>, <span class="seriesInfo">RFC 8259</span>, <span class="seriesInfo">DOI 10.17487/RFC8259</span>, <time datetime="2017-12" class="refDate">December 2017</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8259">https://www.rfc-editor.org/info/rfc8259</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC9110">[RFC9110]</dt>
+      <dd>
+<span class="refAuthor">Fielding, R., Ed.</span>, <span class="refAuthor">Nottingham, M., Ed.</span>, and <span class="refAuthor">J. Reschke, Ed.</span>, <span class="refTitle">"HTTP Semantics"</span>, <span class="seriesInfo">STD 97</span>, <span class="seriesInfo">RFC 9110</span>, <span class="seriesInfo">DOI 10.17487/RFC9110</span>, <time datetime="2022-06" class="refDate">June 2022</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc9110">https://www.rfc-editor.org/info/rfc9110</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC9457">[RFC9457]</dt>
+    <dd>
+<span class="refAuthor">Nottingham, M.</span>, <span class="refAuthor">Wilde, E.</span>, and <span class="refAuthor">S. Dalal</span>, <span class="refTitle">"Problem Details for HTTP APIs"</span>, <span class="seriesInfo">RFC 9457</span>, <span class="seriesInfo">DOI 10.17487/RFC9457</span>, <time datetime="2023-07" class="refDate">July 2023</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc9457">https://www.rfc-editor.org/info/rfc9457</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+</dl>
+</section>
+<section id="section-11">
+      <h2 id="name-informative-references">
+<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+      </h2>
+<dl class="references">
+<dt id="AEB">[AEB]</dt>
+      <dd>
+<span class="refAuthor">Schrock, I.</span>, <span class="refTitle">"The Action Evidence Boundary for Consequential Agent Effects"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-schrock-action-evidence-boundary-03</span>, <time datetime="2026-08" class="refDate">August 2026</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/draft-schrock-action-evidence-boundary/">https://datatracker.ietf.org/doc/draft-schrock-action-evidence-boundary/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="AEC">[AEC]</dt>
+      <dd>
+<span class="refAuthor">Schrock, I.</span>, <span class="refTitle">"Authorization Evidence Chains: Composing Heterogeneous Agent-Action Evidence (EP-AEC)"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-schrock-ep-authorization-evidence-chain-05</span>, <time datetime="2026-08" class="refDate">August 2026</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/draft-schrock-ep-authorization-evidence-chain/">https://datatracker.ietf.org/doc/draft-schrock-ep-authorization-evidence-chain/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="AUTH-RECEIPTS">[AUTH-RECEIPTS]</dt>
+      <dd>
+<span class="refAuthor">Schrock, I.</span>, <span class="refTitle">"Authorization Receipts for High-Risk Agent Actions"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-schrock-ep-authorization-receipts-11</span>, <time datetime="2026-08-09" class="refDate">9 August 2026</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/draft-schrock-ep-authorization-receipts/">https://datatracker.ietf.org/doc/draft-schrock-ep-authorization-receipts/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="BCR">[BCR]</dt>
+      <dd>
+<span class="refAuthor">Schrock, I.</span>, <span class="refTitle">"Bounded Capability Receipts and Durable Spend Control for Agent Actions"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-schrock-ep-bounded-capability-receipts-03</span>, <time datetime="2026-08" class="refDate">August 2026</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/draft-schrock-ep-bounded-capability-receipts/">https://datatracker.ietf.org/doc/draft-schrock-ep-bounded-capability-receipts/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="CAID">[CAID]</dt>
+      <dd>
+<span class="refAuthor">Schrock, I.</span>, <span class="refTitle">"The Canonical Action Identifier (CAID)"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-schrock-canonical-action-identifier-02</span>, <time datetime="2026-08" class="refDate">August 2026</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/draft-schrock-canonical-action-identifier/">https://datatracker.ietf.org/doc/draft-schrock-canonical-action-identifier/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="DMSC-GAPS">[DMSC-GAPS]</dt>
+      <dd>
+<span class="refAuthor">Dunbar, L.</span>, <span class="refAuthor">Wang, Y.</span>, <span class="refAuthor">Schrock, I.</span>, and <span class="refAuthor">B. Liu</span>, <span class="refTitle">"Deployment Scenarios and Gap Analysis for AI Agent Gateway"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-dunbar-dmsc-gw-scenarios-gap-analysis-03</span>, <time datetime="2026-08" class="refDate">August 2026</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/draft-dunbar-dmsc-gw-scenarios-gap-analysis/">https://datatracker.ietf.org/doc/draft-dunbar-dmsc-gw-scenarios-gap-analysis/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="KLRC">[KLRC]</dt>
+      <dd>
+<span class="refAuthor">Kasselman, P.</span>, <span class="refAuthor">Lombardo, J.</span>, <span class="refAuthor">Rosomakho, Y.</span>, <span class="refAuthor">Campbell, B.</span>, <span class="refAuthor">Steele, N.</span>, and <span class="refAuthor">A. Parecki</span>, <span class="refTitle">"AI Agent Authentication and Authorization"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-klrc-aiagent-auth-03</span>, <time datetime="2026-07-09" class="refDate">9 July 2026</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/draft-klrc-aiagent-auth/">https://datatracker.ietf.org/doc/draft-klrc-aiagent-auth/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="OAUTH-TXN-CHALLENGE">[OAUTH-TXN-CHALLENGE]</dt>
+      <dd>
+<span class="refAuthor">Rosomakho, Y.</span>, <span class="refAuthor">Campbell, B.</span>, <span class="refAuthor">McGuinness, K.</span>, and <span class="refAuthor">P. Kasselman</span>, <span class="refTitle">"OAuth Transaction Authorization Challenge"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-rosomakho-oauth-txn-challenge-00</span>, <time datetime="2026-06-25" class="refDate">25 June 2026</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/draft-rosomakho-oauth-txn-challenge/">https://datatracker.ietf.org/doc/draft-rosomakho-oauth-txn-challenge/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC9470">[RFC9470]</dt>
+    <dd>
+<span class="refAuthor">Bertocci, V.</span> and <span class="refAuthor">B. Campbell</span>, <span class="refTitle">"OAuth 2.0 Step Up Authentication Challenge Protocol"</span>, <span class="seriesInfo">RFC 9470</span>, <span class="seriesInfo">DOI 10.17487/RFC9470</span>, <time datetime="2023-09" class="refDate">September 2023</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc9470">https://www.rfc-editor.org/info/rfc9470</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+</dl>
+</section>
+<div id="related-work">
+<section id="appendix-A">
+      <h2 id="name-relationship-to-existing-me">
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-relationship-to-existing-me" class="section-name selfRef">Relationship to Existing Mechanisms</a>
+      </h2>
+<p id="appendix-A-1">CAID <span>[<a href="#CAID" class="cite xref">CAID</a>]</span> is one mechanism for deriving and mapping
+      exact material actions. AEB <span>[<a href="#AEB" class="cite xref">AEB</a>]</span> defines executor-side
+      evidence verification, refusal, and one-time consumption. Bounded
+      Capability Receipts <span>[<a href="#BCR" class="cite xref">BCR</a>]</span> define durable single-domain
+      reservation and consumption. AEC <span>[<a href="#AEC" class="cite xref">AEC</a>]</span> is one possible
+      presentation profile. None is required by the core challenge, and the
+      challenge does not extend any of them across independently operated
+      admission domains.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2">OAuth Transaction Authorization Challenge
+      <span>[<a href="#OAUTH-TXN-CHALLENGE" class="cite xref">OAUTH-TXN-CHALLENGE</a>]</span> supplies the OAuth-native
+      choreography and transaction-bound grant that this document explicitly
+      does not define. The KLRC architecture <span>[<a href="#KLRC" class="cite xref">KLRC</a>]</span> describes
+      broader agent authentication and authorization requirements, including
+      human-in-the-loop and externalized authorization patterns. Authorization
+      Receipts <span>[<a href="#AUTH-RECEIPTS" class="cite xref">AUTH-RECEIPTS</a>]</span> are one possible portable human-
+      evidence type that an AE-CHALLENGE can request; neither the receipt nor
+      AE-CHALLENGE replaces a native OAuth grant or a relying party's final
+      policy decision.<a href="#appendix-A-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="impl">
+<section id="appendix-B">
+      <h2 id="name-implementation-status">
+<a href="#appendix-B" class="section-number selfRef">Appendix B. </a><a href="#name-implementation-status" class="section-name selfRef">Implementation Status</a>
+      </h2>
+<p id="appendix-B-1">The EMILIA Protocol repository contains a same-team reference
+      implementation of the AE-CHALLENGE-v1 core lifecycle, including
+      relying-party-derived action binding, policy-derived requirements,
+      durable body-bound registration, single-use consumption, expiry,
+      follow-up challenges, and action-swap refusal. Revision -03 added a
+      serializer and parser for the RFC 9457 HTTP binding and tests that pin
+      status 403, <code>application/problem+json</code>,
+      <code>Cache-Control: no-store</code>, and the
+      <code>evidence_challenge</code> extension.<a href="#appendix-B-1" class="pilcrow">¶</a></p>
+<p id="appendix-B-2">Revision -04 specifies retry timing, per-hop rebinding, discovery
+      separation, carrier semantics, portable absolute-URI identifiers, and
+      action-before-consumption replay ordering. These additions are based in
+      part on external implementer review, including experience with structured
+      error payloads and per-verifier decision bindings. They are not yet
+      implemented by the same-team reference implementation and are not
+      claimed as an independent implementation of this specification.<a href="#appendix-B-2" class="pilcrow">¶</a></p>
+<p id="appendix-B-3">Revision -05 adds optional self-describing issuance, mandatory state
+      bounds and cap behavior, authoritative replay-domain requirements, and
+      state-exhaustion conformance cases. The same-team implementation uses
+      durable stateful issuance and atomic consumption across workers and
+      restarts, but does not yet implement the -05 configurable cap behavior
+      or self-describing issuance path. No implementation claim is made for
+      those additions.<a href="#appendix-B-3" class="pilcrow">¶</a></p>
+<p id="appendix-B-4">Revision -06 adds binding cap-before-verification ordering,
+      no-requirements disclosure while a hard cap is binding, and an explicit
+      distinction between an authoritative already-claimed replay result and
+      inability to reach the owning shard. These requirements and their
+      conformance cases are not yet implemented by the same-team reference
+      implementation, and no implementation claim is made for them.<a href="#appendix-B-4" class="pilcrow">¶</a></p>
+<p id="appendix-B-5">The OAuth boundary and non-substitution case in revision -05 are
+      normative text and conformance requirements. The same-team reference
+      implementation does not convert an AE-CHALLENGE into an OAuth challenge
+      or grant, and no such conversion is planned. It does not yet implement a
+      composed application profile carrying both mechanisms.<a href="#appendix-B-5" class="pilcrow">¶</a></p>
+<p id="appendix-B-6">This is same-team implementation evidence. No independent
+      implementation or interoperability is claimed. The implementation does
+      not yet provide a DMSC carrier or conserved-admission mechanism. Its
+      current local evidence and presentation identifiers are not the absolute
+      URIs required by this revision.<a href="#appendix-B-6" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="authors-addresses">
+<section id="appendix-C">
+      <h2 id="name-authors-address">
+<a href="#name-authors-address" class="section-name selfRef">Author's Address</a>
+      </h2>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Iman Schrock</span></div>
+<div dir="auto" class="left"><span class="org">EMILIA Protocol, Inc.</span></div>
+<div dir="auto" class="left"><span class="country-name">United States of America</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:team@emiliaprotocol.ai" class="email">team@emiliaprotocol.ai</a>
+</div>
+</address>
+</section>
+</div>
+<script>const toc = document.getElementById("toc");
+toc.querySelector("h2").addEventListener("click", e => {
+  toc.classList.toggle("active");
+});
+toc.querySelector("nav").addEventListener("click", e => {
+  toc.classList.remove("active");
+});
+</script>
+</body>
+</html>

--- a/standards/staged/NEXT-AE-CHALLENGE-06/RENDERS/draft-schrock-ae-challenge-06.txt
+++ b/standards/staged/NEXT-AE-CHALLENGE-06/RENDERS/draft-schrock-ae-challenge-06.txt
@@ -1,0 +1,1232 @@
+
+
+
+
+Network Working Group                                         I. Schrock
+Internet-Draft                                     EMILIA Protocol, Inc.
+Intended status: Informational                            10 August 2026
+Expires: 11 February 2027
+
+
+    An Authorization Evidence Challenge for High-Risk Agent Actions
+                     draft-schrock-ae-challenge-06
+
+Abstract
+
+   When a relying party refuses a consequential agent action because
+   authorization evidence is missing, stale, or unverifiable, the agent
+   needs a machine-readable description of what remains necessary.  This
+   document defines a transport-neutral Authorization Evidence Challenge
+   data model bound to the relying party's exact action.  The challenge
+   identifies outstanding evidence requirements, freshness and status
+   constraints, acceptable presentation profiles, and retry state.  It
+   authorizes nothing, transfers no admission ownership, and provides no
+   promise that a later request will execute.
+
+   The document also defines an HTTP binding using 403 Forbidden and RFC
+   9457 Problem Details, and describes an informative gateway-handoff
+   profile for DMSC-style federation.  The gateway profile communicates
+   evidence requirements; it does not solve conserved admission or
+   double-admission across independently operated gateways.
+
+   A challenge can synchronize corrected retries and amplify load.  The
+   core therefore defines optional retry timing with per-challenge
+   jitter, and the HTTP binding maps its lower bound to Retry-After.
+   Retry timing controls presentation attempts only; it does not
+   authorize the action or make an uncertain action safe to repeat.
+
+   Single-use processing also places state on the refusal path.  The
+   core therefore requires bounded outstanding and replay state, fail-
+   closed behavior when state cannot be claimed, and retention of live
+   replay records until they are no longer security-relevant.  Capacity
+   MUST be reserved before native evidence verification, and a binding
+   capacity refusal reveals no remaining evidence requirements.  In a
+   sharded replay domain, only the authoritative owner can classify a
+   nonce as already claimed; inability to reach that owner is
+   unavailability, not replay.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+
+
+
+Schrock                 Expires 11 February 2027                [Page 1]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on 11 February 2027.
+
+Copyright Notice
+
+   Copyright (c) 2026 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents (https://trustee.ietf.org/
+   license-info) in effect on the date of publication of this document.
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+     1.1.  Boundary with OAuth Transaction Authorization . . . . . .   3
+     1.2.  Requirements Language . . . . . . . . . . . . . . . . . .   4
+     1.3.  Terminology . . . . . . . . . . . . . . . . . . . . . . .   4
+   2.  Transport-Neutral Core Data Model . . . . . . . . . . . . . .   4
+     2.1.  Action and Policy Binding . . . . . . . . . . . . . . . .   5
+     2.2.  Evidence Requirements and Presentation  . . . . . . . . .   7
+     2.3.  Lifecycle, Replay, and Retry  . . . . . . . . . . . . . .   8
+     2.4.  State Bounds and Exhaustion . . . . . . . . . . . . . . .  10
+       2.4.1.  State Exhaustion Conformance Cases  . . . . . . . . .  11
+     2.5.  Extensibility . . . . . . . . . . . . . . . . . . . . . .  12
+     2.6.  Carrier Semantics . . . . . . . . . . . . . . . . . . . .  12
+   3.  HTTP Binding  . . . . . . . . . . . . . . . . . . . . . . . .  12
+     3.1.  OAuth Non-Substitution Conformance Case . . . . . . . . .  14
+   4.  Informative DMSC Gateway Profile  . . . . . . . . . . . . . .  14
+     4.1.  Gateway Conformance Case  . . . . . . . . . . . . . . . .  15
+   5.  Security Considerations . . . . . . . . . . . . . . . . . . .  16
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  17
+   7.  Interoperability Questions for Review . . . . . . . . . . . .  18
+   8.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  18
+   9.  Changes since -05 . . . . . . . . . . . . . . . . . . . . . .  18
+   10. Normative References  . . . . . . . . . . . . . . . . . . . .  19
+   11. Informative References  . . . . . . . . . . . . . . . . . . .  20
+
+
+
+Schrock                 Expires 11 February 2027                [Page 2]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+   Appendix A.  Relationship to Existing Mechanisms  . . . . . . . .  21
+   Appendix B.  Implementation Status  . . . . . . . . . . . . . . .  21
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  22
+
+1.  Introduction
+
+   Evidence formats describe artifacts such as receipts, permits,
+   attestations, and logs.  They do not by themselves define the live
+   interaction that follows when a relying party finds the presented
+   evidence insufficient.  Without a common challenge, each agent
+   protocol invents its own vocabulary for missing evidence, acceptable
+   presentations, freshness, status checking, and retry.
+
+   This document defines the challenge as an application data model,
+   independent of HTTP, a particular agent protocol, and any one
+   evidence format.  OAuth step-up authentication [RFC9470] lets a
+   resource identify stronger authentication requirements.  OAuth
+   Transaction Authorization Challenge [OAUTH-TXN-CHALLENGE] defines a
+   signed, OAuth-specific challenge that an authorization server turns
+   into a transaction-bound access token after obtaining any required
+   approval.  AE-CHALLENGE does not replace either mechanism.  It
+   describes missing authorization evidence for an exact proposed action
+   when an application needs a transport-neutral evidence-negotiation
+   object.
+
+   A challenge is a refusal with information.  It is not an
+   authorization decision, reservation, capability, ownership transfer,
+   or promise of execution.  Satisfying it causes the relying party to
+   evaluate a new presentation under its live local policy.
+
+1.1.  Boundary with OAuth Transaction Authorization
+
+   When the required next step is issuance of a transaction-specific
+   OAuth grant, an implementation SHOULD use OAuth Transaction
+   Authorization Challenge.  It MUST NOT substitute an AE-CHALLENGE, its
+   nonce, or a successfully presented evidence object for that signed
+   OAuth challenge, its transaction identifier, the authorization-server
+   decision, or the resulting access token.  Satisfying AE-CHALLENGE
+   never satisfies a native OAuth grant requirement.
+
+
+
+
+
+
+
+
+
+
+
+
+Schrock                 Expires 11 February 2027                [Page 3]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+   AE-CHALLENGE remains applicable outside OAuth and when a relying
+   party needs evidence that a native authorization protocol does not
+   itself negotiate, such as a current status proof, quorum receipt,
+   hardware attestation, or separately verified policy artifact.  An
+   OAuth application profile MAY carry or reference both mechanisms, but
+   that profile MUST define their exact action and audience join, which
+   challenge is primary for each refusal, and how native grant state
+   remains separate from AE-CHALLENGE replay state.  Without such a
+   profile, the mechanisms are separate and neither is silently
+   converted into the other.
+
+   The single-use property in this document applies only to one
+   evidence-presentation attempt under an AE-CHALLENGE nonce.  It does
+   not consume an OAuth transaction, invalidate an access token, reserve
+   an action, or establish one-time admission at an executor.
+
+1.2.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+1.3.  Terminology
+
+   Relying party:  The component that decides whether evidence satisfies
+      its requirements for a proposed action.
+
+   Presenter:  The agent, gateway, or other component that receives a
+      challenge and may later present evidence.
+
+   Exact action:  The relying-party-derived material action that would
+      be admitted, including every field its selected action profile
+      treats as consequential.
+
+   Challenge:  A single-use, expiring description of evidence still
+      required for one exact action.
+
+2.  Transport-Neutral Core Data Model
+
+   The AE-CHALLENGE-v1 data model is independent of its carrier.  A
+   transport binding MUST preserve every member that the relying party
+   uses when registering or reconstructing and later consuming the
+   challenge.  A binding MUST also provide authenticated integrity and
+   peer identification, or carry the challenge in an authenticated
+   envelope that provides those properties.
+
+
+
+
+Schrock                 Expires 11 February 2027                [Page 4]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+   The JSON format defined by [RFC8259] is the reference serialization
+   of the core model.  A non-JSON binding MUST define an unambiguous
+   mapping to the same members and value types.
+
+   {
+     "@version": "AE-CHALLENGE-v1",
+     "challenge_id": "7a3120d1-...",
+     "nonce": "<single-use unpredictable value>",
+     "action_digest": "sha256:<relying-party-derived digest>",
+     "action_profile": "https://example.net/action/payment-v3",
+     "audience": "https://gateway-b.example",
+     "policy_id": "https://gateway-b.example/policies/high-risk-v4",
+     "policy_digest": "sha256:<relying-party policy digest>",
+     "required_evidence": [
+       {
+         "requirement_id": "human-approval",
+         "type": "https://example.net/e/authorization-receipt",
+         "profiles": ["https://example.net/profiles/receipt-v1"],
+         "max_age_sec": 300,
+         "status": "current"
+       }
+     ],
+     "present_as": ["https://example.net/p/ep-aec-v1"],
+     "obtain_hints": [
+       {
+         "requirement_id": "human-approval",
+         "mechanism": "https://example.net/flows/approval-v1",
+         "uri": "https://approver.example/tasks/123"
+       }
+     ],
+     "retry_timing": {
+       "not_before": "2026-08-09T23:50:30Z",
+       "jitter_sec": 20
+     },
+     "expires_at": "2026-08-10T00:05:00Z"
+   }
+
+2.1.  Action and Policy Binding
+
+   @version MUST equal AE-CHALLENGE-v1.  A recipient that does not
+   implement this version MUST refuse automated processing.
+
+   challenge_id is an opaque correlation identifier.  Authorization
+   decisions MUST NOT depend on its global uniqueness.  nonce MUST be
+   unpredictable, non-empty, and single-use.  Before exposing a
+   challenge, the relying party MUST either register a durable record
+   that binds the nonce to the complete challenge body, or protect the
+   complete body with an issuer-authenticated, self-describing mechanism
+
+
+
+Schrock                 Expires 11 February 2027                [Page 5]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+   defined by the applicable profile.  The latter mechanism MUST let the
+   relying party reconstruct and validate the exact body without
+   trusting presenter-supplied fields.  A bare challenge body carried
+   only under a transport session is not a self-describing mechanism
+   after that session ends.
+
+   Self-describing issuance can avoid retaining one record for every
+   unanswered challenge.  It does not remove single-use state.  On the
+   first returned presentation, the relying party still MUST atomically
+   claim the nonce in its authoritative replay store before evidence
+   evaluation.
+
+   action_digest MUST be computed by the relying party from the exact
+   action it would admit.  It MUST NOT be copied from the presenter or
+   from presented evidence. action_profile MUST be present, MUST be an
+   absolute URI as defined by [RFC3986], and identifies the
+   canonicalization or mapping profile used to derive the digest.  It is
+   descriptive to the presenter; it does not let the presenter select or
+   weaken that profile.  If two parties cannot establish the same
+   material action under an understood profile, the challenge cannot
+   repair the disagreement and the relying party MUST refuse automated
+   admission.
+
+   audience identifies the component that is expected to answer the
+   challenge.  A binding or authenticated envelope MUST let the
+   presenter establish the challenge issuer.  A relying party processing
+   a returned challenge MUST verify the issuer and audience before using
+   any obtain hint or disclosing evidence.
+
+   policy_id and policy_digest identify the local policy state from
+   which the requirements were derived.  They do not transfer policy
+   authority to the presenter.  At evaluation time the relying party
+   MUST use its authenticated live policy and MUST NOT use a policy
+   supplied in the response.
+
+   Delegation, translation, or task rewriting does not preserve one
+   action binding across hops.  Each receiving relying party MUST re-
+   evaluate the action it is asked to admit under its own policy and
+   action profile.  If that relying party issues a challenge, it MUST
+   derive a new action_digest and register its own challenge binding.  A
+   prior hop's challenge or decision record MAY be presented as evidence
+   or context, but it MUST NOT substitute for the receiving relying
+   party's binding to a rewritten action.  A chain of per-hop records
+   does not by itself prove that the actions at different hops are
+   semantically equivalent.
+
+
+
+
+
+
+Schrock                 Expires 11 February 2027                [Page 6]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+2.2.  Evidence Requirements and Presentation
+
+   Each required_evidence entry MUST contain a requirement_id and type.
+   Requirement identifiers are unique within one challenge and correlate
+   requirements with acquisition hints and diagnostics.  Every evidence
+   type, evidence profiles entry, and present_as entry MUST be an
+   absolute URI as defined by [RFC3986] so that the same identifier has
+   portable meaning across transport protocols and conformance corpora.
+   Unless the defining specification says otherwise, these identifiers
+   are compared as exact strings.  A recipient MUST NOT infer security
+   semantics from URI prefixes or substring matches; it uses only
+   locally configured semantics for the complete identifier.
+
+   An entry MAY contain profiles, proof_predicates, max_age_sec, and
+   status.  Profiles are alternatives acceptable for that requirement.
+   max_age_sec is measured at the relying party's evaluation time using
+   the issuance or observation time defined by the selected evidence
+   profile. status equal to current requires a separately authenticated
+   status result satisfying the relying party's freshness policy; it
+   does not mean that absence from an unauthenticated revocation list is
+   sufficient.
+
+   present_as lists alternative presentation profiles.  The order
+   expresses the relying party's preference, not a security ranking.
+   Supporting a presentation profile does not imply support for every
+   evidence type named by the challenge.  The presenter selects one
+   mutually supported profile and includes enough information for the
+   relying party to match every component to a requirement.
+
+   obtain_hints are untrusted routing hints.  Following a hint,
+   authenticating to its URI, or receiving an "approved" response
+   confers no authority at the relying party.  Evidence obtained through
+   a hint remains subject to native verification, exact-action matching,
+   freshness and status checks, policy evaluation, and one-time
+   consumption.  Unknown transports MAY omit obtain hints entirely.
+
+   Capability discovery MAY advertise evidence types, presentation
+   profiles, or acquisition mechanisms that an implementation supports.
+   Such discovery is not an authorization decision and does not
+   establish that any advertised choice is sufficient for a particular
+   action.  The relying party MUST determine sufficiency using its
+   authenticated local policy at evaluation time.  A cached discovery
+   response, a mutually supported profile, or a successful acquisition
+   flow MUST NOT waive an unsatisfied local requirement.
+
+
+
+
+
+
+
+Schrock                 Expires 11 February 2027                [Page 7]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+2.3.  Lifecycle, Replay, and Retry
+
+   expires_at MUST be an absolute timestamp.  The relying party MUST
+   refuse an expired challenge before evidence or policy evaluation.
+   Challenge expiry does not extend the validity of any evidence and
+   evidence expiry does not extend the challenge.
+
+   Evaluation is ordered: version and structure; authenticated issuer
+   and audience; validation of the registered or self-describing body;
+   action agreement; expiry; authoritative routing; binding capacity
+   reservation; atomic nonce claim; native evidence verification; and
+   local policy evaluation.  Malformed input that cannot be associated
+   with a registered body or a valid issuer-protected self-describing
+   body, or a presentation that does not agree with the registered exact
+   action, is refused without claiming a nonce.  Once structural and
+   action matching succeed, the nonce MUST be claimed atomically before
+   evidence evaluation.  Section 2.4 defines the capacity reservation
+   that also precedes evidence evaluation.
+
+   A concurrent duplicate that arrives after another presentation has
+   consumed the nonce, whether that first evaluation is still in flight
+   or has completed, MUST be refused as a replay.  It MUST NOT receive a
+   second evidence evaluation, an indeterminate result merely because
+   the first evaluation is in flight, or a second admission.  An
+   implementation MAY distinguish in-flight from completed consumption
+   internally for operations and audit, but that distinction does not
+   reopen the challenge.
+
+   Every verifier instance that accepts presentations for one challenge
+   issuer MUST use the same authoritative replay domain, or a
+   deterministic partition in which exactly one authoritative shard owns
+   each nonce.  A process-local cache or eventually consistent replica
+   does not satisfy atomic nonce claim.  If the authoritative replay
+   domain is unavailable or its result is uncertain, the relying party
+   MUST refuse without evidence evaluation or admission; it MUST NOT
+   fall back to fresh local state.
+
+   A profile using deterministic partitioning MUST define how the
+   authoritative owner is derived from issuer-protected challenge state.
+   A presenter-controlled routing value outside the authenticated
+   challenge body MUST NOT select the owner.  A front end or non-owning
+   shard MUST route the claim to the owner before classifying the nonce.
+   Only an authoritative owner result that the exact registered body was
+   already claimed is a replay result.  Failure, timeout, partition, or
+   an uncertain result while reaching the owner is temporary
+   unavailability, not replay, and MUST NOT be reported as an already-
+   claimed nonce.
+
+
+
+
+Schrock                 Expires 11 February 2027                [Page 8]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+   If evidence remains missing, stale, or unverifiable, the relying
+   party MAY issue a follow-up challenge.  A follow-up MUST use a fresh
+   challenge identifier and nonce, MUST remain bound to the same locally
+   derived action digest and action profile, and SHOULD list only the
+   requirements that remain unsatisfied.  It is a new refusal, not a
+   continuation of the consumed nonce.
+
+   retry_timing is OPTIONAL.  When present, it MUST contain a not_before
+   Internet timestamp as defined by [RFC3339] and MAY contain a non-
+   negative integer jitter_sec.  A presenter that processes this member
+   MUST NOT send the challenge response before not_before.  When
+   jitter_sec is greater than zero, the presenter SHOULD add an
+   independently selected delay between zero and that many seconds.  The
+   selected delay SHOULD vary for each challenge and MUST NOT be treated
+   as extending expires_at.  The not_before value is only the earliest
+   time to present corrected evidence.  It is not a promise of capacity,
+   evidence sufficiency, admission, or execution.  After waiting, the
+   presenter can receive the same refusal, a different refusal, or an
+   overload response.
+
+   A relying party that expects many correlated refusals SHOULD issue
+   recipient-specific or challenge-specific retry schedules rather than
+   one common retry instant.  It SHOULD provide a jitter interval wide
+   enough for its expected population and recovery capacity.  A
+   presenter remains responsible for its own backoff and rate limits
+   when timing is absent.  A challenge MUST NOT be issued solely to
+   signal overload when the carrying protocol has a distinct overload
+   response.  If evidence insufficiency and load pressure coexist, retry
+   timing can pace the new evidence presentation without changing the
+   refusal semantics.  The presenter can therefore spend effort
+   acquiring third-party evidence and still be refused or shed after the
+   lower bound; timing guidance does not assert which constraint will be
+   decisive later.
+
+   Ignoring retry_timing does not make evidence sufficient or authorize
+   an action, but it can defeat the issuer's load-control goal.  It does
+   not change the semantic meaning of the challenge and therefore MUST
+   NOT appear in critical.  An issuer that needs to enforce pacing uses
+   carrier-level overload handling, admission control, rate limiting, or
+   refusal.  A presenter that cannot establish whether not_before has
+   passed MUST NOT infer permission to send early; it uses its local
+   backoff policy or declines automated retry.
+
+   Unknown acquisition status, timeout, transport failure, or an
+   unverifiable response is indeterminate.  It MUST NOT be interpreted
+   as evidence satisfaction or permission to retry an action whose
+   effect may already have occurred.
+
+
+
+
+Schrock                 Expires 11 February 2027                [Page 9]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+2.4.  State Bounds and Exhaustion
+
+   A relying party MUST configure a finite aggregate upper bound on
+   challenge state retained in one authoritative replay domain.  The
+   bound MUST account for outstanding stateful challenges and in-flight
+   or consumed replay records.  Where a presenter is authenticated
+   before challenge issuance, the relying party SHOULD also apply per-
+   presenter and per-audience bounds.  Multi-tenant deployments SHOULD
+   apply an administrative bound per tenant so one tenant cannot consume
+   the aggregate allowance.
+
+   Admission control for a stateful challenge MUST occur before the
+   challenge is exposed.  If the relying party cannot allocate the
+   required outstanding record, it MUST NOT issue that challenge.  It
+   returns a carrier-appropriate overload or generic refusal without an
+   authorization-evidence challenge.
+
+   For self-describing issuance, the relying party MUST enforce the
+   replay-state bound when the first returned presentation attempts to
+   claim the nonce.  If it cannot durably and atomically claim replay
+   state, it MUST refuse without native evidence verification, policy
+   evaluation, or admission.  It MUST NOT issue a replacement stateful
+   challenge on that path.  Self-describing issuance reduces unanswered
+   outstanding state; it does not make replay processing stateless.
+
+   A relying party that knows its authoritative replay-state bound is
+   currently exhausted MUST NOT issue a self-describing challenge whose
+   return cannot be claimed.  It uses the carrier's overload or generic
+   refusal path until capacity is available.
+
+   An implementation MUST NOT evict a live in-flight or consumed nonce
+   record to admit a newer challenge.  Such a record MUST remain in the
+   authoritative replay domain until the later of expires_at and
+   completion of the in-flight evaluation.  Expired unconsumed records
+   MAY be removed.  Longer retention for audit or abuse detection is a
+   deployment choice.
+
+   Challenge lifetimes SHOULD be no longer than the expected evidence-
+   acquisition workflow requires.  Rate limiting, authentication where
+   available, self-describing issuance, and short lifetimes can reduce
+   state pressure, but none permits fail-open nonce handling.
+
+   For a returned presentation, every applicable aggregate, per-
+   presenter, per-audience, and per-tenant hard cap MUST bind before
+   native evidence verification or local policy evaluation.  A read-only
+   capacity check followed by unreserved evaluation does not satisfy
+   this requirement.  The implementation MUST atomically reserve or
+   debit enough capacity for the maximum refusal-path state that the
+
+
+
+Schrock                 Expires 11 February 2027               [Page 10]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+   evaluation can create, including a follow-up challenge where
+   supported.  It commits that reservation to the resulting state or
+   releases it only after proving that no such state was created.
+   Capacity uncertainty fails closed.
+
+   When a hard cap is binding, capacity handling controls the response
+   even if the supplied evidence is also missing, stale, or
+   unverifiable.  The relying party MUST NOT perform native evidence
+   verification or local policy evaluation, and MUST NOT return a
+   follow-up challenge, a stateless list of remaining requirements,
+   obtain hints, or any other evidence-sufficiency detail.  Withholding
+   those details prevents an unauthenticated or weakly authenticated
+   load probe from using exhaustion handling as a policy-discovery
+   oracle.
+
+2.4.1.  State Exhaustion Conformance Cases
+
+   A conforming implementation demonstrates all of the following:
+
+   *  At the outstanding-state cap, a stateful issuer returns no new
+      challenge and allocates no additional outstanding record.
+
+   *  At the replay-state cap, a returned self-describing challenge
+      receives no evidence evaluation, no admission, and no requirements
+      or obtain hints.
+
+   *  When evidence is insufficient and a hard cap is also binding, the
+      capacity response wins: native verifiers and local policy are not
+      invoked and no follow-up or stateless requirements hint is
+      returned.
+
+   *  Two verifier replicas concurrently receiving the same nonce
+      produce one successful atomic claim and one replay refusal.
+
+   *  A front end that reaches the authoritative owner and receives an
+      already-claimed result reports replay.  The same front end, given
+      an owner timeout, partition, or uncertain response, reports
+      unavailability and does not report replay or evaluate evidence.
+
+   *  Allocating a new challenge never evicts an in-flight or unexpired
+      consumed nonce.
+
+
+
+
+
+
+
+
+
+
+Schrock                 Expires 11 February 2027               [Page 11]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+2.5.  Extensibility
+
+   Recipients MUST ignore an unknown member unless its name appears in
+   the optional critical array.  A recipient that does not understand
+   every member named by critical MUST refuse automated processing.  A
+   specification defining an extension MUST state whether that extension
+   is safe to ignore and how it is bound to the registered challenge
+   body.  The core retry_timing member is safe to ignore for challenge
+   semantics and MUST NOT be named by critical.
+
+2.6.  Carrier Semantics
+
+   A transport binding SHOULD carry a challenge as a structured refusal
+   or error payload when the carrying protocol provides such a facility.
+   A binding that uses a message part, task-state extension, or other
+   carrier MUST preserve the same refusal semantics and scope the
+   challenge to the identified attempt.  It MUST NOT represent the
+   challenge as a successful task result, output artifact,
+   authorization, or durable state that silently applies to later
+   attempts.  These rules constrain carrier semantics without requiring
+   every transport to use the same envelope.
+
+3.  HTTP Binding
+
+   This 403 Problem Details binding is not the OAuth transaction-
+   authorization response.  When a protected resource requires the
+   native transaction-specific OAuth grant defined by
+   [OAUTH-TXN-CHALLENGE], it uses that specification's
+   transaction_authorization_required response and signed
+   transaction_challenge, normally carried with WWW-Authenticate and
+   status 401.  It MUST NOT return only this document's 403 response and
+   then accept AE evidence as a substitute for the missing OAuth grant.
+
+   An HTTP origin server that refuses an action because authorization
+   evidence is missing, stale, or unverifiable SHOULD return 403
+   Forbidden as defined by [RFC9110].  The response body MUST be an
+   application/problem+json Problem Details object as defined by
+   [RFC9457].  Status 428 is not used: it is defined for requests that
+   the origin server requires to be conditional, not for authorization-
+   evidence negotiation.
+
+   If temporary overload is the sole reason for refusal, the origin
+   server MUST NOT fabricate an authorization-evidence challenge.  It
+   uses 503 Service Unavailable, or another response appropriate to the
+   actual failure, and MAY use Retry-After as defined by [RFC9110].  A
+   403 AE-CHALLENGE is appropriate when evidence is actually
+   insufficient and no applicable hard cap is binding; non-binding load
+   pressure can still make pacing the corrected presentation necessary.
+
+
+
+Schrock                 Expires 11 February 2027               [Page 12]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+   If a hard cap is binding, or the server cannot allocate, reserve,
+   route to, or claim the state required by Section 2.4, it uses 503 and
+   MUST NOT include evidence_challenge, remaining requirements, obtain
+   hints, or other evidence-sufficiency details.  This rule applies even
+   when the server suspects that evidence is also insufficient.  The
+   server MAY include Retry-After without disclosing authorization
+   policy.
+
+   HTTP/1.1 403 Forbidden
+   Content-Type: application/problem+json
+   Cache-Control: no-store
+   Date: Sun, 09 Aug 2026 23:50:00 GMT
+   Retry-After: 30
+
+   {
+   "type":"https://iana.org/assignments/http-problem-types#ae-required",
+     "title": "Authorization Evidence Required",
+     "status": 403,
+     "detail": "Required evidence is unavailable.",
+     "evidence_challenge": {
+       "@version": "AE-CHALLENGE-v1",
+       "challenge_id": "7a3120d1-...",
+       "nonce": "...",
+       "action_digest": "sha256:...",
+       "action_profile": "https://example.net/action/payment-v3",
+       "audience": "https://agent.example",
+       "policy_id": "https://resource.example/policies/high-risk-v4",
+       "policy_digest": "sha256:...",
+       "required_evidence": [
+         { "requirement_id": "human-approval",
+           "type": "https://example.net/e/authorization-receipt",
+           "max_age_sec": 300,
+           "status": "current" }
+       ],
+       "present_as": ["https://example.net/p/ep-aec-v1"],
+       "obtain_hints": [],
+       "retry_timing": {
+         "not_before": "2026-08-09T23:50:30Z",
+         "jitter_sec": 20
+       },
+       "expires_at": "2026-08-10T00:05:00Z"
+     }
+   }
+
+
+
+
+
+
+
+
+Schrock                 Expires 11 February 2027               [Page 13]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+   The Problem Details type and title MUST have the values shown above.
+   The HTTP status code and the optional status member MUST both be 403.
+   The core challenge MUST appear in the evidence_challenge extension
+   member.  Human-readable detail text is advisory and MUST NOT be
+   parsed for protocol semantics.
+
+   The origin server MUST send Cache-Control: no-store.  A generic
+   intermediary can still transform an HTTP response, so a client MUST
+   validate the Problem Details object and the authenticated origin
+   before acting on hints or presenting evidence.
+
+   When the core challenge contains retry_timing, the origin server
+   SHOULD send a Retry-After field as defined by [RFC9110].  Its HTTP-
+   date or delay-seconds value MUST NOT permit a follow-up request
+   earlier than not_before.  If the header and core member identify
+   different lower bounds, a client MUST use the later bound and then
+   apply jitter_sec.  Retry-After does not carry the jitter value and
+   does not change the challenge expiry, authorize the action, promise
+   capacity or acceptance, or make a retry safe after an uncertain
+   effect.
+
+3.1.  OAuth Non-Substitution Conformance Case
+
+   A protected resource requires a transaction-specific OAuth grant.
+   The presenter supplies a valid AE-CHALLENGE response but no native
+   transaction-bound access token.  The protected resource MUST refuse
+   the action.  It MUST NOT treat the AE challenge identifier or nonce
+   as the OAuth transaction identifier, and it MUST NOT report the
+   evidence presentation as satisfying the native grant requirement.
+   The case passes only when the protected resource continues the native
+   OAuth flow or refuses.
+
+4.  Informative DMSC Gateway Profile
+
+   Agent gateways can carry the transport-neutral challenge during
+   federation or handoff.  The receiving gateway is the relying party:
+   it derives the exact action, applies its own trust anchors and
+   policy, and issues a challenge when evidence is missing, stale, or
+   unverifiable.  The sending gateway or agent can obtain evidence and
+   return a new presentation using a DMSC-defined extension point or
+   error carrier.
+
+   If the receiving gateway's required next step is a native OAuth
+   transaction grant, the DMSC carrier preserves that native challenge
+   rather than wrapping it as AE-CHALLENGE.  A DMSC application profile
+   can carry both only under the explicit composition rules in
+   Section 1.1.
+
+
+
+
+Schrock                 Expires 11 February 2027               [Page 14]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+   If a gateway rewrites or translates the proposed action, the next
+   gateway re-evaluates that locally derived action and, when necessary,
+   issues its own binding.  The prior gateway's action digest does not
+   survive the rewrite as the receiving gateway's binding.  Any claim
+   that the two actions are equivalent requires a separately defined
+   mapping or transformation proof.
+
+   When a receiving gateway refuses an action because required
+   authorization evidence is missing, stale, or unverifiable, it may
+   return a structured evidence challenge identifying the exact action,
+   outstanding evidence requirements, applicable freshness or status
+   constraints, and supported presentation profiles.  The challenge does
+   not authorize the action or transfer admission ownership; conserved
+   admission across gateway boundaries remains the separate requirement
+   described in Section 7.8 of the proposed next revision of
+   [DMSC-GAPS].
+
+   In particular, AE-CHALLENGE does not prevent Gateway A and Gateway B
+   from admitting the same single-use right.  It does not copy, fence,
+   or relinquish consumption state and does not establish which gateway
+   owns admission during a partition.  The separate handoff property is
+   not a race to decide which gateway admitted first; it is an invariant
+   that committed capacity is not over-allocated under any interleaving
+   of admissions and releases.  A DMSC handoff profile MUST solve that
+   property separately.  If the receiving gateway cannot establish the
+   required exclusivity, its safe result is refusal or indeterminate,
+   not acceptance based on the challenge.
+
+4.1.  Gateway Conformance Case
+
+   Gateway A forwards a proposed action to Gateway B.  Gateway B derives
+   the exact action under its pinned action profile and refuses because
+   a current approval artifact is missing.  B returns an AE-CHALLENGE
+   bound to B's action digest and local evidence requirement.  A obtains
+   and presents the artifact.  B verifies it under B's trust anchors,
+   matches it to the same action, and reevaluates B's policy.  The case
+   passes only if A never treats the challenge as authorization and B
+   refuses an action-digest mismatch, stale status, replayed nonce, or
+   unsupported presentation profile.
+
+   A second case attempts concurrent admission of one single-use right
+   at both gateways.  AE-CHALLENGE alone MUST NOT be reported as passing
+   that case.  The case passes only when a separate conserved-admission
+   mechanism establishes exclusivity, or when the receiving gateway
+   refuses or returns indeterminate because exclusivity cannot be
+   established.
+
+
+
+
+
+Schrock                 Expires 11 February 2027               [Page 15]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+5.  Security Considerations
+
+   *Challenge forgery and evidence exfiltration.* A forged challenge
+   cannot authorize an action, but it can redirect a presenter, induce
+   unnecessary approval work, or solicit sensitive evidence.  Presenters
+   MUST authenticate the relying party and audience before following
+   obtain hints or disclosing evidence.  A bare JSON object copied
+   outside its authenticated carrier has no origin authenticity.
+
+   *Action substitution.* The relying party computes the challenge
+   action digest from the action it would execute and recomputes that
+   binding before admission.  A digest supplied by the presenter or an
+   action profile selected by the presenter defeats the purpose of the
+   protocol.
+
+   *Replay and state exhaustion.* Stateful issuance binds the complete
+   body before exposure; self-describing issuance defers storage but
+   still requires an atomic replay claim before evidence evaluation.  An
+   attacker can provoke refusals cheaply or consume a structurally valid
+   challenge.  Aggregate and scoped bounds, short expiries,
+   authentication where available, and rate limits are therefore
+   required operational controls.  Exhaustion or replay-store
+   uncertainty fails closed.  Live replay state is never evicted to make
+   room for new work.  Hard-cap capacity is reserved before evidence
+   verification so an attacker cannot force expensive signature or
+   status work after the state budget is exhausted.
+
+   *Replica consistency.* Per-process replay caches permit two verifier
+   replicas to accept the same nonce.  Verifiers for one issuer need one
+   atomic replay domain or an exclusive deterministic shard.  During
+   partition or store failure they refuse rather than create local
+   replacement state.  Only the owning shard's authoritative already-
+   claimed result is replay; routing failure is unavailability and is
+   not relabeled as attacker replay.
+
+   *Retry synchronization and load amplification.* A precise challenge
+   tells a presenter how to correct a request, so a population receiving
+   similar refusals can retry in a synchronized burst.  An issuer under
+   pressure SHOULD combine recipient-specific retry timing, a non-zero
+   jitter interval, admission control, and rate limiting.  A presenter
+   SHOULD retain exponential backoff or equivalent local load control
+   even when a challenge supplies a lower bound.  Timing guidance paces
+   only a new evidence presentation and MUST NOT be interpreted as
+   evidence satisfaction, authorization, or a promise that capacity or
+   admission will exist after not_before.
+
+
+
+
+
+
+Schrock                 Expires 11 February 2027               [Page 16]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+   *Information disclosure.* Evidence requirements, policy identifiers,
+   action profiles, and obtain hints can reveal sensitive policy
+   structure.  A relying party SHOULD disclose only the minimum
+   information needed for remediation.  The HTTP binding requires Cache-
+   Control: no-store.  When a hard cap is binding, the relying party
+   discloses no requirements, obtain hints, or evidence-sufficiency
+   details.  Returning a stateless hint in that state would turn
+   overload handling into a policy oracle.
+
+   *Stale facts and uncertain effects.* A satisfied challenge proves
+   only that the relying party's evidence requirement was met at
+   evaluation time.  It does not prove that external facts remain true,
+   that an action executed, or that an uncertain action is safe to
+   retry.  Status rechecking, execution custody, effect observation, and
+   reconciliation remain separate controls.
+
+   *Gateway split brain.* An authenticated challenge from a receiving
+   gateway does not transfer a single-use authorization or its
+   consumption ledger.  Implementations MUST NOT claim cross-gateway
+   double-admission prevention merely because both gateways implement
+   this challenge.
+
+6.  IANA Considerations
+
+   IANA is requested to add the following entry to the "HTTP Problem
+   Types" registry established by [RFC9457].  That registry uses the
+   Specification Required policy defined by [RFC8126]; this request does
+   not require IETF Review or Standards Action.
+
+   Type URI:
+      https://iana.org/assignments/http-problem-types#ae-required
+
+   Title:  Authorization Evidence Required
+
+   Recommended HTTP status code:  403
+
+   Reference:  This document.
+
+   This revision withdraws the earlier request for a new application/
+   authorization-evidence-challenge+json media type.  The HTTP binding
+   reuses the registered application/problem+json media type.  Non-HTTP
+   bindings define their own carriage without changing the core data
+   model.
+
+
+
+
+
+
+
+
+Schrock                 Expires 11 February 2027               [Page 17]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+7.  Interoperability Questions for Review
+
+   This revision resolves the transport layering, HTTP status and media
+   type, gateway-ownership boundary, acquisition-protocol coupling,
+   retry synchronization, retry criticality, bounded replay state, and
+   per-hop binding questions raised through revision -05.  It also
+   resolves the ordering of hard-cap enforcement before evidence
+   evaluation and the distinction between authoritative replay and owner
+   unavailability.  Review is requested on the following remaining
+   choices:
+
+   *  Which Agent2Agent and AgentProto error carriers can preserve the
+      complete challenge, authenticated issuer, audience, and retry
+      timing, and whether either protocol needs an additional attempt
+      identifier.
+
+   *  Whether a DMSC gateway profile should carry the core object
+      directly or reference it by an authenticated, digest-bound URI.
+
+   *  Which application profiles, if any, need both a native OAuth
+      transaction challenge and an AE-CHALLENGE, and how those profiles
+      should expose the two independent replay domains.
+
+8.  Acknowledgments
+
+   Thanks to Sumit P.  Ahuja for identifying synchronized retry and load
+   amplification as a consequence of precise challenge guidance, for
+   correcting retry criticality and non-promissory timing semantics, and
+   for identifying refusal-path state exhaustion, cap-before-
+   verification ordering, policy-oracle risk under load, and the
+   distinction between an authoritative replay result and failure to
+   reach the owning shard.  Thanks to Guigui Wang for implementation
+   feedback on structured error payloads, per-hop action rebinding, and
+   the separation of capability discovery from local authority.  Thanks
+   to Henri Sirkkavaara for review of replay ordering, concurrent-
+   presentation behavior, diagnostic ordering, and portable identifier
+   semantics.
+
+9.  Changes since -05
+
+   *  Requires every applicable hard cap to bind through an atomic
+      reservation or debit before native evidence verification and local
+      policy evaluation.
+
+   *  Makes a binding capacity refusal dominant over evidence
+      insufficiency and prohibits follow-up challenges, stateless
+      requirement lists, obtain hints, and other policy detail on that
+      path.
+
+
+
+Schrock                 Expires 11 February 2027               [Page 18]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+   *  Requires deterministic-shard profiles to derive the owning replay
+      shard from issuer-protected challenge state.
+
+   *  Restricts replay classification to an authoritative owner result
+      that the exact registered body was already claimed; owner routing
+      failure or uncertainty is temporary unavailability.
+
+   *  Adds cap-first, no-policy-oracle, and owner-routing conformance
+      cases, and tightens the HTTP 503 mapping accordingly.
+
+10.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC3339]  Klyne, G. and C. Newman, "Date and Time on the Internet:
+              Timestamps", RFC 3339, DOI 10.17487/RFC3339, July 2002,
+              <https://www.rfc-editor.org/info/rfc3339>.
+
+   [RFC3986]  Berners-Lee, T., Fielding, R. T., and L. Masinter,
+              "Uniform Resource Identifier (URI): Generic Syntax",
+              STD 66, RFC 3986, DOI 10.17487/RFC3986, January 2005,
+              <https://www.rfc-editor.org/info/rfc3986>.
+
+   [RFC8126]  Cotton, M., Leiba, B., and T. Narten, "Guidelines for
+              Writing an IANA Considerations Section in RFCs", BCP 26,
+              RFC 8126, DOI 10.17487/RFC8126, June 2017,
+              <https://www.rfc-editor.org/info/rfc8126>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+   [RFC8259]  Bray, T., Ed., "The JavaScript Object Notation (JSON) Data
+              Interchange Format", STD 90, RFC 8259,
+              DOI 10.17487/RFC8259, December 2017,
+              <https://www.rfc-editor.org/info/rfc8259>.
+
+   [RFC9110]  Fielding, R., Ed., Nottingham, M., Ed., and J. Reschke,
+              Ed., "HTTP Semantics", STD 97, RFC 9110,
+              DOI 10.17487/RFC9110, June 2022,
+              <https://www.rfc-editor.org/info/rfc9110>.
+
+   [RFC9457]  Nottingham, M., Wilde, E., and S. Dalal, "Problem Details
+              for HTTP APIs", RFC 9457, DOI 10.17487/RFC9457, July 2023,
+              <https://www.rfc-editor.org/info/rfc9457>.
+
+
+
+Schrock                 Expires 11 February 2027               [Page 19]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+11.  Informative References
+
+   [AEB]      Schrock, I., "The Action Evidence Boundary for
+              Consequential Agent Effects", Work in Progress, Internet-
+              Draft, draft-schrock-action-evidence-boundary-03, August
+              2026, <https://datatracker.ietf.org/doc/draft-schrock-
+              action-evidence-boundary/>.
+
+   [AEC]      Schrock, I., "Authorization Evidence Chains: Composing
+              Heterogeneous Agent-Action Evidence (EP-AEC)", Work in
+              Progress, Internet-Draft, draft-schrock-ep-authorization-
+              evidence-chain-05, August 2026,
+              <https://datatracker.ietf.org/doc/draft-schrock-ep-
+              authorization-evidence-chain/>.
+
+   [AUTH-RECEIPTS]
+              Schrock, I., "Authorization Receipts for High-Risk Agent
+              Actions", Work in Progress, Internet-Draft, draft-schrock-
+              ep-authorization-receipts-11, 9 August 2026,
+              <https://datatracker.ietf.org/doc/draft-schrock-ep-
+              authorization-receipts/>.
+
+   [BCR]      Schrock, I., "Bounded Capability Receipts and Durable
+              Spend Control for Agent Actions", Work in Progress,
+              Internet-Draft, draft-schrock-ep-bounded-capability-
+              receipts-03, August 2026,
+              <https://datatracker.ietf.org/doc/draft-schrock-ep-
+              bounded-capability-receipts/>.
+
+   [CAID]     Schrock, I., "The Canonical Action Identifier (CAID)",
+              Work in Progress, Internet-Draft, draft-schrock-canonical-
+              action-identifier-02, August 2026,
+              <https://datatracker.ietf.org/doc/draft-schrock-canonical-
+              action-identifier/>.
+
+   [DMSC-GAPS]
+              Dunbar, L., Wang, Y., Schrock, I., and B. Liu, "Deployment
+              Scenarios and Gap Analysis for AI Agent Gateway", Work in
+              Progress, Internet-Draft, draft-dunbar-dmsc-gw-scenarios-
+              gap-analysis-03, August 2026,
+              <https://datatracker.ietf.org/doc/draft-dunbar-dmsc-gw-
+              scenarios-gap-analysis/>.
+
+
+
+
+
+
+
+
+
+Schrock                 Expires 11 February 2027               [Page 20]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+   [KLRC]     Kasselman, P., Lombardo, J., Rosomakho, Y., Campbell, B.,
+              Steele, N., and A. Parecki, "AI Agent Authentication and
+              Authorization", Work in Progress, Internet-Draft, draft-
+              klrc-aiagent-auth-03, 9 July 2026,
+              <https://datatracker.ietf.org/doc/draft-klrc-aiagent-
+              auth/>.
+
+   [OAUTH-TXN-CHALLENGE]
+              Rosomakho, Y., Campbell, B., McGuinness, K., and P.
+              Kasselman, "OAuth Transaction Authorization Challenge",
+              Work in Progress, Internet-Draft, draft-rosomakho-oauth-
+              txn-challenge-00, 25 June 2026,
+              <https://datatracker.ietf.org/doc/draft-rosomakho-oauth-
+              txn-challenge/>.
+
+   [RFC9470]  Bertocci, V. and B. Campbell, "OAuth 2.0 Step Up
+              Authentication Challenge Protocol", RFC 9470,
+              DOI 10.17487/RFC9470, September 2023,
+              <https://www.rfc-editor.org/info/rfc9470>.
+
+Appendix A.  Relationship to Existing Mechanisms
+
+   CAID [CAID] is one mechanism for deriving and mapping exact material
+   actions.  AEB [AEB] defines executor-side evidence verification,
+   refusal, and one-time consumption.  Bounded Capability Receipts [BCR]
+   define durable single-domain reservation and consumption.  AEC [AEC]
+   is one possible presentation profile.  None is required by the core
+   challenge, and the challenge does not extend any of them across
+   independently operated admission domains.
+
+   OAuth Transaction Authorization Challenge [OAUTH-TXN-CHALLENGE]
+   supplies the OAuth-native choreography and transaction-bound grant
+   that this document explicitly does not define.  The KLRC architecture
+   [KLRC] describes broader agent authentication and authorization
+   requirements, including human-in-the-loop and externalized
+   authorization patterns.  Authorization Receipts [AUTH-RECEIPTS] are
+   one possible portable human- evidence type that an AE-CHALLENGE can
+   request; neither the receipt nor AE-CHALLENGE replaces a native OAuth
+   grant or a relying party's final policy decision.
+
+Appendix B.  Implementation Status
+
+   The EMILIA Protocol repository contains a same-team reference
+   implementation of the AE-CHALLENGE-v1 core lifecycle, including
+   relying-party-derived action binding, policy-derived requirements,
+   durable body-bound registration, single-use consumption, expiry,
+   follow-up challenges, and action-swap refusal.  Revision -03 added a
+   serializer and parser for the RFC 9457 HTTP binding and tests that
+
+
+
+Schrock                 Expires 11 February 2027               [Page 21]
+
+Internet-Draft             Evidence Challenge                August 2026
+
+
+   pin status 403, application/problem+json, Cache-Control: no-store,
+   and the evidence_challenge extension.
+
+   Revision -04 specifies retry timing, per-hop rebinding, discovery
+   separation, carrier semantics, portable absolute-URI identifiers, and
+   action-before-consumption replay ordering.  These additions are based
+   in part on external implementer review, including experience with
+   structured error payloads and per-verifier decision bindings.  They
+   are not yet implemented by the same-team reference implementation and
+   are not claimed as an independent implementation of this
+   specification.
+
+   Revision -05 adds optional self-describing issuance, mandatory state
+   bounds and cap behavior, authoritative replay-domain requirements,
+   and state-exhaustion conformance cases.  The same-team implementation
+   uses durable stateful issuance and atomic consumption across workers
+   and restarts, but does not yet implement the -05 configurable cap
+   behavior or self-describing issuance path.  No implementation claim
+   is made for those additions.
+
+   Revision -06 adds binding cap-before-verification ordering, no-
+   requirements disclosure while a hard cap is binding, and an explicit
+   distinction between an authoritative already-claimed replay result
+   and inability to reach the owning shard.  These requirements and
+   their conformance cases are not yet implemented by the same-team
+   reference implementation, and no implementation claim is made for
+   them.
+
+   The OAuth boundary and non-substitution case in revision -05 are
+   normative text and conformance requirements.  The same-team reference
+   implementation does not convert an AE-CHALLENGE into an OAuth
+   challenge or grant, and no such conversion is planned.  It does not
+   yet implement a composed application profile carrying both
+   mechanisms.
+
+   This is same-team implementation evidence.  No independent
+   implementation or interoperability is claimed.  The implementation
+   does not yet provide a DMSC carrier or conserved-admission mechanism.
+   Its current local evidence and presentation identifiers are not the
+   absolute URIs required by this revision.
+
+Author's Address
+
+   Iman Schrock
+   EMILIA Protocol, Inc.
+   United States of America
+   Email: team@emiliaprotocol.ai
+
+
+
+
+Schrock                 Expires 11 February 2027               [Page 22]

--- a/standards/staged/NEXT-AE-CHALLENGE-06/SHA256SUMS.txt
+++ b/standards/staged/NEXT-AE-CHALLENGE-06/SHA256SUMS.txt
@@ -1,0 +1,3 @@
+aa189344c491948a1df2d18d9bff529d696e618ebb2f73ebe607445031744433  UPLOAD-THIS/draft-schrock-ae-challenge-06.xml
+dca44205eaa35459cf144fbe036e9a4a38e4a69d50785b92f7c2e9bf0d91479c  RENDERS/draft-schrock-ae-challenge-06.html
+94a1a9f2d003684513b004cb61df2ad20de9166ac248c88144a9657237ed1fff  RENDERS/draft-schrock-ae-challenge-06.txt

--- a/standards/staged/NEXT-AE-CHALLENGE-06/UPLOAD-THIS/draft-schrock-ae-challenge-06.xml
+++ b/standards/staged/NEXT-AE-CHALLENGE-06/UPLOAD-THIS/draft-schrock-ae-challenge-06.xml
@@ -1,0 +1,940 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude"
+     docName="draft-schrock-ae-challenge-06"
+     category="info" ipr="trust200902" submissionType="independent"
+     version="3" tocInclude="true" sortRefs="true" symRefs="true">
+  <front>
+    <title abbrev="Evidence Challenge">An Authorization Evidence Challenge for High-Risk Agent Actions</title>
+    <seriesInfo name="Internet-Draft" value="draft-schrock-ae-challenge-06"/>
+    <author fullname="Iman Schrock">
+      <organization>EMILIA Protocol, Inc.</organization>
+      <address>
+        <postal><country>US</country></postal>
+        <email>team@emiliaprotocol.ai</email>
+      </address>
+    </author>
+    <date year="2026" month="August" day="10"/>
+    <area>sec</area>
+    <keyword>AI agents</keyword>
+    <keyword>evidence</keyword>
+    <keyword>challenge</keyword>
+    <keyword>step-up</keyword>
+    <abstract>
+      <t>When a relying party refuses a consequential agent action because
+      authorization evidence is missing, stale, or unverifiable, the agent
+      needs a machine-readable description of what remains necessary. This
+      document defines a transport-neutral Authorization Evidence Challenge
+      data model bound to the relying party's exact action. The challenge
+      identifies outstanding evidence requirements, freshness and status
+      constraints, acceptable presentation profiles, and retry state. It
+      authorizes nothing, transfers no admission ownership, and provides no
+      promise that a later request will execute.</t>
+      <t>The document also defines an HTTP binding using 403 Forbidden and
+      RFC 9457 Problem Details, and describes an informative gateway-handoff
+      profile for DMSC-style federation. The gateway profile communicates
+      evidence requirements; it does not solve conserved admission or
+      double-admission across independently operated gateways.</t>
+      <t>A challenge can synchronize corrected retries and amplify load. The
+      core therefore defines optional retry timing with per-challenge jitter,
+      and the HTTP binding maps its lower bound to Retry-After. Retry timing
+      controls presentation attempts only; it does not authorize the action
+      or make an uncertain action safe to repeat.</t>
+      <t>Single-use processing also places state on the refusal path. The core
+      therefore requires bounded outstanding and replay state, fail-closed
+      behavior when state cannot be claimed, and retention of live replay
+      records until they are no longer security-relevant. Capacity MUST be
+      reserved before native evidence verification, and a binding capacity
+      refusal reveals no remaining evidence requirements. In a sharded replay
+      domain, only the authoritative owner can classify a nonce as already
+      claimed; inability to reach that owner is unavailability, not replay.</t>
+    </abstract>
+  </front>
+  <middle>
+    <section anchor="intro">
+      <name>Introduction</name>
+      <t>Evidence formats describe artifacts such as receipts, permits,
+      attestations, and logs. They do not by themselves define the live
+      interaction that follows when a relying party finds the presented
+      evidence insufficient. Without a common challenge, each agent protocol
+      invents its own vocabulary for missing evidence, acceptable
+      presentations, freshness, status checking, and retry.</t>
+      <t>This document defines the challenge as an application data model,
+      independent of HTTP, a particular agent protocol, and any one evidence
+      format. OAuth step-up authentication <xref target="RFC9470"/> lets a
+      resource identify stronger authentication requirements. OAuth
+      Transaction Authorization Challenge
+      <xref target="OAUTH-TXN-CHALLENGE"/> defines a signed, OAuth-specific
+      challenge that an authorization server turns into a transaction-bound
+      access token after obtaining any required approval. AE-CHALLENGE does
+      not replace either mechanism. It describes missing authorization
+      evidence for an exact proposed action when an application needs a
+      transport-neutral evidence-negotiation object.</t>
+      <t>A challenge is a refusal with information. It is not an
+      authorization decision, reservation, capability, ownership transfer,
+      or promise of execution. Satisfying it causes the relying party to
+      evaluate a new presentation under its live local policy.</t>
+      <section anchor="oauth-boundary">
+        <name>Boundary with OAuth Transaction Authorization</name>
+        <t>When the required next step is issuance of a transaction-specific
+        OAuth grant, an implementation <bcp14>SHOULD</bcp14> use OAuth
+        Transaction Authorization Challenge. It <bcp14>MUST NOT</bcp14>
+        substitute an AE-CHALLENGE, its nonce, or a successfully presented
+        evidence object for that signed OAuth challenge, its transaction
+        identifier, the authorization-server decision, or the resulting
+        access token. Satisfying AE-CHALLENGE never satisfies a native OAuth
+        grant requirement.</t>
+        <t>AE-CHALLENGE remains applicable outside OAuth and when a relying
+        party needs evidence that a native authorization protocol does not
+        itself negotiate, such as a current status proof, quorum receipt,
+        hardware attestation, or separately verified policy artifact. An
+        OAuth application profile <bcp14>MAY</bcp14> carry or reference both
+        mechanisms, but that profile <bcp14>MUST</bcp14> define their exact
+        action and audience join, which challenge is primary for each
+        refusal, and how native grant state remains separate from
+        AE-CHALLENGE replay state. Without such a profile, the mechanisms are
+        separate and neither is silently converted into the other.</t>
+        <t>The single-use property in this document applies only to one
+        evidence-presentation attempt under an AE-CHALLENGE nonce. It does not
+        consume an OAuth transaction, invalidate an access token, reserve an
+        action, or establish one-time admission at an executor.</t>
+      </section>
+      <section anchor="requirements-language">
+        <name>Requirements Language</name>
+        <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL",
+        "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT
+        RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+        interpreted as described in BCP 14 <xref target="RFC2119"/>
+        <xref target="RFC8174"/> when, and only when, they appear in all
+        capitals, as shown here.</t>
+      </section>
+      <section anchor="terms">
+        <name>Terminology</name>
+        <dl>
+          <dt>Relying party:</dt>
+          <dd>The component that decides whether evidence satisfies its
+          requirements for a proposed action.</dd>
+          <dt>Presenter:</dt>
+          <dd>The agent, gateway, or other component that receives a
+          challenge and may later present evidence.</dd>
+          <dt>Exact action:</dt>
+          <dd>The relying-party-derived material action that would be
+          admitted, including every field its selected action profile treats
+          as consequential.</dd>
+          <dt>Challenge:</dt>
+          <dd>A single-use, expiring description of evidence still required
+          for one exact action.</dd>
+        </dl>
+      </section>
+    </section>
+
+    <section anchor="core">
+      <name>Transport-Neutral Core Data Model</name>
+      <t>The AE-CHALLENGE-v1 data model is independent of its carrier. A
+      transport binding MUST preserve every member that the relying party
+      uses when registering or reconstructing and later consuming the
+      challenge. A binding MUST
+      also provide authenticated integrity and peer identification, or carry
+      the challenge in an authenticated envelope that provides those
+      properties.</t>
+      <t>The JSON format defined by <xref target="RFC8259"/> is the reference
+      serialization of the core model. A non-JSON binding MUST define an
+      unambiguous mapping to the same members and value types.</t>
+      <sourcecode type="json"><![CDATA[
+{
+  "@version": "AE-CHALLENGE-v1",
+  "challenge_id": "7a3120d1-...",
+  "nonce": "<single-use unpredictable value>",
+  "action_digest": "sha256:<relying-party-derived digest>",
+  "action_profile": "https://example.net/action/payment-v3",
+  "audience": "https://gateway-b.example",
+  "policy_id": "https://gateway-b.example/policies/high-risk-v4",
+  "policy_digest": "sha256:<relying-party policy digest>",
+  "required_evidence": [
+    {
+      "requirement_id": "human-approval",
+      "type": "https://example.net/e/authorization-receipt",
+      "profiles": ["https://example.net/profiles/receipt-v1"],
+      "max_age_sec": 300,
+      "status": "current"
+    }
+  ],
+  "present_as": ["https://example.net/p/ep-aec-v1"],
+  "obtain_hints": [
+    {
+      "requirement_id": "human-approval",
+      "mechanism": "https://example.net/flows/approval-v1",
+      "uri": "https://approver.example/tasks/123"
+    }
+  ],
+  "retry_timing": {
+    "not_before": "2026-08-09T23:50:30Z",
+    "jitter_sec": 20
+  },
+  "expires_at": "2026-08-10T00:05:00Z"
+}
+]]></sourcecode>
+
+      <section anchor="core-binding">
+        <name>Action and Policy Binding</name>
+        <t><tt>@version</tt> MUST equal <tt>AE-CHALLENGE-v1</tt>. A
+        recipient that does not implement this version MUST refuse automated
+        processing.</t>
+        <t><tt>challenge_id</tt> is an opaque correlation identifier.
+        Authorization decisions MUST NOT depend on its global uniqueness.
+        <tt>nonce</tt> MUST be unpredictable, non-empty, and single-use.
+        Before exposing a challenge, the relying party MUST either register a
+        durable record that binds the nonce to the complete challenge body,
+        or protect the complete body with an issuer-authenticated,
+        self-describing mechanism defined by the applicable profile. The
+        latter mechanism MUST let the relying party reconstruct and validate
+        the exact body without trusting presenter-supplied fields. A bare
+        challenge body carried only under a transport session is not a
+        self-describing mechanism after that session ends.</t>
+        <t>Self-describing issuance can avoid retaining one record for every
+        unanswered challenge. It does not remove single-use state. On the
+        first returned presentation, the relying party still MUST atomically
+        claim the nonce in its authoritative replay store before evidence
+        evaluation.</t>
+        <t><tt>action_digest</tt> MUST be computed by the relying party from
+        the exact action it would admit. It MUST NOT be copied from the
+        presenter or from presented evidence. <tt>action_profile</tt> MUST be
+        present, MUST be an absolute URI as defined by
+        <xref target="RFC3986"/>, and identifies the canonicalization or
+        mapping profile used to derive the digest. It is descriptive to the
+        presenter; it does not let the presenter select or weaken that
+        profile. If two parties cannot
+        establish the same material action under an understood profile, the
+        challenge cannot repair the disagreement and the relying party MUST
+        refuse automated admission.</t>
+        <t><tt>audience</tt> identifies the component that is expected to
+        answer the challenge. A binding or authenticated envelope MUST let the
+        presenter establish the challenge issuer. A relying party processing
+        a returned challenge MUST verify the issuer and audience before using
+        any obtain hint or disclosing evidence.</t>
+        <t><tt>policy_id</tt> and <tt>policy_digest</tt> identify the local
+        policy state from which the requirements were derived. They do not
+        transfer policy authority to the presenter. At evaluation time the
+        relying party MUST use its authenticated live policy and MUST NOT use
+        a policy supplied in the response.</t>
+        <t>Delegation, translation, or task rewriting does not preserve one
+        action binding across hops. Each receiving relying party MUST
+        re-evaluate the action it is asked to admit under its own policy and
+        action profile. If that relying party issues a challenge, it MUST
+        derive a new <tt>action_digest</tt> and register its own challenge
+        binding. A prior hop's challenge or decision record MAY be presented
+        as evidence or context, but it MUST NOT substitute for the receiving
+        relying party's binding to a rewritten action. A chain of per-hop
+        records does not by itself prove that the actions at different hops
+        are semantically equivalent.</t>
+      </section>
+
+      <section anchor="core-requirements">
+        <name>Evidence Requirements and Presentation</name>
+        <t>Each <tt>required_evidence</tt> entry MUST contain a
+        <tt>requirement_id</tt> and <tt>type</tt>. Requirement identifiers
+        are unique within one challenge and correlate requirements with
+        acquisition hints and diagnostics. Every evidence <tt>type</tt>,
+        evidence <tt>profiles</tt> entry, and <tt>present_as</tt> entry MUST
+        be an absolute URI as defined by <xref target="RFC3986"/> so that the
+        same identifier has portable meaning across transport protocols and
+        conformance corpora. Unless the defining specification says
+        otherwise, these identifiers are compared as exact strings. A
+        recipient MUST NOT infer security semantics from URI prefixes or
+        substring matches; it uses only locally configured semantics for the
+        complete identifier.</t>
+        <t>An entry MAY contain <tt>profiles</tt>,
+        <tt>proof_predicates</tt>, <tt>max_age_sec</tt>, and
+        <tt>status</tt>. Profiles are alternatives acceptable for that
+        requirement. <tt>max_age_sec</tt> is measured at the relying party's
+        evaluation time using the issuance or observation time defined by the
+        selected evidence profile. <tt>status</tt> equal to
+        <tt>current</tt> requires a separately authenticated status result
+        satisfying the relying party's freshness policy; it does not mean
+        that absence from an unauthenticated revocation list is sufficient.</t>
+        <t><tt>present_as</tt> lists alternative presentation profiles. The
+        order expresses the relying party's preference, not a security
+        ranking. Supporting a presentation profile does not imply support for
+        every evidence type named by the challenge. The presenter selects one
+        mutually supported profile and includes enough information for the
+        relying party to match every component to a requirement.</t>
+        <t><tt>obtain_hints</tt> are untrusted routing hints. Following a
+        hint, authenticating to its URI, or receiving an "approved" response
+        confers no authority at the relying party. Evidence obtained through
+        a hint remains subject to native verification, exact-action matching,
+        freshness and status checks, policy evaluation, and one-time
+        consumption. Unknown transports MAY omit obtain hints entirely.</t>
+        <t>Capability discovery MAY advertise evidence types, presentation
+        profiles, or acquisition mechanisms that an implementation supports.
+        Such discovery is not an authorization decision and does not establish
+        that any advertised choice is sufficient for a particular action.
+        The relying party MUST determine sufficiency using its authenticated
+        local policy at evaluation time. A cached discovery response, a
+        mutually supported profile, or a successful acquisition flow MUST NOT
+        waive an unsatisfied local requirement.</t>
+      </section>
+
+      <section anchor="core-lifecycle">
+        <name>Lifecycle, Replay, and Retry</name>
+        <t><tt>expires_at</tt> MUST be an absolute timestamp. The relying
+        party MUST refuse an expired challenge before evidence or policy
+        evaluation.
+        Challenge expiry does not extend the validity of any evidence and
+        evidence expiry does not extend the challenge.</t>
+        <t>Evaluation is ordered: version and structure; authenticated issuer
+        and audience; validation of the registered or self-describing body;
+        action agreement; expiry; authoritative routing; binding capacity
+        reservation; atomic nonce claim; native evidence verification; and local
+        policy evaluation. Malformed input that
+        cannot be associated with a registered body or a valid
+        issuer-protected self-describing body, or a presentation that does not
+        agree with the registered exact action, is refused without claiming a
+        nonce. Once structural and action matching succeed, the nonce MUST be
+        claimed atomically before evidence evaluation. Section 2.4 defines the
+        capacity reservation that also precedes evidence evaluation.</t>
+        <t>A concurrent duplicate that arrives after another presentation has
+        consumed the nonce, whether that first evaluation is still in flight
+        or has completed, MUST be refused as a replay. It MUST NOT receive a
+        second evidence evaluation, an indeterminate result merely because the
+        first evaluation is in flight, or a second admission. An
+        implementation MAY distinguish in-flight from completed consumption
+        internally for operations and audit, but that distinction does not
+        reopen the challenge.</t>
+        <t>Every verifier instance that accepts presentations for one
+        challenge issuer MUST use the same authoritative replay domain, or a
+        deterministic partition in which exactly one authoritative shard owns
+        each nonce. A process-local cache or eventually consistent replica
+        does not satisfy atomic nonce claim. If the authoritative replay
+        domain is unavailable or its result is uncertain, the relying party
+        MUST refuse without evidence evaluation or admission; it MUST NOT fall
+        back to fresh local state.</t>
+        <t>A profile using deterministic partitioning MUST define how the
+        authoritative owner is derived from issuer-protected challenge state.
+        A presenter-controlled routing value outside the authenticated
+        challenge body MUST NOT select the owner. A front end or non-owning
+        shard MUST route the claim to the owner before classifying the nonce.
+        Only an authoritative owner result that the exact registered body was
+        already claimed is a replay result. Failure, timeout, partition, or an
+        uncertain result while reaching the owner is temporary unavailability,
+        not replay, and MUST NOT be reported as an already-claimed nonce.</t>
+        <t>If evidence remains missing, stale, or unverifiable, the relying
+        party MAY issue a follow-up challenge. A follow-up MUST use a fresh
+        challenge identifier and nonce, MUST remain bound to the same locally
+        derived action digest and action profile, and SHOULD list only the
+        requirements that remain unsatisfied. It is a new refusal, not a
+        continuation of the consumed nonce.</t>
+        <t><tt>retry_timing</tt> is OPTIONAL. When present, it MUST contain a
+        <tt>not_before</tt> Internet timestamp as defined by
+        <xref target="RFC3339"/> and MAY contain a non-negative integer
+        <tt>jitter_sec</tt>. A presenter that processes this member MUST NOT
+        send the challenge response before <tt>not_before</tt>. When
+        <tt>jitter_sec</tt> is greater than zero, the presenter SHOULD add an
+        independently selected delay between zero and that many seconds. The
+        selected delay SHOULD vary for each challenge and MUST NOT be treated
+        as extending <tt>expires_at</tt>. The <tt>not_before</tt> value is only
+        the earliest time to present corrected evidence. It is not a promise
+        of capacity, evidence sufficiency, admission, or execution. After
+        waiting, the presenter can receive the same refusal, a different
+        refusal, or an overload response.</t>
+        <t>A relying party that expects many correlated refusals SHOULD issue
+        recipient-specific or challenge-specific retry schedules rather than
+        one common retry instant. It SHOULD provide a jitter interval wide
+        enough for its expected population and recovery capacity. A presenter
+        remains responsible for its own backoff and rate limits when timing is
+        absent. A challenge MUST NOT be issued solely to signal overload when
+        the carrying protocol has a distinct overload response. If evidence
+        insufficiency and load pressure coexist, retry timing can pace the new
+        evidence presentation without changing the refusal semantics. The
+        presenter can therefore spend effort acquiring third-party evidence
+        and still be refused or shed after the lower bound; timing guidance
+        does not assert which constraint will be decisive later.</t>
+        <t>Ignoring <tt>retry_timing</tt> does not make evidence sufficient or
+        authorize an action, but it can defeat the issuer's load-control goal.
+        It does not change the semantic meaning of the challenge and therefore
+        MUST NOT appear in <tt>critical</tt>. An issuer that needs to enforce
+        pacing uses carrier-level overload handling, admission control, rate
+        limiting, or refusal. A presenter that cannot establish whether
+        <tt>not_before</tt> has passed MUST NOT infer permission to send early;
+        it uses its local backoff policy or declines automated retry.</t>
+        <t>Unknown acquisition status, timeout, transport failure, or an
+        unverifiable response is indeterminate. It MUST NOT be interpreted as
+        evidence satisfaction or permission to retry an action whose effect
+        may already have occurred.</t>
+      </section>
+
+      <section anchor="state-bounds">
+        <name>State Bounds and Exhaustion</name>
+        <t>A relying party MUST configure a finite aggregate upper bound on
+        challenge state retained in one authoritative replay domain. The
+        bound MUST account for outstanding stateful challenges and in-flight
+        or consumed replay records. Where a presenter is authenticated before
+        challenge issuance, the relying party SHOULD also apply per-presenter
+        and per-audience bounds. Multi-tenant deployments SHOULD apply an
+        administrative bound per tenant so one tenant cannot consume the
+        aggregate allowance.</t>
+        <t>Admission control for a stateful challenge MUST occur before the
+        challenge is exposed. If the relying party cannot allocate the
+        required outstanding record, it MUST NOT issue that challenge. It
+        returns a carrier-appropriate overload or generic refusal without an
+        authorization-evidence challenge.</t>
+        <t>For self-describing issuance, the relying party MUST enforce the
+        replay-state bound when the first returned presentation attempts to
+        claim the nonce. If it cannot durably and atomically claim replay
+        state, it MUST refuse without native evidence verification, policy
+        evaluation, or admission. It MUST NOT issue a replacement stateful
+        challenge on that path. Self-describing issuance reduces unanswered
+        outstanding state; it does not make replay processing stateless.</t>
+        <t>A relying party that knows its authoritative replay-state bound is
+        currently exhausted MUST NOT issue a self-describing challenge whose
+        return cannot be claimed. It uses the carrier's overload or generic
+        refusal path until capacity is available.</t>
+        <t>An implementation MUST NOT evict a live in-flight or consumed nonce
+        record to admit a newer challenge. Such a record MUST remain in the
+        authoritative replay domain until the later of <tt>expires_at</tt> and
+        completion of the in-flight evaluation. Expired unconsumed records
+        MAY be removed. Longer retention for audit or abuse detection is a
+        deployment choice.</t>
+        <t>Challenge lifetimes SHOULD be no longer than the expected evidence-
+        acquisition workflow requires. Rate limiting, authentication where
+        available, self-describing issuance, and short lifetimes can reduce
+        state pressure, but none permits fail-open nonce handling.</t>
+        <t>For a returned presentation, every applicable aggregate,
+        per-presenter, per-audience, and per-tenant hard cap MUST bind before
+        native evidence verification or local policy evaluation. A read-only
+        capacity check followed by unreserved evaluation does not satisfy this
+        requirement. The implementation MUST atomically reserve or debit enough
+        capacity for the maximum refusal-path state that the evaluation can
+        create, including a follow-up challenge where supported. It commits that
+        reservation to the resulting state or releases it only after proving
+        that no such state was created. Capacity uncertainty fails closed.</t>
+        <t>When a hard cap is binding, capacity handling controls the response
+        even if the supplied evidence is also missing, stale, or unverifiable.
+        The relying party MUST NOT perform native evidence verification or
+        local policy evaluation, and MUST NOT return a follow-up challenge, a
+        stateless list of remaining requirements, obtain hints, or any other
+        evidence-sufficiency detail. Withholding those details prevents an
+        unauthenticated or weakly authenticated load probe from using exhaustion
+        handling as a policy-discovery oracle.</t>
+        <section anchor="state-conformance">
+          <name>State Exhaustion Conformance Cases</name>
+          <t>A conforming implementation demonstrates all of the following:</t>
+          <ul>
+            <li>At the outstanding-state cap, a stateful issuer returns no new
+            challenge and allocates no additional outstanding record.</li>
+            <li>At the replay-state cap, a returned self-describing challenge
+            receives no evidence evaluation, no admission, and no requirements
+            or obtain hints.</li>
+            <li>When evidence is insufficient and a hard cap is also binding,
+            the capacity response wins: native verifiers and local policy are
+            not invoked and no follow-up or stateless requirements hint is
+            returned.</li>
+            <li>Two verifier replicas concurrently receiving the same nonce
+            produce one successful atomic claim and one replay refusal.</li>
+            <li>A front end that reaches the authoritative owner and receives
+            an already-claimed result reports replay. The same front end, given
+            an owner timeout, partition, or uncertain response, reports
+            unavailability and does not report replay or evaluate evidence.</li>
+            <li>Allocating a new challenge never evicts an in-flight or
+            unexpired consumed nonce.</li>
+          </ul>
+        </section>
+      </section>
+
+      <section anchor="core-extensibility">
+        <name>Extensibility</name>
+        <t>Recipients MUST ignore an unknown member unless its name appears
+        in the optional <tt>critical</tt> array. A recipient that does not
+        understand every member named by <tt>critical</tt> MUST refuse
+        automated processing. A specification defining an extension MUST
+        state whether that extension is safe to ignore and how it is bound to
+        the registered challenge body. The core <tt>retry_timing</tt> member
+        is safe to ignore for challenge semantics and MUST NOT be named by
+        <tt>critical</tt>.</t>
+      </section>
+
+      <section anchor="carrier-semantics">
+        <name>Carrier Semantics</name>
+        <t>A transport binding SHOULD carry a challenge as a structured
+        refusal or error payload when the carrying protocol provides such a
+        facility. A binding that uses a message part, task-state extension, or
+        other carrier MUST preserve the same refusal semantics and scope the
+        challenge to the identified attempt. It MUST NOT represent the
+        challenge as a successful task result, output artifact, authorization,
+        or durable state that silently applies to later attempts. These rules
+        constrain carrier semantics without requiring every transport to use
+        the same envelope.</t>
+      </section>
+    </section>
+
+    <section anchor="http-binding">
+      <name>HTTP Binding</name>
+      <t>This 403 Problem Details binding is not the OAuth transaction-
+      authorization response. When a protected resource requires the native
+      transaction-specific OAuth grant defined by
+      <xref target="OAUTH-TXN-CHALLENGE"/>, it uses that specification's
+      <tt>transaction_authorization_required</tt> response and signed
+      <tt>transaction_challenge</tt>, normally carried with
+      <tt>WWW-Authenticate</tt> and status 401. It <bcp14>MUST NOT</bcp14>
+      return only this document's 403 response and then accept AE evidence as
+      a substitute for the missing OAuth grant.</t>
+      <t>An HTTP origin server that refuses an action because authorization
+      evidence is missing, stale, or unverifiable SHOULD return
+      <tt>403 Forbidden</tt> as defined by <xref target="RFC9110"/>. The
+      response body MUST be an <tt>application/problem+json</tt> Problem
+      Details object as defined by <xref target="RFC9457"/>. Status 428 is not
+      used: it is defined for requests that the origin server requires to be
+      conditional, not for authorization-evidence negotiation.</t>
+      <t>If temporary overload is the sole reason for refusal, the origin
+      server MUST NOT fabricate an authorization-evidence challenge. It uses
+      <tt>503 Service Unavailable</tt>, or another response appropriate to the
+      actual failure, and MAY use <tt>Retry-After</tt> as defined by
+      <xref target="RFC9110"/>. A 403 AE-CHALLENGE is appropriate when
+      evidence is actually insufficient and no applicable hard cap is binding;
+      non-binding load pressure can still make pacing the corrected
+      presentation necessary. If a hard cap is binding, or the server cannot
+      allocate, reserve, route to, or claim the state required by Section 2.4,
+      it uses 503 and MUST NOT include <tt>evidence_challenge</tt>, remaining
+      requirements, obtain hints, or other evidence-sufficiency details. This
+      rule applies even when the server suspects that evidence is also
+      insufficient. The server MAY include <tt>Retry-After</tt> without
+      disclosing authorization policy.</t>
+      <sourcecode type="http"><![CDATA[
+HTTP/1.1 403 Forbidden
+Content-Type: application/problem+json
+Cache-Control: no-store
+Date: Sun, 09 Aug 2026 23:50:00 GMT
+Retry-After: 30
+
+{
+"type":"https://iana.org/assignments/http-problem-types#ae-required",
+  "title": "Authorization Evidence Required",
+  "status": 403,
+  "detail": "Required evidence is unavailable.",
+  "evidence_challenge": {
+    "@version": "AE-CHALLENGE-v1",
+    "challenge_id": "7a3120d1-...",
+    "nonce": "...",
+    "action_digest": "sha256:...",
+    "action_profile": "https://example.net/action/payment-v3",
+    "audience": "https://agent.example",
+    "policy_id": "https://resource.example/policies/high-risk-v4",
+    "policy_digest": "sha256:...",
+    "required_evidence": [
+      { "requirement_id": "human-approval",
+        "type": "https://example.net/e/authorization-receipt",
+        "max_age_sec": 300,
+        "status": "current" }
+    ],
+    "present_as": ["https://example.net/p/ep-aec-v1"],
+    "obtain_hints": [],
+    "retry_timing": {
+      "not_before": "2026-08-09T23:50:30Z",
+      "jitter_sec": 20
+    },
+    "expires_at": "2026-08-10T00:05:00Z"
+  }
+}
+]]></sourcecode>
+      <t>The Problem Details <tt>type</tt> and <tt>title</tt> MUST have the
+      values shown above. The HTTP status code and the optional
+      <tt>status</tt> member MUST both be 403. The core challenge MUST appear
+      in the <tt>evidence_challenge</tt> extension member. Human-readable
+      <tt>detail</tt> text is advisory and MUST NOT be parsed for protocol
+      semantics.</t>
+      <t>The origin server MUST send <tt>Cache-Control: no-store</tt>. A
+      generic intermediary can still transform an HTTP response, so a client
+      MUST validate the Problem Details object and the authenticated origin
+      before acting on hints or presenting evidence.</t>
+      <t>When the core challenge contains <tt>retry_timing</tt>, the origin
+      server SHOULD send a <tt>Retry-After</tt> field as defined by
+      <xref target="RFC9110"/>. Its HTTP-date or delay-seconds value MUST NOT
+      permit a follow-up request earlier than <tt>not_before</tt>. If the
+      header and core member identify different lower bounds, a client MUST
+      use the later bound and then apply <tt>jitter_sec</tt>. Retry-After does
+      not carry the jitter value and does not change the challenge expiry,
+      authorize the action, promise capacity or acceptance, or make a retry
+      safe after an uncertain effect.</t>
+      <section anchor="oauth-non-substitution-case">
+        <name>OAuth Non-Substitution Conformance Case</name>
+        <t>A protected resource requires a transaction-specific OAuth grant.
+        The presenter supplies a valid AE-CHALLENGE response but no native
+        transaction-bound access token. The protected resource
+        <bcp14>MUST</bcp14> refuse the action. It <bcp14>MUST NOT</bcp14> treat
+        the AE challenge identifier or nonce as the OAuth transaction
+        identifier, and it <bcp14>MUST NOT</bcp14> report the evidence
+        presentation as satisfying the native grant requirement. The case
+        passes only when the protected resource continues the native OAuth
+        flow or refuses.</t>
+      </section>
+    </section>
+
+    <section anchor="dmsc-profile">
+      <name>Informative DMSC Gateway Profile</name>
+      <t>Agent gateways can carry the transport-neutral challenge during
+      federation or handoff. The receiving gateway is the relying party: it
+      derives the exact action, applies its own trust anchors and policy, and
+      issues a challenge when evidence is missing, stale, or unverifiable.
+      The sending gateway or agent can obtain evidence and return a new
+      presentation using a DMSC-defined extension point or error carrier.</t>
+      <t>If the receiving gateway's required next step is a native OAuth
+      transaction grant, the DMSC carrier preserves that native challenge
+      rather than wrapping it as AE-CHALLENGE. A DMSC application profile can
+      carry both only under the explicit composition rules in
+      <xref target="oauth-boundary"/>.</t>
+      <t>If a gateway rewrites or translates the proposed action, the next
+      gateway re-evaluates that locally derived action and, when necessary,
+      issues its own binding. The prior gateway's action digest does not
+      survive the rewrite as the receiving gateway's binding. Any claim that
+      the two actions are equivalent requires a separately defined mapping or
+      transformation proof.</t>
+      <t>When a receiving gateway refuses an action because required
+      authorization evidence is missing, stale, or unverifiable, it may
+      return a structured evidence challenge identifying the exact action,
+      outstanding evidence requirements, applicable freshness or status
+      constraints, and supported presentation profiles. The challenge does
+      not authorize the action or transfer admission ownership; conserved
+      admission across gateway boundaries remains the separate requirement
+      described in Section 7.8 of the proposed next revision of
+      <xref target="DMSC-GAPS"/>.</t>
+      <t>In particular, AE-CHALLENGE does not prevent Gateway A and Gateway B
+      from admitting the same single-use right. It does not copy, fence, or
+      relinquish consumption state and does not establish which gateway owns
+      admission during a partition. The separate handoff property is not a
+      race to decide which gateway admitted first; it is an invariant that
+      committed capacity is not over-allocated under any interleaving of
+      admissions and releases. A DMSC handoff profile MUST solve that property
+      separately. If the receiving gateway cannot establish the
+      required exclusivity, its safe result is refusal or indeterminate, not
+      acceptance based on the challenge.</t>
+      <section anchor="dmsc-case">
+        <name>Gateway Conformance Case</name>
+        <t>Gateway A forwards a proposed action to Gateway B. Gateway B derives
+        the exact action under its pinned action profile and refuses because a
+        current approval artifact is missing. B returns an AE-CHALLENGE bound
+        to B's action digest and local evidence requirement. A obtains and
+        presents the artifact. B verifies it under B's trust anchors, matches
+        it to the same action, and reevaluates B's policy. The case passes only
+        if A never treats the challenge as authorization and B refuses an
+        action-digest mismatch, stale status, replayed nonce, or unsupported
+        presentation profile.</t>
+        <t>A second case attempts concurrent admission of one single-use right
+        at both gateways. AE-CHALLENGE alone MUST NOT be reported as passing
+        that case. The case passes only when a separate conserved-admission
+        mechanism establishes exclusivity, or when the receiving gateway
+        refuses or returns indeterminate because exclusivity cannot be
+        established.</t>
+      </section>
+    </section>
+
+    <section anchor="security">
+      <name>Security Considerations</name>
+      <t><strong>Challenge forgery and evidence exfiltration.</strong> A
+      forged challenge cannot authorize an action, but it can redirect a
+      presenter, induce unnecessary approval work, or solicit sensitive
+      evidence. Presenters MUST authenticate the relying party and audience
+      before following obtain hints or disclosing evidence. A bare JSON object
+      copied outside its authenticated carrier has no origin authenticity.</t>
+      <t><strong>Action substitution.</strong> The relying party computes the
+      challenge action digest from the action it would execute and recomputes
+      that binding before admission. A digest supplied by the presenter or an
+      action profile selected by the presenter defeats the purpose of the
+      protocol.</t>
+      <t><strong>Replay and state exhaustion.</strong> Stateful issuance binds
+      the complete body before exposure; self-describing issuance defers
+      storage but still requires an atomic replay claim before evidence
+      evaluation. An attacker can provoke refusals cheaply or consume a
+      structurally valid challenge. Aggregate and scoped bounds, short
+      expiries, authentication where available, and rate limits are therefore
+      required operational controls. Exhaustion or replay-store uncertainty
+      fails closed. Live replay state is never evicted to make room for new
+      work. Hard-cap capacity is reserved before evidence verification so an
+      attacker cannot force expensive signature or status work after the state
+      budget is exhausted.</t>
+      <t><strong>Replica consistency.</strong> Per-process replay caches permit
+      two verifier replicas to accept the same nonce. Verifiers for one issuer
+      need one atomic replay domain or an exclusive deterministic shard.
+      During partition or store failure they refuse rather than create local
+      replacement state. Only the owning shard's authoritative already-claimed
+      result is replay; routing failure is unavailability and is not relabeled
+      as attacker replay.</t>
+      <t><strong>Retry synchronization and load amplification.</strong> A
+      precise challenge tells a presenter how to correct a request, so a
+      population receiving similar refusals can retry in a synchronized burst.
+      An issuer under pressure SHOULD combine recipient-specific retry timing,
+      a non-zero jitter interval, admission control, and rate limiting. A
+      presenter SHOULD retain exponential backoff or equivalent local load
+      control even when a challenge supplies a lower bound. Timing guidance
+      paces only a new evidence presentation and MUST NOT be interpreted as
+      evidence satisfaction, authorization, or a promise that capacity or
+      admission will exist after <tt>not_before</tt>.</t>
+      <t><strong>Information disclosure.</strong> Evidence requirements,
+      policy identifiers, action profiles, and obtain hints can reveal
+      sensitive policy structure. A relying party SHOULD disclose only the
+      minimum information needed for remediation. The HTTP binding requires
+      <tt>Cache-Control: no-store</tt>. When a hard cap is binding, the relying
+      party discloses no requirements, obtain hints, or evidence-sufficiency
+      details. Returning a stateless hint in that state would turn overload
+      handling into a policy oracle.</t>
+      <t><strong>Stale facts and uncertain effects.</strong> A satisfied
+      challenge proves only that the relying party's evidence requirement was
+      met at evaluation time. It does not prove that external facts remain
+      true, that an action executed, or that an uncertain action is safe to
+      retry. Status rechecking, execution custody, effect observation, and
+      reconciliation remain separate controls.</t>
+      <t><strong>Gateway split brain.</strong> An authenticated challenge from
+      a receiving gateway does not transfer a single-use authorization or its
+      consumption ledger. Implementations MUST NOT claim cross-gateway
+      double-admission prevention merely because both gateways implement this
+      challenge.</t>
+    </section>
+
+    <section anchor="iana">
+      <name>IANA Considerations</name>
+      <t>IANA is requested to add the following entry to the "HTTP Problem
+      Types" registry established by <xref target="RFC9457"/>. That registry
+      uses the Specification Required policy defined by
+      <xref target="RFC8126"/>; this request does not require IETF Review or
+      Standards Action.</t>
+      <dl>
+        <dt>Type URI:</dt>
+        <dd>https://iana.org/assignments/http-problem-types#ae-required</dd>
+        <dt>Title:</dt>
+        <dd>Authorization Evidence Required</dd>
+        <dt>Recommended HTTP status code:</dt>
+        <dd>403</dd>
+        <dt>Reference:</dt>
+        <dd>This document.</dd>
+      </dl>
+      <t>This revision withdraws the earlier request for a new
+      <tt>application/authorization-evidence-challenge+json</tt> media type.
+      The HTTP binding reuses the registered
+      <tt>application/problem+json</tt> media type. Non-HTTP bindings define
+      their own carriage without changing the core data model.</t>
+    </section>
+
+    <section anchor="open-questions">
+      <name>Interoperability Questions for Review</name>
+      <t>This revision resolves the transport layering, HTTP status and media
+      type, gateway-ownership boundary, acquisition-protocol coupling, retry
+      synchronization, retry criticality, bounded replay state, and per-hop
+      binding questions raised through revision -05. It also resolves the
+      ordering of hard-cap enforcement before evidence evaluation and the
+      distinction between authoritative replay and owner unavailability.
+      Review is requested on
+      the following remaining choices:</t>
+      <ul>
+        <li>Which Agent2Agent and AgentProto error carriers can preserve the
+        complete challenge, authenticated issuer, audience, and retry timing,
+        and whether either protocol needs an additional attempt identifier.</li>
+        <li>Whether a DMSC gateway profile should carry the core object
+        directly or reference it by an authenticated, digest-bound URI.</li>
+        <li>Which application profiles, if any, need both a native OAuth
+        transaction challenge and an AE-CHALLENGE, and how those profiles
+        should expose the two independent replay domains.</li>
+      </ul>
+    </section>
+
+    <section anchor="acknowledgments">
+      <name>Acknowledgments</name>
+      <t>Thanks to Sumit P. Ahuja for identifying synchronized retry and load
+      amplification as a consequence of precise challenge guidance, for
+      correcting retry criticality and non-promissory timing semantics, and
+      for identifying refusal-path state exhaustion, cap-before-verification
+      ordering, policy-oracle risk under load, and the distinction between an
+      authoritative replay result and failure to reach the owning shard.
+      Thanks to Guigui Wang for
+      implementation feedback on structured error payloads, per-hop action
+      rebinding, and the separation of capability discovery from local
+      authority. Thanks to Henri Sirkkavaara for review of replay ordering,
+      concurrent-presentation behavior, diagnostic ordering, and portable
+      identifier semantics.</t>
+    </section>
+
+    <section anchor="changes">
+      <name>Changes since -05</name>
+      <ul>
+        <li>Requires every applicable hard cap to bind through an atomic
+        reservation or debit before native evidence verification and local
+        policy evaluation.</li>
+        <li>Makes a binding capacity refusal dominant over evidence
+        insufficiency and prohibits follow-up challenges, stateless requirement
+        lists, obtain hints, and other policy detail on that path.</li>
+        <li>Requires deterministic-shard profiles to derive the owning replay
+        shard from issuer-protected challenge state.</li>
+        <li>Restricts replay classification to an authoritative owner result
+        that the exact registered body was already claimed; owner routing
+        failure or uncertainty is temporary unavailability.</li>
+        <li>Adds cap-first, no-policy-oracle, and owner-routing conformance
+        cases, and tightens the HTTP 503 mapping accordingly.</li>
+      </ul>
+    </section>
+  </middle>
+
+  <back>
+    <references>
+        <name>Normative References</name>
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml"/>
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.3339.xml"/>
+        <reference anchor="RFC3986" target="https://www.rfc-editor.org/info/rfc3986">
+          <front>
+            <title>Uniform Resource Identifier (URI): Generic Syntax</title>
+            <author fullname="Tim Berners-Lee"/>
+            <author fullname="Roy T. Fielding"/>
+            <author fullname="Larry Masinter"/>
+            <date year="2005" month="January"/>
+          </front>
+          <seriesInfo name="STD" value="66"/>
+          <seriesInfo name="RFC" value="3986"/>
+          <seriesInfo name="DOI" value="10.17487/RFC3986"/>
+        </reference>
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8126.xml"/>
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"/>
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8259.xml"/>
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.9110.xml"/>
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.9457.xml"/>
+    </references>
+    <references>
+        <name>Informative References</name>
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.9470.xml"/>
+        <reference anchor="OAUTH-TXN-CHALLENGE" target="https://datatracker.ietf.org/doc/draft-rosomakho-oauth-txn-challenge/">
+          <front>
+            <title>OAuth Transaction Authorization Challenge</title>
+            <author fullname="Yaroslav Rosomakho"><organization>Zscaler</organization></author>
+            <author fullname="Brian Campbell"><organization>Ping Identity</organization></author>
+            <author fullname="Karl McGuinness"><organization>Independent</organization></author>
+            <author fullname="Pieter Kasselman"><organization>Defakto Security</organization></author>
+            <date year="2026" month="June" day="25"/>
+          </front>
+          <seriesInfo name="Internet-Draft" value="draft-rosomakho-oauth-txn-challenge-00"/>
+        </reference>
+        <reference anchor="KLRC" target="https://datatracker.ietf.org/doc/draft-klrc-aiagent-auth/">
+          <front>
+            <title>AI Agent Authentication and Authorization</title>
+            <author fullname="Pieter Kasselman"/>
+            <author fullname="Jean-Francois Lombardo"/>
+            <author fullname="Yaroslav Rosomakho"/>
+            <author fullname="Brian Campbell"/>
+            <author fullname="Nick Steele"/>
+            <author fullname="Aaron Parecki"/>
+            <date year="2026" month="July" day="9"/>
+          </front>
+          <seriesInfo name="Internet-Draft" value="draft-klrc-aiagent-auth-03"/>
+        </reference>
+        <reference anchor="DMSC-GAPS" target="https://datatracker.ietf.org/doc/draft-dunbar-dmsc-gw-scenarios-gap-analysis/">
+          <front>
+            <title>Deployment Scenarios and Gap Analysis for AI Agent Gateway</title>
+            <author fullname="Linda Dunbar"/>
+            <author fullname="YiFei Wang"/>
+            <author fullname="Iman Schrock"/>
+            <author fullname="Bing Liu"/>
+            <date year="2026" month="August"/>
+          </front>
+          <seriesInfo name="Internet-Draft" value="draft-dunbar-dmsc-gw-scenarios-gap-analysis-03"/>
+        </reference>
+        <reference anchor="CAID" target="https://datatracker.ietf.org/doc/draft-schrock-canonical-action-identifier/">
+          <front>
+            <title>The Canonical Action Identifier (CAID)</title>
+            <author fullname="Iman Schrock"/>
+            <date year="2026" month="August"/>
+          </front>
+          <seriesInfo name="Internet-Draft" value="draft-schrock-canonical-action-identifier-02"/>
+        </reference>
+        <reference anchor="AEB" target="https://datatracker.ietf.org/doc/draft-schrock-action-evidence-boundary/">
+          <front>
+            <title>The Action Evidence Boundary for Consequential Agent Effects</title>
+            <author fullname="Iman Schrock"/>
+            <date year="2026" month="August"/>
+          </front>
+          <seriesInfo name="Internet-Draft" value="draft-schrock-action-evidence-boundary-03"/>
+        </reference>
+        <reference anchor="BCR" target="https://datatracker.ietf.org/doc/draft-schrock-ep-bounded-capability-receipts/">
+          <front>
+            <title>Bounded Capability Receipts and Durable Spend Control for Agent Actions</title>
+            <author fullname="Iman Schrock"/>
+            <date year="2026" month="August"/>
+          </front>
+          <seriesInfo name="Internet-Draft" value="draft-schrock-ep-bounded-capability-receipts-03"/>
+        </reference>
+        <reference anchor="AEC" target="https://datatracker.ietf.org/doc/draft-schrock-ep-authorization-evidence-chain/">
+          <front>
+            <title>Authorization Evidence Chains: Composing Heterogeneous Agent-Action Evidence (EP-AEC)</title>
+            <author fullname="Iman Schrock"/>
+            <date year="2026" month="August"/>
+          </front>
+          <seriesInfo name="Internet-Draft" value="draft-schrock-ep-authorization-evidence-chain-05"/>
+        </reference>
+        <reference anchor="AUTH-RECEIPTS" target="https://datatracker.ietf.org/doc/draft-schrock-ep-authorization-receipts/">
+          <front>
+            <title>Authorization Receipts for High-Risk Agent Actions</title>
+            <author fullname="Iman Schrock"/>
+            <date year="2026" month="August" day="9"/>
+          </front>
+          <seriesInfo name="Internet-Draft" value="draft-schrock-ep-authorization-receipts-11"/>
+        </reference>
+    </references>
+
+    <section anchor="related-work">
+      <name>Relationship to Existing Mechanisms</name>
+      <t>CAID <xref target="CAID"/> is one mechanism for deriving and mapping
+      exact material actions. AEB <xref target="AEB"/> defines executor-side
+      evidence verification, refusal, and one-time consumption. Bounded
+      Capability Receipts <xref target="BCR"/> define durable single-domain
+      reservation and consumption. AEC <xref target="AEC"/> is one possible
+      presentation profile. None is required by the core challenge, and the
+      challenge does not extend any of them across independently operated
+      admission domains.</t>
+      <t>OAuth Transaction Authorization Challenge
+      <xref target="OAUTH-TXN-CHALLENGE"/> supplies the OAuth-native
+      choreography and transaction-bound grant that this document explicitly
+      does not define. The KLRC architecture <xref target="KLRC"/> describes
+      broader agent authentication and authorization requirements, including
+      human-in-the-loop and externalized authorization patterns. Authorization
+      Receipts <xref target="AUTH-RECEIPTS"/> are one possible portable human-
+      evidence type that an AE-CHALLENGE can request; neither the receipt nor
+      AE-CHALLENGE replaces a native OAuth grant or a relying party's final
+      policy decision.</t>
+    </section>
+
+    <section anchor="impl">
+      <name>Implementation Status</name>
+      <t>The EMILIA Protocol repository contains a same-team reference
+      implementation of the AE-CHALLENGE-v1 core lifecycle, including
+      relying-party-derived action binding, policy-derived requirements,
+      durable body-bound registration, single-use consumption, expiry,
+      follow-up challenges, and action-swap refusal. Revision -03 added a
+      serializer and parser for the RFC 9457 HTTP binding and tests that pin
+      status 403, <tt>application/problem+json</tt>,
+      <tt>Cache-Control: no-store</tt>, and the
+      <tt>evidence_challenge</tt> extension.</t>
+      <t>Revision -04 specifies retry timing, per-hop rebinding, discovery
+      separation, carrier semantics, portable absolute-URI identifiers, and
+      action-before-consumption replay ordering. These additions are based in
+      part on external implementer review, including experience with structured
+      error payloads and per-verifier decision bindings. They are not yet
+      implemented by the same-team reference implementation and are not
+      claimed as an independent implementation of this specification.</t>
+      <t>Revision -05 adds optional self-describing issuance, mandatory state
+      bounds and cap behavior, authoritative replay-domain requirements, and
+      state-exhaustion conformance cases. The same-team implementation uses
+      durable stateful issuance and atomic consumption across workers and
+      restarts, but does not yet implement the -05 configurable cap behavior
+      or self-describing issuance path. No implementation claim is made for
+      those additions.</t>
+      <t>Revision -06 adds binding cap-before-verification ordering,
+      no-requirements disclosure while a hard cap is binding, and an explicit
+      distinction between an authoritative already-claimed replay result and
+      inability to reach the owning shard. These requirements and their
+      conformance cases are not yet implemented by the same-team reference
+      implementation, and no implementation claim is made for them.</t>
+      <t>The OAuth boundary and non-substitution case in revision -05 are
+      normative text and conformance requirements. The same-team reference
+      implementation does not convert an AE-CHALLENGE into an OAuth challenge
+      or grant, and no such conversion is planned. It does not yet implement a
+      composed application profile carrying both mechanisms.</t>
+      <t>This is same-team implementation evidence. No independent
+      implementation or interoperability is claimed. The implementation does
+      not yet provide a DMSC carrier or conserved-admission mechanism. Its
+      current local evidence and presentation identifiers are not the absolute
+      URIs required by this revision.</t>
+    </section>
+  </back>
+</rfc>

--- a/standards/staged/NEXT-AE-CHALLENGE-06/VALIDATION.md
+++ b/standards/staged/NEXT-AE-CHALLENGE-06/VALIDATION.md
@@ -20,6 +20,10 @@ Validated on 2026-08-10 against
   platform-specific skips).
 - `npm run build`: PASS. The existing unused-eslint-disable warnings remain
   warnings and are unrelated to this packet.
+- `TLA2TOOLS_JAR=<checksum-verified v1.7.4 jar> npm run
+  check:security-case`: PASS, 35 executable claims over 259 hashed evidence
+  files. The jar matched the repository-pinned SHA-256
+  `936a262061c914694dfd669a543be24573c45d5aa0ff20a8b96b23d01e050e88`.
 - Revision -06 does not claim that the reference implementation already
   supplies the new configurable capacity-reservation or replay-shard routing
   interfaces.

--- a/standards/staged/NEXT-AE-CHALLENGE-06/VALIDATION.md
+++ b/standards/staged/NEXT-AE-CHALLENGE-06/VALIDATION.md
@@ -1,0 +1,29 @@
+# Validation record
+
+Validated on 2026-08-10 against
+`UPLOAD-THIS/draft-schrock-ae-challenge-06.xml`.
+
+- `xmllint --noout`: PASS.
+- `xml2rfc 3.34.0 --text` and `--html`: PASS.
+- `idnits 3.1.0 -m submission`: PASS, no nits found.
+- `node scripts/check-ae-challenge-06.mjs`: validates the cap-first ordering,
+  binding capacity reservation, no-policy-oracle response, authoritative owner
+  replay classification, HTTP 503 mapping, retained renderings, checksums, and
+  immutable published -05 source.
+- `npx vitest run tests/evidence-challenge.test.ts
+  tests/evidence-challenge-durable.test.ts`: PASS, 44 of 44 tests.
+- `node formal/check-evidence-challenge-lifecycle.mjs`: PASS, including 1,024
+  sequential lifecycle states and the listed restart and concurrency checks.
+  That existing model does not establish the new -06 capacity-reservation or
+  replay-shard routing requirements.
+- `npm run test:run`: PASS, 8,865 tests across 533 files (8,762 passed and 103
+  platform-specific skips).
+- `npm run build`: PASS. The existing unused-eslint-disable warnings remain
+  warnings and are unrelated to this packet.
+- Revision -06 does not claim that the reference implementation already
+  supplies the new configurable capacity-reservation or replay-shard routing
+  interfaces.
+- `SHA256SUMS.txt` pins the upload XML and both retained renderings.
+
+The immutable published -05 XML SHA-256 is
+`77fce83124c69fbd1cd5b45fb13aba64d00a2ffdd4f17c4610f6ace895a8106b`.


### PR DESCRIPTION
## Summary
- require binding capacity reservation before native evidence and policy evaluation
- return no challenge or policy hints when a hard cap controls the refusal
- distinguish authoritative owner replay from owner-routing unavailability
- add revision-pinned publication packet and focused checker
- repair the stale governed README test count

## Verification
- xmllint and xml2rfc 3.34.0 clean; clean rebuild byte-identical
- idnits 3.1.0 submission mode: no nits
- focused AE Challenge tests: 44/44
- lifecycle bounded model: PASS, 1,024 states plus restart/concurrency checks
- full Vitest: 8,865 tests across 533 files
- production Next.js build: PASS
- public-conformance and staged-standards gates: PASS
- security case with checksum-pinned TLC v1.7.4: PASS, 35 claims / 259 files

Revision -06 explicitly does not claim that the reference implementation already implements the new capacity-reservation or replay-shard interfaces.