### PR TITLE
fix(ot): harden command transport binding

### DIFF
--- a/docs/standards-engagement/OT-COMMAND-TRANSPORT-BINDING-OUTLINE.md
+++ b/docs/standards-engagement/OT-COMMAND-TRANSPORT-BINDING-OUTLINE.md
@@ -32,12 +32,12 @@ other autonomous safety actions MUST NOT depend on this binding.
    correlation. A correlation-only field MUST NOT change the action digest.
 3. The conduit MUST compare the observed action identifier with the action
    authorized by the evidence before forwarding the command.
-4. Inline and detached evidence carriage MUST provide equivalent action
-   agreement, evidence verification, and consumption properties. They do not
-   provide request-instance binding the same way: inline carriage depends on
-   the authenticated channel, while detached carriage depends on a
+4. Each binding MUST be evaluated only under its pinned transport encoding and
+   request-instance-binding profile. Inline carriage depends on the
+   authenticated channel, while detached carriage depends on a
    conduit-established attempt reference bound to authenticated request or
-   session context. An unbound reference is not proof by itself.
+   session context. An unbound reference is not proof by itself. This document
+   makes no equivalence claim across transports or carriage modes.
 5. A detached-evidence binding MUST resolve evidence by both a distinct attempt
    reference and the collision-resistant digest of the exact action. The action
    digest is not secret and MUST NOT be used as the request-instance key. Two
@@ -67,14 +67,18 @@ those properties.
 
 ## Initial binding profiles
 
+The Modbus TCP and DNP3 v1 bindings below are native-encoding profiles, not
+effect-normalization profiles. Authority for one native encoding does not admit
+another encoding unless a later profile defines that normalization explicitly.
+
 ### Modbus TCP transport binding
 
 #### Applicability
 
-This profile binds a Modbus TCP write to holding registers, function code 0x06
-(Write Single Register) and function code 0x10 (Write Multiple Registers).
-Modbus carries no envelope space in either function, so evidence is detached in
-both cases.
+This native-encoding profile binds a Modbus TCP write to holding registers,
+function code 0x06 (Write Single Register) and function code 0x10 (Write
+Multiple Registers). Modbus carries no envelope space in either function, so
+evidence is detached in both cases.
 
 Modbus TCP supplies no device authentication, no message integrity, and no
 replay protection. The conduit therefore establishes every fact about WHO and
@@ -117,9 +121,10 @@ address in the digest.
 The unit identifier is both a material field and a routing field. Behind a
 serial gateway it selects the physical device, and the conduit has already
 established which device its link context refers to. The conduit MUST refuse a
-request whose wire unit identifier does not agree with the unit mapped to its
-established device context, and MUST refuse it before any evidence lookup.
-Resolving the disagreement in favour of either source is a conformance failure.
+request if that context has no conduit-owned unit mapping or if the wire unit
+identifier does not agree with the mapped unit, and MUST refuse it before any
+evidence lookup. Resolving a missing or inconsistent mapping in favour of the
+sender is a conformance failure.
 
 #### Encoding scope
 
@@ -149,11 +154,16 @@ A conforming implementation demonstrates that:
 3. changing only the MBAP transaction identifier yields the same action
    identifier;
 4. a 4xxxxx label never appears in the digest input;
-5. a wire unit identifier inconsistent with conduit device context is refused
-   before evidence lookup;
+5. a missing conduit-owned unit mapping, or a wire unit identifier inconsistent
+   with that mapping, is refused before evidence lookup;
 6. function code 0x06 and function code 0x10 with quantity one yield different
-   action identifiers; and
-7. a request whose MBAP protocol identifier is non-zero, or whose length field
+   action identifiers;
+7. a function code 0x10 quantity-one request round-trips through its native
+   encoder and decoder;
+8. a function code 0x10 request with quantity outside 1 through 123, byte count
+   other than twice the quantity, or frame length inconsistent with byte count
+   is refused as malformed; and
+9. a request whose MBAP protocol identifier is non-zero, or whose length field
    disagrees with the function code, is refused as malformed rather than
    admitted.
 
@@ -161,9 +171,9 @@ A conforming implementation demonstrates that:
 
 #### Applicability
 
-This profile binds DNP3 Control Relay Output Block operations, object group 12
-variation 1, carried by application function DIRECT_OPERATE (5) and
-DIRECT_OPERATE_NR (6).
+This native-encoding profile binds DNP3 Control Relay Output Block operations,
+object group 12 variation 1, carried by application function DIRECT_OPERATE
+(5) and DIRECT_OPERATE_NR (6).
 
 SELECT followed by OPERATE (functions 3 and 4) is outside this profile. A
 profile adding it MUST bind both phases to a single authorisation and MUST
@@ -183,7 +193,7 @@ digest rather than binding the first.
 | material | application function, object group, variation, object index, control octet, CROB operation count, on-time, off-time |
 | conduit context | site, device, outstation address |
 | correlation only | application control sequence number |
-| fixed or derived | qualifier code, qualifier object count, CROB status field |
+| fixed or derived | application control FIR 1, FIN 1, CON 0, UNS 0; qualifier code 0x17; qualifier object count 1; CROB status field 0 |
 
 The outstation address is conduit context rather than a decoded field. An
 application fragment begins at the application control octet and carries no
@@ -196,7 +206,7 @@ part of the physical act. It is the DNP3 analogue of the Modbus transaction
 identifier and MUST NOT contribute to the digest.
 
 The CROB status field is a response field, zero in a request, and MUST NOT be
-bound.
+bound. A non-zero request status MUST be refused as malformed.
 
 #### The control octet
 
@@ -223,6 +233,15 @@ silently bring unbound timing into effect.
 The CROB operation count MUST be bound and MUST be named distinctly from the
 qualifier object count. The two are unrelated: the first is how many times the
 point operates, the second is how many objects the request carries.
+
+#### Encoding scope
+
+This v1 profile admits only qualifier `0x17`, qualifier object count one, and a
+one-octet object index in the range 0 through 255. Other qualifier, count, or
+index encodings are outside this profile even if they could identify a similar
+control object. A request fragment MUST have FIR and FIN set and CON and UNS
+clear. Any other application-control flag combination is malformed for this
+single-fragment request profile.
 
 #### Evidence carriage
 
@@ -258,9 +277,12 @@ A conforming implementation demonstrates that:
    identifier;
 5. a SELECT or OPERATE function code is refused as out of profile rather than
    admitted as a direct operate;
-6. a request carrying more than one control object is refused as out of profile;
-   and
-7. a DIRECT_OPERATE_NR request that is forwarded terminates `INDETERMINATE`, its
+6. a request whose qualifier is not 0x17, whose qualifier object count is not
+   one, or whose index is not representable in one octet is refused as out of
+   profile;
+7. a request with FIN clear, CON set, UNS set, or non-zero request status is
+   refused as malformed; and
+8. a DIRECT_OPERATE_NR request that is forwarded terminates `INDETERMINATE`, its
    authorisation stays consumed, and no retry is issued.
 
 ### OPC-UA Call
@@ -288,6 +310,8 @@ A conforming implementation demonstrates at least the following:
   count, on-time, or off-time changes the action identifier;
 - changing only the DNP3 application sequence changes the fragment bytes but
   not the action identifier;
+- a DNP3 request with FIN clear, CON set, UNS set, or non-zero request status is
+  refused as malformed;
 - two authorizations for the same exact action remain separately addressable by
   distinct conduit attempt references;
 - DNP3 DIRECT_OPERATE_NR enters the device and terminates `INDETERMINATE`;
@@ -302,11 +326,12 @@ Pinned experimental vectors and executable checks are in
 
 ## Current implementation status
 
-The repository contains synthetic encoders and decoders for the three command
-shapes and executable tests for the requirements above. They are not certified
-protocol stacks and have not been exercised against a live PLC, RTU, DCS, or
-safety system. Independent reproduction against one production-quality stack
-is the next interoperability gate.
+The repository contains synthetic encoders and decoders for Modbus FC 0x06,
+Modbus FC 0x10, DNP3 CROB direct operate, and OPC-UA Call, plus executable tests
+for the requirements above. They are not certified protocol stacks and have
+not been exercised against a live PLC, RTU, DCS, or safety system. Independent
+reproduction against one production-quality stack is the next interoperability
+gate.
 
 ## Source documents
 

--- a/examples/ot-command-binding-v1/README.md
+++ b/examples/ot-command-binding-v1/README.md
@@ -18,7 +18,7 @@ Control protocols differ in whether they can carry an authorization at all.
 | Transport | What it can carry | What it cannot carry | Binding mode |
 | --- | --- | --- | --- |
 | OPC-UA | Request structures have an extension slot, so an authorization travels with the call. In this example the receipt rides in the request header's extension object. | Nothing relevant. | Inline |
-| Modbus TCP | Unit id, function code, protocol address, value. That is the whole write. | Anything else. The frame this example encodes is 12 octets and every one of them is a protocol-defined field; the MBAP length field pins the rest of the frame at 6 octets, so there is no optional field to grow into. | Out of band, keyed by a conduit attempt reference plus the command digest |
+| Modbus TCP | Unit id, function code, protocol address, and function-defined write fields. That is the whole write. | Anything else. FC 0x06 is 12 octets; FC 0x10 is length-pinned by quantity and byte count. Every octet is protocol-defined, so there is no optional field to grow into. | Out of band, keyed by a conduit attempt reference plus the command digest |
 | DNP3 | A typed object in a typed object space. The control relay output block this example encodes is a fixed 11 octets inside an 18-octet application fragment. | Anything else. No octet of the fragment is free for an envelope. | Out of band, keyed by a conduit attempt reference plus the command digest |
 
 For Modbus and DNP3 the authorization cannot travel with the command, so it is
