### PR TITLE
docs(conformance): make clean-clone reproduction exact

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ preserves **8 deliberately weakened variants that produce concrete
 attack traces when load-bearing checks are removed**. The live same-team conformance corpus contains **21 suites and
 331 current vectors**. Separately, an externally authored Rust verifier is pinned to the frozen
 **16-suite/164-vector** bundle and a **359-case hostility campaign**. The broader suite contains
-**9,083 automated tests across 561 files**.
+**9,104 automated tests across 563 files**.
 
 Production JavaScript and JSDoc surfaces are compiler-checked with TypeScript
 `checkJs`; the secure app has its own compatibility compiler project, while
@@ -362,7 +362,7 @@ Three same-team reference ports (JS / Python / Go) agree across all 21 suites an
 
 | Metric | Value |
 |---|---|
-| Automated test cases | 9,083 across 561 files; all platform-applicable cases must pass |
+| Automated test cases | 9,104 across 563 files; all platform-applicable cases must pass |
 | TLA+ safety properties | 26 bounded invariants held in the configured state space; not an implementation-refinement or unbounded proof — see [PROOF_STATUS.md](formal/PROOF_STATUS.md) |
 | Alloy relational assertions | 35 facts + 32 assertions across four models — verified in CI |
 | Red-team cases cataloged | 85 — [RED_TEAM_CASES.md](docs/conformance/RED_TEAM_CASES.md) |

--- a/conformance/composition/gap6-execution-evidence-v0.1/README.md
+++ b/conformance/composition/gap6-execution-evidence-v0.1/README.md
@@ -66,10 +66,15 @@ account numbers enter the evidence only as digests.
 ## Run it
 
 ```bash
+npm ci --ignore-scripts
 node conformance/composition/gap6-execution-evidence-v0.1/run.mjs          # demonstration
 node conformance/composition/gap6-execution-evidence-v0.1/run.mjs --json   # full report
 npm run pilot:finance-field-origin                                      # paid-pilot bundle
 ```
+
+The install step is required in a clean clone because the runner imports the
+repository's pinned workspace dependencies. It does not modify the committed
+reference report or its deterministic results digest.
 
 One execution emits three outputs:
 


### PR DESCRIPTION
## What changed

- document the required `npm ci --ignore-scripts` step before running the Gap 6 profile from a clean clone
- state why the install is required and that it does not alter the committed reference report or deterministic digest
- align the README test claim with the already-generated proof manifest after CI exposed the moving-main mismatch

## Verification

Executed from this clean worktree:

```text
npm ci --ignore-scripts
node conformance/composition/gap6-execution-evidence-v0.1/run.mjs
npx vitest run tests/public-claims.test.ts
```

Results:

- all 14 Gap 6 cases passed
- deterministic digest unchanged: `sha256:d79e68656441dcf231a4802c1b5c973fa798ca7d48d7e6acacd2c5683148b239`
- README freshness contract passed against `lib/proof-stats.json`: 9,104 cases across 563 files

This closes the reproducibility gap Joel Hillier identified. It does not change runtime behavior or claim independent implementation.
