### PR TITLE
ci(security): cover model-to-matter PQ mutations

### DIFF
--- a/stryker.model-to-matter.config.js
+++ b/stryker.model-to-matter.config.js
@@ -27,6 +27,8 @@ export default {
     'tests/model-to-matter.test.{js,ts}',
     'tests/model-to-matter-security-branches.test.{js,ts}',
     'tests/model-to-matter-mutation-oracles.test.{js,ts}',
+    'tests/model-to-matter-hybrid.test.{js,ts}',
+    'tests/model-to-matter-physical-state.test.{js,ts}',
   ],
   thresholds: {
     // See the status file for the score produced by the current source and


### PR DESCRIPTION
Closes the mutation-gate regression introduced when Model-to-Matter gained hybrid post-quantum and physical-state branches. The Stryker campaign now includes the two existing suites that exercise those branches.\n\nVerification:\n- `npm run test:mutation:model-to-matter`: 81.16% mutation score, 801 killed, 153 survived, 33 no-coverage, threshold unchanged at 80%\n- `npx vitest run tests/security-mutation-workflow-coverage.test.ts`: pass\n\nNo production code or mutation threshold changes.