### PR TITLE
fix(ci): wire local verifier into fuzz job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,7 +385,9 @@ jobs:
   # consume-once attempts against the REAL capability and consumption stores
   # every push and asserts the safety invariants. A regression fails at a named
   # seed the author can replay locally. The deeper nightly sweep is documented
-  # in fuzz/README.md. No product deps, no network — Node built-ins only.
+  # in fuzz/README.md. The gate runtime now imports the repository-local
+  # zero-dependency verifier package, so CI wires that one local package name
+  # without contacting a registry.
   fuzz:
     runs-on: ubuntu-latest
     steps:
@@ -393,6 +395,10 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
+      - name: Wire the repository-local verifier package
+        run: |
+          mkdir -p node_modules/@emilia-protocol
+          ln -s ../../packages/verify node_modules/@emilia-protocol/verify
       - name: Run the bounded fixed-seed fuzz batch (<60s)
         run: node fuzz/ci-batch.mjs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -828,6 +828,10 @@ jobs:
         with:
           go-version: '1.26.6'
       - run: python -m pip install --require-hashes -r .github/workflow-requirements/cryptography.txt
+      - name: Wire the repository-local verifier package
+        run: |
+          mkdir -p node_modules/@emilia-protocol
+          ln -s ../../packages/verify node_modules/@emilia-protocol/verify
       - name: Cross-language conformance (EP-RECEIPT-v1, JS + Python + Go)
         env:
           NODE_OPTIONS: '--import ${{ github.workspace }}/scripts/ts-loader/register.mjs'


### PR DESCRIPTION
## Root cause
The fuzz job intentionally skipped dependency installation, but the checked-in Gate runtime now imports the repository-local zero-dependency verify package by package name. A clean runner therefore failed before any invariant executed.

## Repair
Wire only `@emilia-protocol/verify` to the repository-local package. No registry access and no dependency install.

## Verification
- exact `node fuzz/ci-batch.mjs`: passed
- 18,000 deterministic iterations across all three targets
- actionlint: passed