@@ -33,9 +33,10 @@ That only works if the digest is recomputable from what actually reached the
 wire. So every transport here has a decoder, and the enforcement point sits in
 front of the device: it decodes the frame it is about to forward, and derives
 the observed action from those bytes plus the link facts it owns because it
-terminates the connection (site and device, the Modbus unit-to-device mapping,
-and for DNP3 the outstation address, a data-link field). The observed action,
-never the requester's description of it,
+terminates the connection (site and device, the required Modbus unit-to-device
+mapping, and for DNP3 the outstation address, a data-link field). A missing or
+inconsistent Modbus unit mapping is refused before evidence lookup. The
+observed action, never the requester's description of it,
 is what the gate binds. `commands.mjs` exposes that as `commandDigest()`, which
 is `hashCanonical` from `@emilia-protocol/gate` — the same function the gate
 uses to record `observed_action_hash`, so the index key and the authorized
@@ -56,15 +57,19 @@ exactly as an out-of-band lookup for a different digest would be
 | 4. `unresolved-after-dispatch` | The command is accepted and dispatched, the PLC goes quiet, and the outcome is recorded as indeterminate. A blind retry is refused and the authorization does not return to the pool. Recovery is a new human authorization, not a retry. | `gate.run` throwing `EMILIA_GATE_TERMINAL_OUTCOME` with `outcome: 'indeterminate'`, the consumption store backend read directly, and the hash-chained evidence log |
 | 5. `spent-once` | Freshness and single-use are different properties. An authorization still inside its freshness window but already consumed is refused, and under a different name than one that is merely stale. | `gate.run` reasons `replay_refused` and `receipt_rejected:receipt_expired`, cross-checked by `verifyEmiliaReceipt` from `@emilia-protocol/require-receipt` |
 
-The pinned profile is intentionally encoding-scoped. Modbus FC 0x06 and FC
-0x10 with quantity one are different authorities even when they can have the
-same register effect. The Modbus action binds the zero-based protocol address;
-the familiar 4xxxxx register label is display metadata. The DNP3 action binds
-the application function, complete CROB control octet, operation count,
-on-time, and off-time. DIRECT_OPERATE_NR is modeled as `INDETERMINATE` after
-dispatch because it has no protocol acknowledgement. SELECT/OPERATE is outside
-this first profile; adding it requires one state machine for both phases and the
-arm timer.
+The Modbus and DNP3 authorities are explicitly scoped to their pinned native
+encoding profiles. Modbus FC 0x06 and FC 0x10 with quantity one are different
+authorities even when they can have the same register effect. FC 0x10 quantity
+one has its own native encode/decode vector, and malformed quantity or byte
+count is refused. The Modbus action binds the zero-based protocol address; the
+familiar 4xxxxx register label is display metadata. DNP3 v1 admits only
+qualifier `0x17`, object count one, and a one-octet object index from 0 through
+255. The DNP3 action binds the application function, complete CROB control
+octet, operation count, on-time, and off-time. Requests also require FIR and
+FIN set, CON and UNS clear, and status zero. DIRECT_OPERATE_NR is modeled as
+`INDETERMINATE` after dispatch because it has no protocol acknowledgement.
+SELECT/OPERATE is outside this first profile; adding it requires one state
+machine for both phases and the arm timer.
 
 Scene 4 is the one the Command Authority Envelope does not currently cover. The
 repository mechanism is `gate.run()` in `packages/gate/src/index.ts`. Once the
@@ -115,11 +120,10 @@ Author the `.mts` sources; the `.mjs` companions are generated by
   and permanent but not shared durable state; the gate is constructed with
   `allowEphemeralStore: true` for that reason. A deployed enforcement point
   requires a durable backend and drops that flag.
-- Inline and detached modes demonstrate equivalent action agreement,
-  verification, and consumption. They do not obtain request-instance binding
-  the same way: inline carriage relies on the authenticated channel, while
-  detached carriage relies on an attempt reference bound to the conduit's
-  authenticated request or session context. The synthetic context in this
-  example models that binding; it does not implement channel authentication.
+- Each transport is evaluated only under its pinned encoding and
+  request-instance-binding profile. No cross-transport equivalence is claimed
+  between inline OPC-UA carriage and detached Modbus or DNP3 evidence. The
+  synthetic context in this example models the required channel or conduit
+  binding; it does not implement channel authentication.
 - The issuer and approver keys are generated per run by the EG-1 harness. No
   real operator approved anything.

--- a/examples/ot-command-binding-v1/commands.mjs
+++ b/examples/ot-command-binding-v1/commands.mjs
@@ -44,15 +44,34 @@ export const TRANSPORT_PROFILES = Object.freeze({
     }),
     'modbus-tcp': Object.freeze({
         transport: 'modbus-tcp',
+        encoding_profile: Object.freeze({
+            id: 'EP-OT-MODBUS-TCP-WRITE-ENCODING-v1',
+            scope: 'native-encoding',
+            function_codes: Object.freeze([0x06, 0x10]),
+            normalization: 'none',
+        }),
         envelope_capacity: 'none',
         carries_authorization_inline: false,
         binding_mode: 'out-of-band-digest',
         extension_point: null,
         metadata_octets_available: 0,
-        why: 'A write is unit id, function code, register address, and value. Length is fixed by the function code; nothing else fits on the wire.',
+        why: 'A write is unit id, function code, register address, and function-defined write fields. Length is fixed by those fields; nothing else fits on the wire.',
     }),
     dnp3: Object.freeze({
         transport: 'dnp3',
+        encoding_profile: Object.freeze({
+            id: 'EP-OT-DNP3-CROB-DIRECT-OPERATE-ENCODING-v1',
+            scope: 'native-encoding',
+            object_header: Object.freeze({
+                qualifier: 0x17,
+                object_count: 1,
+                index_octets: 1,
+                index_min: 0,
+                index_max: 0xff,
+            }),
+            application_control_flags: Object.freeze({ FIR: 1, FIN: 1, CON: 0, UNS: 0 }),
+            request_status: 0,
+        }),
         envelope_capacity: 'fixed-object-space',
         carries_authorization_inline: false,
         binding_mode: 'out-of-band-digest',
@@ -192,11 +211,23 @@ export const BOUND_FIELDS = Object.freeze({
 // Modbus TCP
 // ---------------------------------------------------------------------------
 const MODBUS_FC_WRITE_SINGLE_REGISTER = 0x06;
+const MODBUS_FC_WRITE_MULTIPLE_REGISTERS = 0x10;
 /** Transaction id (2) + protocol id (2) + length (2) + unit id (1). */
 const MODBUS_MBAP_OCTETS = 7;
 /** Function code (1) + register address (2) + register value (2). */
 const MODBUS_FC06_PDU_OCTETS = 5;
-const MODBUS_ADU_OCTETS = MODBUS_MBAP_OCTETS + MODBUS_FC06_PDU_OCTETS;
+const MODBUS_FC06_ADU_OCTETS = MODBUS_MBAP_OCTETS + MODBUS_FC06_PDU_OCTETS;
+/** Function code (1) + address (2) + quantity (2) + byte count (1). */
+const MODBUS_FC16_FIXED_PDU_OCTETS = 6;
+function requireMappedModbusUnit(unitId, link) {
+    if (link?.unit_id === undefined) {
+        throw new TypeError('Modbus unit id mapping is required from conduit device context');
+    }
+    const mappedUnitId = requireSafeInt(link.unit_id, 'link.unit_id', 0, 247);
+    if (unitId !== mappedUnitId) {
+        throw new TypeError('Modbus unit id does not match conduit device context');
+    }
+}
 /**
  * Encode the Modbus TCP application data unit for a write-single-register.
  *
@@ -210,7 +241,7 @@ export function encodeModbusWriteRegister(action, { transactionId = 1 } = {}) {
     }
     const protocolAddress = requireSafeInt(action.protocol_address, 'protocolAddress', 0, 0xffff);
     requireSafeInt(transactionId, 'transactionId', 0, 0xffff);
-    const frame = Buffer.alloc(MODBUS_ADU_OCTETS);
+    const frame = Buffer.alloc(MODBUS_FC06_ADU_OCTETS);
     frame.writeUInt16BE(transactionId, 0); // MBAP transaction id
     frame.writeUInt16BE(0, 2); // MBAP protocol id
     frame.writeUInt16BE(6, 4); // MBAP length: unit id + 5-octet PDU
@@ -236,7 +267,7 @@ export function encodeModbusWriteRegister(action, { transactionId = 1 } = {}) {
  */
 export function decodeModbusWriteRegister(hex, link) {
     const frame = Buffer.from(requireString(hex, 'hex'), 'hex');
-    if (frame.length !== MODBUS_ADU_OCTETS)
+    if (frame.length !== MODBUS_FC06_ADU_OCTETS)
         throw new TypeError('unexpected Modbus ADU length');
     if (frame.readUInt16BE(2) !== 0)
         throw new TypeError('unexpected Modbus protocol id');
@@ -246,15 +277,88 @@ export function decodeModbusWriteRegister(hex, link) {
         throw new TypeError('unexpected Modbus function code');
     }
     const unitId = frame.readUInt8(6);
-    if (link?.unit_id !== undefined && unitId !== link.unit_id) {
-        throw new TypeError('Modbus unit id does not match conduit device context');
-    }
+    requireMappedModbusUnit(unitId, link);
     return modbusWriteRegisterAction({
         site: link?.site,
         device: link?.device,
         unitId,
         protocolAddress: frame.readUInt16BE(8),
         value: frame.readUInt16BE(10),
+    });
+}
+/** Encode a Modbus TCP FC 0x10 write-multiple-registers request. */
+export function encodeModbusWriteMultipleRegisters(action, { transactionId = 1 } = {}) {
+    if (action?.transport !== 'modbus-tcp'
+        || action?.function_code !== MODBUS_FC_WRITE_MULTIPLE_REGISTERS) {
+        throw new TypeError('encodeModbusWriteMultipleRegisters requires a modbus-tcp write-multiple-registers action');
+    }
+    if (!Array.isArray(action.values)) {
+        throw new TypeError('values must be an array');
+    }
+    const quantity = requireSafeInt(action.quantity, 'quantity', 1, 123);
+    if (action.values.length !== quantity) {
+        throw new TypeError('Modbus quantity does not match register values');
+    }
+    const byteCount = requireSafeInt(action.byte_count, 'byteCount', 2, 246);
+    if (byteCount !== quantity * 2) {
+        throw new TypeError('Modbus byte count does not match quantity');
+    }
+    const protocolAddress = requireSafeInt(action.protocol_address, 'protocolAddress', 0, 0xffff);
+    const unitId = requireSafeInt(action.unit_id, 'unitId', 0, 247);
+    requireSafeInt(transactionId, 'transactionId', 0, 0xffff);
+    const values = action.values.map((value, index) => (requireSafeInt(value, `values[${index}]`, 0, 0xffff)));
+    const frame = Buffer.alloc(MODBUS_MBAP_OCTETS + MODBUS_FC16_FIXED_PDU_OCTETS + byteCount);
+    frame.writeUInt16BE(transactionId, 0);
+    frame.writeUInt16BE(0, 2);
+    frame.writeUInt16BE(frame.length - 6, 4);
+    frame.writeUInt8(unitId, 6);
+    frame.writeUInt8(MODBUS_FC_WRITE_MULTIPLE_REGISTERS, 7);
+    frame.writeUInt16BE(protocolAddress, 8);
+    frame.writeUInt16BE(quantity, 10);
+    frame.writeUInt8(byteCount, 12);
+    values.forEach((value, index) => frame.writeUInt16BE(value, 13 + (index * 2)));
+    return Object.freeze({
+        transport: 'modbus-tcp',
+        hex: frame.toString('hex'),
+        octets: frame.length,
+        protocol_address: protocolAddress,
+        quantity,
+        byte_count: byteCount,
+        metadata_octets_available: frame.length - MODBUS_MBAP_OCTETS - MODBUS_FC16_FIXED_PDU_OCTETS - byteCount,
+        carries_authorization: false,
+    });
+}
+/** Decode a Modbus TCP FC 0x10 request into its encoding-scoped action. */
+export function decodeModbusWriteMultipleRegisters(hex, link) {
+    const frame = Buffer.from(requireString(hex, 'hex'), 'hex');
+    if (frame.length < MODBUS_MBAP_OCTETS + MODBUS_FC16_FIXED_PDU_OCTETS + 2) {
+        throw new TypeError('unexpected Modbus ADU length');
+    }
+    if (frame.readUInt16BE(2) !== 0)
+        throw new TypeError('unexpected Modbus protocol id');
+    if (frame.readUInt16BE(4) !== frame.length - 6) {
+        throw new TypeError('unexpected Modbus length field');
+    }
+    if (frame.readUInt8(7) !== MODBUS_FC_WRITE_MULTIPLE_REGISTERS) {
+        throw new TypeError('unexpected Modbus function code');
+    }
+    const quantity = requireSafeInt(frame.readUInt16BE(10), 'quantity', 1, 123);
+    const byteCount = frame.readUInt8(12);
+    if (byteCount !== quantity * 2) {
+        throw new TypeError('Modbus byte count does not match quantity');
+    }
+    if (frame.length !== MODBUS_MBAP_OCTETS + MODBUS_FC16_FIXED_PDU_OCTETS + byteCount) {
+        throw new TypeError('unexpected Modbus ADU length for byte count');
+    }
+    const unitId = frame.readUInt8(6);
+    requireMappedModbusUnit(unitId, link);
+    const values = Array.from({ length: quantity }, (_, index) => frame.readUInt16BE(13 + (index * 2)));
+    return modbusWriteMultipleRegistersAction({
+        site: link?.site,
+        device: link?.device,
+        unitId,
+        protocolAddress: frame.readUInt16BE(8),
+        values,
     });
 }
 // ---------------------------------------------------------------------------
@@ -319,6 +423,9 @@ export function decodeDnp3ControlRelay(hex, link) {
     const fragment = Buffer.from(requireString(hex, 'hex'), 'hex');
     if (fragment.length !== DNP3_FRAGMENT_OCTETS)
         throw new TypeError('unexpected DNP3 fragment length');
+    if ((fragment.readUInt8(0) & 0xf0) !== 0xc0) {
+        throw new TypeError('unexpected DNP3 application control for single-fragment request');
+    }
     const applicationFunction = fragment.readUInt8(1);
     if (applicationFunction !== DNP3_FC_DIRECT_OPERATE
         && applicationFunction !== DNP3_FC_DIRECT_OPERATE_NO_ACK) {
@@ -329,6 +436,9 @@ export function decodeDnp3ControlRelay(hex, link) {
     }
     if (fragment.readUInt8(4) !== 0x17 || fragment.readUInt8(5) !== 1) {
         throw new TypeError('unexpected DNP3 qualifier or object count');
+    }
+    if (fragment.readUInt8(17) !== 0) {
+        throw new TypeError('DNP3 request status must be zero');
     }
     return dnp3ControlRelayAction({
         site: link?.site,
@@ -417,6 +527,8 @@ export default {
     opcuaCallMethodAction,
     encodeModbusWriteRegister,
     decodeModbusWriteRegister,
+    encodeModbusWriteMultipleRegisters,
+    decodeModbusWriteMultipleRegisters,
     encodeDnp3ControlRelay,
     decodeDnp3ControlRelay,
     encodeOpcuaCall,

--- a/examples/ot-command-binding-v1/commands.mts
+++ b/examples/ot-command-binding-v1/commands.mts
@@ -44,15 +44,34 @@ export const TRANSPORT_PROFILES = Object.freeze({
   }),
   'modbus-tcp': Object.freeze({
     transport: 'modbus-tcp',
+    encoding_profile: Object.freeze({
+      id: 'EP-OT-MODBUS-TCP-WRITE-ENCODING-v1',
+      scope: 'native-encoding',
+      function_codes: Object.freeze([0x06, 0x10]),
+      normalization: 'none',
+    }),
     envelope_capacity: 'none',
     carries_authorization_inline: false,
     binding_mode: 'out-of-band-digest',
     extension_point: null,
     metadata_octets_available: 0,
-    why: 'A write is unit id, function code, register address, and value. Length is fixed by the function code; nothing else fits on the wire.',
+    why: 'A write is unit id, function code, register address, and function-defined write fields. Length is fixed by those fields; nothing else fits on the wire.',
   }),
   dnp3: Object.freeze({
     transport: 'dnp3',
+    encoding_profile: Object.freeze({
+      id: 'EP-OT-DNP3-CROB-DIRECT-OPERATE-ENCODING-v1',
+      scope: 'native-encoding',
+      object_header: Object.freeze({
+        qualifier: 0x17,
+        object_count: 1,
+        index_octets: 1,
+        index_min: 0,
+        index_max: 0xff,
+      }),
+      application_control_flags: Object.freeze({ FIR: 1, FIN: 1, CON: 0, UNS: 0 }),
+      request_status: 0,
+    }),
     envelope_capacity: 'fixed-object-space',
     carries_authorization_inline: false,
     binding_mode: 'out-of-band-digest',
@@ -235,11 +254,24 @@ export const BOUND_FIELDS = Object.freeze({
 // ---------------------------------------------------------------------------
 
 const MODBUS_FC_WRITE_SINGLE_REGISTER = 0x06;
+const MODBUS_FC_WRITE_MULTIPLE_REGISTERS = 0x10;
 /** Transaction id (2) + protocol id (2) + length (2) + unit id (1). */
 const MODBUS_MBAP_OCTETS = 7;
 /** Function code (1) + register address (2) + register value (2). */
 const MODBUS_FC06_PDU_OCTETS = 5;
-const MODBUS_ADU_OCTETS = MODBUS_MBAP_OCTETS + MODBUS_FC06_PDU_OCTETS;
+const MODBUS_FC06_ADU_OCTETS = MODBUS_MBAP_OCTETS + MODBUS_FC06_PDU_OCTETS;
+/** Function code (1) + address (2) + quantity (2) + byte count (1). */
+const MODBUS_FC16_FIXED_PDU_OCTETS = 6;
+
+function requireMappedModbusUnit(unitId: number, link: any): void {
+  if (link?.unit_id === undefined) {
+    throw new TypeError('Modbus unit id mapping is required from conduit device context');
+  }
+  const mappedUnitId = requireSafeInt(link.unit_id, 'link.unit_id', 0, 247);
+  if (unitId !== mappedUnitId) {
+    throw new TypeError('Modbus unit id does not match conduit device context');
+  }
+}
 
 /**
  * Encode the Modbus TCP application data unit for a write-single-register.
@@ -254,7 +286,7 @@ export function encodeModbusWriteRegister(action: any, { transactionId = 1 }: an
   }
   const protocolAddress = requireSafeInt(action.protocol_address, 'protocolAddress', 0, 0xffff);
   requireSafeInt(transactionId, 'transactionId', 0, 0xffff);
-  const frame = Buffer.alloc(MODBUS_ADU_OCTETS);
+  const frame = Buffer.alloc(MODBUS_FC06_ADU_OCTETS);
   frame.writeUInt16BE(transactionId, 0);   // MBAP transaction id
   frame.writeUInt16BE(0, 2);               // MBAP protocol id
   frame.writeUInt16BE(6, 4);               // MBAP length: unit id + 5-octet PDU
@@ -281,22 +313,105 @@ export function encodeModbusWriteRegister(action: any, { transactionId = 1 }: an
  */
 export function decodeModbusWriteRegister(hex: string, link: any): any {
   const frame = Buffer.from(requireString(hex, 'hex'), 'hex');
-  if (frame.length !== MODBUS_ADU_OCTETS) throw new TypeError('unexpected Modbus ADU length');
+  if (frame.length !== MODBUS_FC06_ADU_OCTETS) throw new TypeError('unexpected Modbus ADU length');
   if (frame.readUInt16BE(2) !== 0) throw new TypeError('unexpected Modbus protocol id');
   if (frame.readUInt16BE(4) !== 6) throw new TypeError('unexpected Modbus length field');
   if (frame.readUInt8(7) !== MODBUS_FC_WRITE_SINGLE_REGISTER) {
     throw new TypeError('unexpected Modbus function code');
   }
   const unitId = frame.readUInt8(6);
-  if (link?.unit_id !== undefined && unitId !== link.unit_id) {
-    throw new TypeError('Modbus unit id does not match conduit device context');
-  }
+  requireMappedModbusUnit(unitId, link);
   return modbusWriteRegisterAction({
     site: link?.site,
     device: link?.device,
     unitId,
     protocolAddress: frame.readUInt16BE(8),
     value: frame.readUInt16BE(10),
+  });
+}
+
+/** Encode a Modbus TCP FC 0x10 write-multiple-registers request. */
+export function encodeModbusWriteMultipleRegisters(
+  action: any,
+  { transactionId = 1 }: any = {},
+): any {
+  if (action?.transport !== 'modbus-tcp'
+      || action?.function_code !== MODBUS_FC_WRITE_MULTIPLE_REGISTERS) {
+    throw new TypeError('encodeModbusWriteMultipleRegisters requires a modbus-tcp write-multiple-registers action');
+  }
+  if (!Array.isArray(action.values)) {
+    throw new TypeError('values must be an array');
+  }
+  const quantity = requireSafeInt(action.quantity, 'quantity', 1, 123);
+  if (action.values.length !== quantity) {
+    throw new TypeError('Modbus quantity does not match register values');
+  }
+  const byteCount = requireSafeInt(action.byte_count, 'byteCount', 2, 246);
+  if (byteCount !== quantity * 2) {
+    throw new TypeError('Modbus byte count does not match quantity');
+  }
+  const protocolAddress = requireSafeInt(action.protocol_address, 'protocolAddress', 0, 0xffff);
+  const unitId = requireSafeInt(action.unit_id, 'unitId', 0, 247);
+  requireSafeInt(transactionId, 'transactionId', 0, 0xffff);
+  const values = action.values.map((value: any, index: number) => (
+    requireSafeInt(value, `values[${index}]`, 0, 0xffff)
+  ));
+  const frame = Buffer.alloc(MODBUS_MBAP_OCTETS + MODBUS_FC16_FIXED_PDU_OCTETS + byteCount);
+  frame.writeUInt16BE(transactionId, 0);
+  frame.writeUInt16BE(0, 2);
+  frame.writeUInt16BE(frame.length - 6, 4);
+  frame.writeUInt8(unitId, 6);
+  frame.writeUInt8(MODBUS_FC_WRITE_MULTIPLE_REGISTERS, 7);
+  frame.writeUInt16BE(protocolAddress, 8);
+  frame.writeUInt16BE(quantity, 10);
+  frame.writeUInt8(byteCount, 12);
+  values.forEach((value: number, index: number) => frame.writeUInt16BE(value, 13 + (index * 2)));
+  return Object.freeze({
+    transport: 'modbus-tcp',
+    hex: frame.toString('hex'),
+    octets: frame.length,
+    protocol_address: protocolAddress,
+    quantity,
+    byte_count: byteCount,
+    metadata_octets_available:
+      frame.length - MODBUS_MBAP_OCTETS - MODBUS_FC16_FIXED_PDU_OCTETS - byteCount,
+    carries_authorization: false,
+  });
+}
+
+/** Decode a Modbus TCP FC 0x10 request into its encoding-scoped action. */
+export function decodeModbusWriteMultipleRegisters(hex: string, link: any): any {
+  const frame = Buffer.from(requireString(hex, 'hex'), 'hex');
+  if (frame.length < MODBUS_MBAP_OCTETS + MODBUS_FC16_FIXED_PDU_OCTETS + 2) {
+    throw new TypeError('unexpected Modbus ADU length');
+  }
+  if (frame.readUInt16BE(2) !== 0) throw new TypeError('unexpected Modbus protocol id');
+  if (frame.readUInt16BE(4) !== frame.length - 6) {
+    throw new TypeError('unexpected Modbus length field');
+  }
+  if (frame.readUInt8(7) !== MODBUS_FC_WRITE_MULTIPLE_REGISTERS) {
+    throw new TypeError('unexpected Modbus function code');
+  }
+  const quantity = requireSafeInt(frame.readUInt16BE(10), 'quantity', 1, 123);
+  const byteCount = frame.readUInt8(12);
+  if (byteCount !== quantity * 2) {
+    throw new TypeError('Modbus byte count does not match quantity');
+  }
+  if (frame.length !== MODBUS_MBAP_OCTETS + MODBUS_FC16_FIXED_PDU_OCTETS + byteCount) {
+    throw new TypeError('unexpected Modbus ADU length for byte count');
+  }
+  const unitId = frame.readUInt8(6);
+  requireMappedModbusUnit(unitId, link);
+  const values = Array.from(
+    { length: quantity },
+    (_, index) => frame.readUInt16BE(13 + (index * 2)),
+  );
+  return modbusWriteMultipleRegistersAction({
+    site: link?.site,
+    device: link?.device,
+    unitId,
+    protocolAddress: frame.readUInt16BE(8),
+    values,
   });
 }
 
@@ -366,6 +481,9 @@ export function encodeDnp3ControlRelay(action: any, { sequence = 0 }: any = {}):
 export function decodeDnp3ControlRelay(hex: string, link: any): any {
   const fragment = Buffer.from(requireString(hex, 'hex'), 'hex');
   if (fragment.length !== DNP3_FRAGMENT_OCTETS) throw new TypeError('unexpected DNP3 fragment length');
+  if ((fragment.readUInt8(0) & 0xf0) !== 0xc0) {
+    throw new TypeError('unexpected DNP3 application control for single-fragment request');
+  }
   const applicationFunction = fragment.readUInt8(1);
   if (applicationFunction !== DNP3_FC_DIRECT_OPERATE
       && applicationFunction !== DNP3_FC_DIRECT_OPERATE_NO_ACK) {
@@ -376,6 +494,9 @@ export function decodeDnp3ControlRelay(hex: string, link: any): any {
   }
   if (fragment.readUInt8(4) !== 0x17 || fragment.readUInt8(5) !== 1) {
     throw new TypeError('unexpected DNP3 qualifier or object count');
+  }
+  if (fragment.readUInt8(17) !== 0) {
+    throw new TypeError('DNP3 request status must be zero');
   }
   return dnp3ControlRelayAction({
     site: link?.site,
@@ -466,6 +587,8 @@ export default {
   opcuaCallMethodAction,
   encodeModbusWriteRegister,
   decodeModbusWriteRegister,
+  encodeModbusWriteMultipleRegisters,
+  decodeModbusWriteMultipleRegisters,
   encodeDnp3ControlRelay,
   decodeDnp3ControlRelay,
   encodeOpcuaCall,

--- a/examples/ot-command-binding-v1/generate-vectors.mjs
+++ b/examples/ot-command-binding-v1/generate-vectors.mjs
@@ -5,7 +5,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { TRANSPORT_PROFILES, commandDigest, dnp3ControlRelayAction, encodeDnp3ControlRelay, encodeModbusWriteRegister, encodeOpcuaCall, modbusWriteMultipleRegistersAction, } from './commands.mjs';
+import { TRANSPORT_PROFILES, commandDigest, dnp3ControlRelayAction, encodeDnp3ControlRelay, encodeModbusWriteMultipleRegisters, encodeModbusWriteRegister, encodeOpcuaCall, modbusWriteMultipleRegistersAction, } from './commands.mjs';
 import { EXACT_COMMANDS } from './scenario.mjs';
 export const OT_COMMAND_BINDING_VECTOR_PROFILE = 'EP-OT-COMMAND-BINDING-VECTORS-v1';
 const INLINE_REFERENCE = Object.freeze({
@@ -48,6 +48,7 @@ export function buildOtCommandBindingVectors() {
     });
     const dnp3Sequence0 = encodeDnp3ControlRelay(dnp3, { sequence: 0 });
     const dnp3Sequence9 = encodeDnp3ControlRelay(dnp3, { sequence: 9 });
+    const modbusFc16QuantityOneWire = encodeModbusWriteMultipleRegisters(modbusFc16QuantityOne, { transactionId: 1 });
     const encodedOpcua = encodeOpcuaCall(opcua, { receipt: INLINE_REFERENCE });
     return {
         '@type': OT_COMMAND_BINDING_VECTOR_PROFILE,
@@ -68,7 +69,8 @@ export function buildOtCommandBindingVectors() {
             digest_is_secret: false,
             repeated_action_rule: 'two authorizations for the same action use distinct attempt references',
             failure_domain: 'attempt holder and authoritative consumption record are conduit-owned',
-            equivalence_boundary: 'inline and detached modes can provide equivalent agreement, verification, and consumption; request-instance binding depends on the secure channel or authenticated conduit context plus attempt reference',
+            cross_transport_equivalence: 'not-claimed',
+            profile_locality: 'Each binding is evaluated only under its pinned transport encoding profile and request-instance mechanism.',
         },
         freshness: {
             clock: 'conduit-owned',
@@ -99,8 +101,11 @@ export function buildOtCommandBindingVectors() {
                 },
                 encoding_scope: {
                     fc06_and_fc16_quantity_one_are_distinct: true,
-                    equivalent_effect_action: modbusFc16QuantityOne,
-                    equivalent_effect_action_digest: commandDigest(modbusFc16QuantityOne),
+                    fc16_quantity_one: {
+                        action: modbusFc16QuantityOne,
+                        action_digest: commandDigest(modbusFc16QuantityOne),
+                        native_command: modbusFc16QuantityOneWire,
+                    },
                     note: 'The profile binds native encoding and does not normalize FC 0x06 into FC 0x10 quantity one.',
                 },
                 negative_cases: [
@@ -128,6 +133,7 @@ export function buildOtCommandBindingVectors() {
                     correlation_only: ['application_control.sequence'],
                     fixed_or_derived: [
                         'application_control.FIR=1', 'application_control.FIN=1',
+                        'application_control.CON=0', 'application_control.UNS=0',
                         'qualifier=0x17', 'object_count=1', 'status=0',
                     ],
                 },

--- a/examples/ot-command-binding-v1/generate-vectors.mts
+++ b/examples/ot-command-binding-v1/generate-vectors.mts
@@ -10,6 +10,7 @@ import {
   commandDigest,
   dnp3ControlRelayAction,
   encodeDnp3ControlRelay,
+  encodeModbusWriteMultipleRegisters,
   encodeModbusWriteRegister,
   encodeOpcuaCall,
   modbusWriteMultipleRegistersAction,
@@ -60,6 +61,10 @@ export function buildOtCommandBindingVectors() {
   });
   const dnp3Sequence0 = encodeDnp3ControlRelay(dnp3, { sequence: 0 });
   const dnp3Sequence9 = encodeDnp3ControlRelay(dnp3, { sequence: 9 });
+  const modbusFc16QuantityOneWire = encodeModbusWriteMultipleRegisters(
+    modbusFc16QuantityOne,
+    { transactionId: 1 },
+  );
   const encodedOpcua = encodeOpcuaCall(opcua, { receipt: INLINE_REFERENCE });
 
   return {
@@ -81,8 +86,9 @@ export function buildOtCommandBindingVectors() {
       digest_is_secret: false,
       repeated_action_rule: 'two authorizations for the same action use distinct attempt references',
       failure_domain: 'attempt holder and authoritative consumption record are conduit-owned',
-      equivalence_boundary:
-        'inline and detached modes can provide equivalent agreement, verification, and consumption; request-instance binding depends on the secure channel or authenticated conduit context plus attempt reference',
+      cross_transport_equivalence: 'not-claimed',
+      profile_locality:
+        'Each binding is evaluated only under its pinned transport encoding profile and request-instance mechanism.',
     },
     freshness: {
       clock: 'conduit-owned',
@@ -113,8 +119,11 @@ export function buildOtCommandBindingVectors() {
         },
         encoding_scope: {
           fc06_and_fc16_quantity_one_are_distinct: true,
-          equivalent_effect_action: modbusFc16QuantityOne,
-          equivalent_effect_action_digest: commandDigest(modbusFc16QuantityOne),
+          fc16_quantity_one: {
+            action: modbusFc16QuantityOne,
+            action_digest: commandDigest(modbusFc16QuantityOne),
+            native_command: modbusFc16QuantityOneWire,
+          },
           note: 'The profile binds native encoding and does not normalize FC 0x06 into FC 0x10 quantity one.',
         },
         negative_cases: [
@@ -142,6 +151,7 @@ export function buildOtCommandBindingVectors() {
           correlation_only: ['application_control.sequence'],
           fixed_or_derived: [
             'application_control.FIR=1', 'application_control.FIN=1',
+            'application_control.CON=0', 'application_control.UNS=0',
             'qualifier=0x17', 'object_count=1', 'status=0',
           ],
         },

--- a/examples/ot-command-binding-v1/scenario.test.mjs
+++ b/examples/ot-command-binding-v1/scenario.test.mjs
@@ -4,6 +4,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { TRANSPORT_PROFILES, commandDigest, commandDigestHex, decodeDnp3ControlRelay, decodeModbusWriteRegister, dnp3ControlRelayAction, encodeDnp3ControlRelay, encodeModbusWriteRegister, encodeOpcuaCall, extractOpcuaAuthorization, modbusWriteMultipleRegistersAction, modbusWriteRegisterAction, } from './commands.mjs';
+import * as commandCodecs from './commands.mjs';
 import { EXACT_COMMANDS, createEnforcementPoint, createOutOfBandAuthorizationIndex, runOtCommandBindingLab, } from './scenario.mjs';
 const LAB = await runOtCommandBindingLab();
 const [DERIVATION, AUTHORIZED, DRIFT, UNRESOLVED, SPENT] = LAB.scenes;
@@ -19,6 +20,10 @@ test('only OPC-UA can carry an authorization on the wire', () => {
         assert.equal(TRANSPORT_PROFILES[transport].binding_mode, 'out-of-band-digest');
         assert.equal(TRANSPORT_PROFILES[transport].metadata_octets_available, 0);
     }
+});
+test('the Modbus and DNP3 authorities are explicitly native-encoding-profile scoped', () => {
+    assert.equal(TRANSPORT_PROFILES['modbus-tcp'].encoding_profile.scope, 'native-encoding');
+    assert.equal(TRANSPORT_PROFILES.dnp3.encoding_profile.scope, 'native-encoding');
 });
 test('the Modbus frame is fully occupied by protocol fields', () => {
     const encoded = encodeModbusWriteRegister(EXACT_COMMANDS['modbus-tcp'], { transactionId: 1 });
@@ -102,6 +107,62 @@ test('Modbus FC 0x06 and FC 0x10 quantity one remain encoding-scoped authorities
     assert.equal(fc10.values[0], fc06.value);
     assert.notEqual(commandDigest(fc10), commandDigest(fc06));
 });
+test('Modbus FC 0x10 quantity one has a native wire encode/decode round trip', () => {
+    const fc06 = EXACT_COMMANDS['modbus-tcp'];
+    const fc10 = modbusWriteMultipleRegistersAction({
+        site: fc06.site,
+        device: fc06.device,
+        unitId: fc06.unit_id,
+        protocolAddress: fc06.protocol_address,
+        values: [fc06.value],
+    });
+    assert.equal(typeof commandCodecs.encodeModbusWriteMultipleRegisters, 'function');
+    assert.equal(typeof commandCodecs.decodeModbusWriteMultipleRegisters, 'function');
+    const encoded = commandCodecs.encodeModbusWriteMultipleRegisters(fc10, { transactionId: 9 });
+    assert.equal(encoded.octets, 15);
+    assert.equal(encoded.metadata_octets_available, 0);
+    assert.deepEqual(commandCodecs.decodeModbusWriteMultipleRegisters(encoded.hex, {
+        site: fc10.site,
+        device: fc10.device,
+        unit_id: fc10.unit_id,
+    }), fc10);
+});
+test('Modbus FC 0x10 refuses malformed quantity and byte-count fields', () => {
+    const valid = Buffer.from('000100000009031000000001020001', 'hex');
+    const missingQuantity = Buffer.from(valid);
+    missingQuantity.writeUInt16BE(0, 10);
+    assert.throws(() => commandCodecs.decodeModbusWriteMultipleRegisters(missingQuantity.toString('hex'), {
+        site: 'ep:site:demo-lift-station',
+        device: 'ep:device:plc-3',
+        unit_id: 3,
+    }), /quantity/);
+    const wrongByteCount = Buffer.from(valid);
+    wrongByteCount.writeUInt8(4, 12);
+    assert.throws(() => commandCodecs.decodeModbusWriteMultipleRegisters(wrongByteCount.toString('hex'), {
+        site: 'ep:site:demo-lift-station',
+        device: 'ep:device:plc-3',
+        unit_id: 3,
+    }), /byte count/);
+});
+test('Modbus decoders refuse a wire unit id without conduit-owned unit mapping', () => {
+    const fc06 = EXACT_COMMANDS['modbus-tcp'];
+    const fc10 = modbusWriteMultipleRegistersAction({
+        site: fc06.site,
+        device: fc06.device,
+        unitId: fc06.unit_id,
+        protocolAddress: fc06.protocol_address,
+        values: [fc06.value],
+    });
+    for (const [encoded, decode] of [
+        [encodeModbusWriteRegister(fc06), decodeModbusWriteRegister],
+        [commandCodecs.encodeModbusWriteMultipleRegisters(fc10), commandCodecs.decodeModbusWriteMultipleRegisters],
+    ]) {
+        assert.throws(() => decode(encoded.hex, {
+            site: 'ep:site:demo-lift-station',
+            device: 'ep:device:plc-3',
+        }), /unit id mapping is required/);
+    }
+});
 test('a Modbus unit-id mismatch with conduit device context is refused during decode', () => {
     const encoded = encodeModbusWriteRegister(EXACT_COMMANDS['modbus-tcp']);
     assert.throws(() => decodeModbusWriteRegister(encoded.hex, {
@@ -133,6 +194,62 @@ test('a DNP3 CROB digest binds the complete control octet, timing, count, and fu
         assert.notEqual(commandDigest(dnp3ControlRelayAction({ ...link, index: 7, ...variant })), commandDigest(base));
     }
 });
+for (const hostile of [
+    { name: 'FIN cleared', offset: 0, value: 0x80, reason: /application control/ },
+    { name: 'CON set', offset: 0, value: 0xe0, reason: /application control/ },
+    { name: 'UNS set', offset: 0, value: 0xd0, reason: /application control/ },
+    { name: 'request status nonzero', offset: 17, value: 1, reason: /request status/ },
+]) {
+    test(`DNP3 refuses a hostile request with ${hostile.name}`, () => {
+        const fragment = Buffer.from(encodeDnp3ControlRelay(EXACT_COMMANDS.dnp3).hex, 'hex');
+        fragment.writeUInt8(hostile.value, hostile.offset);
+        assert.throws(() => decodeDnp3ControlRelay(fragment.toString('hex'), {
+            site: EXACT_COMMANDS.dnp3.site,
+            device: EXACT_COMMANDS.dnp3.device,
+            outstation_address: EXACT_COMMANDS.dnp3.outstation_address,
+        }), hostile.reason);
+    });
+}
+test('DNP3 v1 pins qualifier 0x17, count one, and one-octet index range', () => {
+    assert.deepEqual(TRANSPORT_PROFILES.dnp3.encoding_profile.object_header, {
+        qualifier: 0x17,
+        object_count: 1,
+        index_octets: 1,
+        index_min: 0,
+        index_max: 0xff,
+    });
+    assert.deepEqual(TRANSPORT_PROFILES.dnp3.encoding_profile.application_control_flags, {
+        FIR: 1,
+        FIN: 1,
+        CON: 0,
+        UNS: 0,
+    });
+    assert.equal(TRANSPORT_PROFILES.dnp3.encoding_profile.request_status, 0);
+    const maxIndex = dnp3ControlRelayAction({
+        site: EXACT_COMMANDS.dnp3.site,
+        device: EXACT_COMMANDS.dnp3.device,
+        outstationAddress: EXACT_COMMANDS.dnp3.outstation_address,
+        index: 0xff,
+        applicationFunction: 5,
+        controlOctet: 0x03,
+    });
+    const encoded = encodeDnp3ControlRelay(maxIndex);
+    assert.equal(Buffer.from(encoded.hex, 'hex').readUInt8(4), 0x17);
+    assert.equal(Buffer.from(encoded.hex, 'hex').readUInt8(5), 1);
+    assert.deepEqual(decodeDnp3ControlRelay(encoded.hex, {
+        site: maxIndex.site,
+        device: maxIndex.device,
+        outstation_address: maxIndex.outstation_address,
+    }), maxIndex);
+    assert.throws(() => dnp3ControlRelayAction({
+        site: maxIndex.site,
+        device: maxIndex.device,
+        outstationAddress: maxIndex.outstation_address,
+        index: 0x100,
+        applicationFunction: 5,
+        controlOctet: 0x03,
+    }), /index must be an integer in \[0, 255\]/);
+});
 test('detached evidence distinguishes two authorizations for the same exact action', () => {
     const index = createOutOfBandAuthorizationIndex({ defaultRequestContext: 'session-a' });
     const action = EXACT_COMMANDS['modbus-tcp'];
@@ -161,7 +278,7 @@ test('the per-request correlation id is not part of the act', () => {
     assert.equal(invariance.digest_a, commandDigest(EXACT_COMMANDS['modbus-tcp']));
 });
 test('the wire round-trips through the decoder without moving the digest', () => {
-    const link = { site: 'ep:site:demo-lift-station', device: 'ep:device:plc-3' };
+    const link = { site: 'ep:site:demo-lift-station', device: 'ep:device:plc-3', unit_id: 3 };
     const modbus = encodeModbusWriteRegister(EXACT_COMMANDS['modbus-tcp'], { transactionId: 7 });
     assert.deepEqual(decodeModbusWriteRegister(modbus.hex, link), EXACT_COMMANDS['modbus-tcp']);
     const dnp3Link = { site: 'ep:site:demo-lift-station', device: 'ep:device:rtu-12', outstation_address: 12 };

--- a/examples/ot-command-binding-v1/scenario.test.mts
+++ b/examples/ot-command-binding-v1/scenario.test.mts
@@ -17,6 +17,7 @@ import {
   modbusWriteMultipleRegistersAction,
   modbusWriteRegisterAction,
 } from './commands.mjs';
+import * as commandCodecs from './commands.mjs';
 import {
   EXACT_COMMANDS,
   createEnforcementPoint,
@@ -41,6 +42,11 @@ test('only OPC-UA can carry an authorization on the wire', () => {
     assert.equal(TRANSPORT_PROFILES[transport].binding_mode, 'out-of-band-digest');
     assert.equal(TRANSPORT_PROFILES[transport].metadata_octets_available, 0);
   }
+});
+
+test('the Modbus and DNP3 authorities are explicitly native-encoding-profile scoped', () => {
+  assert.equal(TRANSPORT_PROFILES['modbus-tcp'].encoding_profile.scope, 'native-encoding');
+  assert.equal(TRANSPORT_PROFILES.dnp3.encoding_profile.scope, 'native-encoding');
 });
 
 test('the Modbus frame is fully occupied by protocol fields', () => {
@@ -132,6 +138,78 @@ test('Modbus FC 0x06 and FC 0x10 quantity one remain encoding-scoped authorities
   assert.notEqual(commandDigest(fc10), commandDigest(fc06));
 });
 
+test('Modbus FC 0x10 quantity one has a native wire encode/decode round trip', () => {
+  const fc06 = EXACT_COMMANDS['modbus-tcp'];
+  const fc10 = modbusWriteMultipleRegistersAction({
+    site: fc06.site,
+    device: fc06.device,
+    unitId: fc06.unit_id,
+    protocolAddress: fc06.protocol_address,
+    values: [fc06.value],
+  });
+  assert.equal(typeof commandCodecs.encodeModbusWriteMultipleRegisters, 'function');
+  assert.equal(typeof commandCodecs.decodeModbusWriteMultipleRegisters, 'function');
+  const encoded = commandCodecs.encodeModbusWriteMultipleRegisters(fc10, { transactionId: 9 });
+  assert.equal(encoded.octets, 15);
+  assert.equal(encoded.metadata_octets_available, 0);
+  assert.deepEqual(
+    commandCodecs.decodeModbusWriteMultipleRegisters(encoded.hex, {
+      site: fc10.site,
+      device: fc10.device,
+      unit_id: fc10.unit_id,
+    }),
+    fc10,
+  );
+});
+
+test('Modbus FC 0x10 refuses malformed quantity and byte-count fields', () => {
+  const valid = Buffer.from('000100000009031000000001020001', 'hex');
+  const missingQuantity = Buffer.from(valid);
+  missingQuantity.writeUInt16BE(0, 10);
+  assert.throws(
+    () => commandCodecs.decodeModbusWriteMultipleRegisters(missingQuantity.toString('hex'), {
+      site: 'ep:site:demo-lift-station',
+      device: 'ep:device:plc-3',
+      unit_id: 3,
+    }),
+    /quantity/,
+  );
+
+  const wrongByteCount = Buffer.from(valid);
+  wrongByteCount.writeUInt8(4, 12);
+  assert.throws(
+    () => commandCodecs.decodeModbusWriteMultipleRegisters(wrongByteCount.toString('hex'), {
+      site: 'ep:site:demo-lift-station',
+      device: 'ep:device:plc-3',
+      unit_id: 3,
+    }),
+    /byte count/,
+  );
+});
+
+test('Modbus decoders refuse a wire unit id without conduit-owned unit mapping', () => {
+  const fc06 = EXACT_COMMANDS['modbus-tcp'];
+  const fc10 = modbusWriteMultipleRegistersAction({
+    site: fc06.site,
+    device: fc06.device,
+    unitId: fc06.unit_id,
+    protocolAddress: fc06.protocol_address,
+    values: [fc06.value],
+  });
+  for (const [encoded, decode] of [
+    [encodeModbusWriteRegister(fc06), decodeModbusWriteRegister],
+    [commandCodecs.encodeModbusWriteMultipleRegisters(fc10), commandCodecs.decodeModbusWriteMultipleRegisters],
+  ] as const) {
+    assert.throws(
+      () => decode(encoded.hex, {
+        site: 'ep:site:demo-lift-station',
+        device: 'ep:device:plc-3',
+      }),
+      /unit id mapping is required/,
+    );
+  }
+});
+
 test('a Modbus unit-id mismatch with conduit device context is refused during decode', () => {
   const encoded = encodeModbusWriteRegister(EXACT_COMMANDS['modbus-tcp']);
   assert.throws(
@@ -177,6 +255,67 @@ test('a DNP3 CROB digest binds the complete control octet, timing, count, and fu
   }
 });
 
+for (const hostile of [
+  { name: 'FIN cleared', offset: 0, value: 0x80, reason: /application control/ },
+  { name: 'CON set', offset: 0, value: 0xe0, reason: /application control/ },
+  { name: 'UNS set', offset: 0, value: 0xd0, reason: /application control/ },
+  { name: 'request status nonzero', offset: 17, value: 1, reason: /request status/ },
+]) {
+  test(`DNP3 refuses a hostile request with ${hostile.name}`, () => {
+    const fragment = Buffer.from(encodeDnp3ControlRelay(EXACT_COMMANDS.dnp3).hex, 'hex');
+    fragment.writeUInt8(hostile.value, hostile.offset);
+    assert.throws(
+      () => decodeDnp3ControlRelay(fragment.toString('hex'), {
+        site: EXACT_COMMANDS.dnp3.site,
+        device: EXACT_COMMANDS.dnp3.device,
+        outstation_address: EXACT_COMMANDS.dnp3.outstation_address,
+      }),
+      hostile.reason,
+    );
+  });
+}
+
+test('DNP3 v1 pins qualifier 0x17, count one, and one-octet index range', () => {
+  assert.deepEqual(TRANSPORT_PROFILES.dnp3.encoding_profile.object_header, {
+    qualifier: 0x17,
+    object_count: 1,
+    index_octets: 1,
+    index_min: 0,
+    index_max: 0xff,
+  });
+  assert.deepEqual(TRANSPORT_PROFILES.dnp3.encoding_profile.application_control_flags, {
+    FIR: 1,
+    FIN: 1,
+    CON: 0,
+    UNS: 0,
+  });
+  assert.equal(TRANSPORT_PROFILES.dnp3.encoding_profile.request_status, 0);
+  const maxIndex = dnp3ControlRelayAction({
+    site: EXACT_COMMANDS.dnp3.site,
+    device: EXACT_COMMANDS.dnp3.device,
+    outstationAddress: EXACT_COMMANDS.dnp3.outstation_address,
+    index: 0xff,
+    applicationFunction: 5,
+    controlOctet: 0x03,
+  });
+  const encoded = encodeDnp3ControlRelay(maxIndex);
+  assert.equal(Buffer.from(encoded.hex, 'hex').readUInt8(4), 0x17);
+  assert.equal(Buffer.from(encoded.hex, 'hex').readUInt8(5), 1);
+  assert.deepEqual(decodeDnp3ControlRelay(encoded.hex, {
+    site: maxIndex.site,
+    device: maxIndex.device,
+    outstation_address: maxIndex.outstation_address,
+  }), maxIndex);
+  assert.throws(() => dnp3ControlRelayAction({
+    site: maxIndex.site,
+    device: maxIndex.device,
+    outstationAddress: maxIndex.outstation_address,
+    index: 0x100,
+    applicationFunction: 5,
+    controlOctet: 0x03,
+  }), /index must be an integer in \[0, 255\]/);
+});
+
 test('detached evidence distinguishes two authorizations for the same exact action', () => {
   const index = createOutOfBandAuthorizationIndex({ defaultRequestContext: 'session-a' });
   const action = EXACT_COMMANDS['modbus-tcp'];
@@ -207,7 +346,7 @@ test('the per-request correlation id is not part of the act', () => {
 });
 
 test('the wire round-trips through the decoder without moving the digest', () => {
-  const link = { site: 'ep:site:demo-lift-station', device: 'ep:device:plc-3' };
+  const link = { site: 'ep:site:demo-lift-station', device: 'ep:device:plc-3', unit_id: 3 };
   const modbus = encodeModbusWriteRegister(EXACT_COMMANDS['modbus-tcp'], { transactionId: 7 });
   assert.deepEqual(
     decodeModbusWriteRegister(modbus.hex, link),

--- a/examples/ot-command-binding-v1/vectors.test.mjs
+++ b/examples/ot-command-binding-v1/vectors.test.mjs
@@ -5,7 +5,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { commandDigest, decodeDnp3ControlRelay, decodeModbusWriteRegister, decodeOpcuaCall, extractOpcuaAuthorization, } from './commands.mjs';
+import { commandDigest, decodeDnp3ControlRelay, decodeModbusWriteMultipleRegisters, decodeModbusWriteRegister, decodeOpcuaCall, extractOpcuaAuthorization, } from './commands.mjs';
 import { buildOtCommandBindingVectors } from './generate-vectors.mjs';
 const vectorPath = fileURLToPath(new URL('./vectors.v1.json', import.meta.url));
 const pinned = JSON.parse(readFileSync(vectorPath, 'utf8'));
@@ -50,6 +50,18 @@ test('Modbus correlation changes native bytes without changing the action', () =
     assert.equal(commandDigest(decodeModbusWriteRegister(vector.native_command.hex, link)), vector.action_digest);
     assert.equal(commandDigest(decodeModbusWriteRegister(vector.correlation_variant.native_command.hex, link)), vector.action_digest);
 });
+test('the pinned Modbus FC 0x10 quantity-one command decodes under its native encoding profile', () => {
+    const vector = pinned.vectors.find((candidate) => candidate.id === 'modbus-write-single-register-v1');
+    const fc16 = vector.encoding_scope.fc16_quantity_one;
+    const observed = decodeModbusWriteMultipleRegisters(fc16.native_command.hex, {
+        site: fc16.action.site,
+        device: fc16.action.device,
+        unit_id: fc16.action.unit_id,
+    });
+    assert.deepEqual(observed, fc16.action);
+    assert.equal(commandDigest(observed), fc16.action_digest);
+    assert.notEqual(fc16.action_digest, vector.action_digest);
+});
 test('DNP3 application sequence changes native bytes without changing the action', () => {
     const vector = pinned.vectors.find((candidate) => candidate.id === 'dnp3-direct-operate-crob-v1');
     assert.notEqual(vector.native_command.hex, vector.correlation_variant.native_command.hex);
@@ -67,15 +79,35 @@ test('the pinned profiles state their normalization and request-instance boundar
     assert.equal(modbus.action.protocol_address, 0);
     assert.equal(Object.hasOwn(modbus.action, 'register'), false);
     assert.equal(modbus.encoding_scope.fc06_and_fc16_quantity_one_are_distinct, true);
+    assert.equal(modbus.transport_profile.encoding_profile.scope, 'native-encoding');
     assert.equal(dnp3.action.application_function, 5);
     assert.equal(dnp3.action.control_octet, 3);
     assert.equal(dnp3.action.operation_count, 1);
     assert.equal(dnp3.action.on_time_ms, 0);
     assert.equal(dnp3.action.off_time_ms, 0);
     assert.equal(dnp3.profile_scope.select_operate_supported, false);
+    assert.equal(dnp3.transport_profile.encoding_profile.scope, 'native-encoding');
+    assert.deepEqual(dnp3.transport_profile.encoding_profile.object_header, {
+        qualifier: 0x17,
+        object_count: 1,
+        index_octets: 1,
+        index_min: 0,
+        index_max: 0xff,
+    });
+    assert.deepEqual(dnp3.transport_profile.encoding_profile.application_control_flags, {
+        FIR: 1,
+        FIN: 1,
+        CON: 0,
+        UNS: 0,
+    });
+    assert.equal(dnp3.transport_profile.encoding_profile.request_status, 0);
     assert.equal(pinned.detached_evidence.request_instance_binding, 'authenticated-conduit-context-plus-attempt-reference');
     assert.equal(pinned.detached_evidence.digest_is_secret, false);
     assert.equal(pinned.freshness.clock, 'conduit-owned');
+});
+test('the pinned vectors make no cross-transport equivalence claim', () => {
+    assert.equal(pinned.detached_evidence.cross_transport_equivalence, 'not-claimed');
+    assert.equal(Object.hasOwn(pinned.detached_evidence, 'equivalence_boundary'), false);
 });
 test('the OPC-UA vector demonstrates carriage but never pretends its reference is authorization', () => {
     const vector = pinned.vectors.find((candidate) => candidate.id === 'opcua-call-method-v1');

--- a/examples/ot-command-binding-v1/vectors.test.mts
+++ b/examples/ot-command-binding-v1/vectors.test.mts
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 import {
   commandDigest,
   decodeDnp3ControlRelay,
+  decodeModbusWriteMultipleRegisters,
   decodeModbusWriteRegister,
   decodeOpcuaCall,
   extractOpcuaAuthorization,
@@ -64,6 +65,19 @@ test('Modbus correlation changes native bytes without changing the action', () =
   assert.equal(commandDigest(decodeModbusWriteRegister(vector.correlation_variant.native_command.hex, link)), vector.action_digest);
 });
 
+test('the pinned Modbus FC 0x10 quantity-one command decodes under its native encoding profile', () => {
+  const vector = pinned.vectors.find((candidate: any) => candidate.id === 'modbus-write-single-register-v1');
+  const fc16 = vector.encoding_scope.fc16_quantity_one;
+  const observed = decodeModbusWriteMultipleRegisters(fc16.native_command.hex, {
+    site: fc16.action.site,
+    device: fc16.action.device,
+    unit_id: fc16.action.unit_id,
+  });
+  assert.deepEqual(observed, fc16.action);
+  assert.equal(commandDigest(observed), fc16.action_digest);
+  assert.notEqual(fc16.action_digest, vector.action_digest);
+});
+
 test('DNP3 application sequence changes native bytes without changing the action', () => {
   const vector = pinned.vectors.find((candidate: any) => candidate.id === 'dnp3-direct-operate-crob-v1');
   assert.notEqual(vector.native_command.hex, vector.correlation_variant.native_command.hex);
@@ -82,15 +96,36 @@ test('the pinned profiles state their normalization and request-instance boundar
   assert.equal(modbus.action.protocol_address, 0);
   assert.equal(Object.hasOwn(modbus.action, 'register'), false);
   assert.equal(modbus.encoding_scope.fc06_and_fc16_quantity_one_are_distinct, true);
+  assert.equal(modbus.transport_profile.encoding_profile.scope, 'native-encoding');
   assert.equal(dnp3.action.application_function, 5);
   assert.equal(dnp3.action.control_octet, 3);
   assert.equal(dnp3.action.operation_count, 1);
   assert.equal(dnp3.action.on_time_ms, 0);
   assert.equal(dnp3.action.off_time_ms, 0);
   assert.equal(dnp3.profile_scope.select_operate_supported, false);
+  assert.equal(dnp3.transport_profile.encoding_profile.scope, 'native-encoding');
+  assert.deepEqual(dnp3.transport_profile.encoding_profile.object_header, {
+    qualifier: 0x17,
+    object_count: 1,
+    index_octets: 1,
+    index_min: 0,
+    index_max: 0xff,
+  });
+  assert.deepEqual(dnp3.transport_profile.encoding_profile.application_control_flags, {
+    FIR: 1,
+    FIN: 1,
+    CON: 0,
+    UNS: 0,
+  });
+  assert.equal(dnp3.transport_profile.encoding_profile.request_status, 0);
   assert.equal(pinned.detached_evidence.request_instance_binding, 'authenticated-conduit-context-plus-attempt-reference');
   assert.equal(pinned.detached_evidence.digest_is_secret, false);
   assert.equal(pinned.freshness.clock, 'conduit-owned');
+});
+
+test('the pinned vectors make no cross-transport equivalence claim', () => {
+  assert.equal(pinned.detached_evidence.cross_transport_equivalence, 'not-claimed');
+  assert.equal(Object.hasOwn(pinned.detached_evidence, 'equivalence_boundary'), false);
 });
 
 test('the OPC-UA vector demonstrates carriage but never pretends its reference is authorization', () => {

--- a/examples/ot-command-binding-v1/vectors.v1.json
+++ b/examples/ot-command-binding-v1/vectors.v1.json
@@ -17,7 +17,8 @@
     "digest_is_secret": false,
     "repeated_action_rule": "two authorizations for the same action use distinct attempt references",
     "failure_domain": "attempt holder and authoritative consumption record are conduit-owned",
-    "equivalence_boundary": "inline and detached modes can provide equivalent agreement, verification, and consumption; request-instance binding depends on the secure channel or authenticated conduit context plus attempt reference"
+    "cross_transport_equivalence": "not-claimed",
+    "profile_locality": "Each binding is evaluated only under its pinned transport encoding profile and request-instance mechanism."
   },
   "freshness": {
     "clock": "conduit-owned",
@@ -29,12 +30,21 @@
       "id": "modbus-write-single-register-v1",
       "transport_profile": {
         "transport": "modbus-tcp",
+        "encoding_profile": {
+          "id": "EP-OT-MODBUS-TCP-WRITE-ENCODING-v1",
+          "scope": "native-encoding",
+          "function_codes": [
+            6,
+            16
+          ],
+          "normalization": "none"
+        },
         "envelope_capacity": "none",
         "carries_authorization_inline": false,
         "binding_mode": "out-of-band-digest",
         "extension_point": null,
         "metadata_octets_available": 0,
-        "why": "A write is unit id, function code, register address, and value. Length is fixed by the function code; nothing else fits on the wire."
+        "why": "A write is unit id, function code, register address, and function-defined write fields. Length is fixed by those fields; nothing else fits on the wire."
       },
       "action": {
         "action_type": "ot.modbus.write_single_register",
@@ -92,21 +102,33 @@
       },
       "encoding_scope": {
         "fc06_and_fc16_quantity_one_are_distinct": true,
-        "equivalent_effect_action": {
-          "action_type": "ot.modbus.write_multiple_registers",
-          "transport": "modbus-tcp",
-          "site": "ep:site:demo-lift-station",
-          "device": "ep:device:plc-3",
-          "unit_id": 3,
-          "function_code": 16,
-          "protocol_address": 0,
-          "quantity": 1,
-          "byte_count": 2,
-          "values": [
-            1
-          ]
+        "fc16_quantity_one": {
+          "action": {
+            "action_type": "ot.modbus.write_multiple_registers",
+            "transport": "modbus-tcp",
+            "site": "ep:site:demo-lift-station",
+            "device": "ep:device:plc-3",
+            "unit_id": 3,
+            "function_code": 16,
+            "protocol_address": 0,
+            "quantity": 1,
+            "byte_count": 2,
+            "values": [
+              1
+            ]
+          },
+          "action_digest": "sha256:6b802c5e2cf9b9e55368a5358c55691f364ac64cc749c7ebf732fcd91b8bcbd2",
+          "native_command": {
+            "transport": "modbus-tcp",
+            "hex": "000100000009031000000001020001",
+            "octets": 15,
+            "protocol_address": 0,
+            "quantity": 1,
+            "byte_count": 2,
+            "metadata_octets_available": 0,
+            "carries_authorization": false
+          }
         },
-        "equivalent_effect_action_digest": "sha256:6b802c5e2cf9b9e55368a5358c55691f364ac64cc749c7ebf732fcd91b8bcbd2",
         "note": "The profile binds native encoding and does not normalize FC 0x06 into FC 0x10 quantity one."
       },
       "negative_cases": [
@@ -134,6 +156,24 @@
       "id": "dnp3-direct-operate-crob-v1",
       "transport_profile": {
         "transport": "dnp3",
+        "encoding_profile": {
+          "id": "EP-OT-DNP3-CROB-DIRECT-OPERATE-ENCODING-v1",
+          "scope": "native-encoding",
+          "object_header": {
+            "qualifier": 23,
+            "object_count": 1,
+            "index_octets": 1,
+            "index_min": 0,
+            "index_max": 255
+          },
+          "application_control_flags": {
+            "FIR": 1,
+            "FIN": 1,
+            "CON": 0,
+            "UNS": 0
+          },
+          "request_status": 0
+        },
         "envelope_capacity": "fixed-object-space",
         "carries_authorization_inline": false,
         "binding_mode": "out-of-band-digest",
@@ -195,6 +235,8 @@
         "fixed_or_derived": [
           "application_control.FIR=1",
           "application_control.FIN=1",
+          "application_control.CON=0",
+          "application_control.UNS=0",
           "qualifier=0x17",
           "object_count=1",
           "status=0"

--- a/scripts/check-bounded-capability-04.mjs
+++ b/scripts/check-bounded-capability-04.mjs
@@ -179,6 +179,12 @@ function relationContextKey(context) {
   ].join('|');
 }
 
+/**
+ * @param {{
+ *   hops: Array<{ parent: string, child: string, localResult: string, context: Record<string, unknown> }>,
+ *   establishment?: { authenticated: boolean, runnerTrusted: boolean, exactContextMatch: boolean, domain: string[] }
+ * }} input
+ */
 function chainComposable({ hops, establishment }) {
   if (hops.length === 0) return false;
   if (hops.some((hop) => hop.localResult !== 'NO_BROADER')) return false;


### PR DESCRIPTION
## Summary

- scope Modbus and DNP3 authorization to explicit native-encoding profiles
- add Modbus FC 0x10 wire round-trip and malformed-field refusal
- refuse missing conduit-owned Modbus unit mappings
- reject unsafe DNP3 application flags, request status, qualifier, count, and index forms
- preserve the published CAID/BCR vocabulary pending collaborator agreement
- correct the BCR-04 checker type contract for its intentional single-hop case

## Red to green

Baseline against `origin/main` at `7633a7bb`:

```text
tests 49
pass 39
fail 10
```

After repair:

```text
tests 50
pass 50
fail 0
```

Also passed:

- `npm run check:ot-command-binding-vectors`
- `npm run check:standalone-runtimes`
- `node scripts/check-bounded-capability-04.mjs`
- `npm run typecheck:rest`
- production build
- repository-boundary check

## Boundaries

This remains a synthetic transport-binding example, not a certified Modbus or DNP3 stack. It does not assert cross-transport effect equivalence and does not change published `INDETERMINATE` terminology.