### PR TITLE
test(conformance): isolate the anchor-leaf binding axis — lifted-anchor vector with a valid Merkle path

### DIFF
--- a/conformance/vectors/generate.mjs
+++ b/conformance/vectors/generate.mjs
@@ -65,7 +65,17 @@ add('reject_legacy_v1_anchor_by_default', 'A legacy EP-MERKLE-v1 (sorted-pair, u
     const goodAnchorV2 = { alg: 'EP-MERKLE-v2', leaf_hash: v2Leaf, merkle_proof: [{ hash: v2Sibling, position: 'right' }], merkle_root: v2Root };
     add('accept_with_merkle_anchor_v2', 'Valid receipt with a v2 domain-separated, payload-bound Merkle anchor', true, null, KEY.pub, receipt(v2Payload, { anchor: goodAnchorV2 }));
     // Self-binding: a v2 anchor whose leaf_hash is NOT SHA-256(0x00||canon(payload)) is refused.
+    // This one's Merkle PATH is also invalid (sha('not-the-real-leaf') does not fold to v2Root),
+    // so it exercises the reject but cannot ISOLATE the payload-binding self-check: a verifier that
+    // skipped the binding check and only folded the path would still refuse it.
     add('reject_v2_unbound_leaf', 'v2 anchor leaf_hash not bound to the receipt payload is refused', false, 'anchor_leaf_unbound', KEY.pub, receipt({ receipt_id: 'tr_v2_unbound', issuer: 'ep:demo' }, { anchor: { alg: 'EP-MERKLE-v2', leaf_hash: sha('not-the-real-leaf'), merkle_proof: [{ hash: v2Sibling, position: 'right' }], merkle_root: v2Root } }));
+    // Isolating variant (lifted anchor): reuse accept_with_merkle_anchor_v2's OWN valid anchor
+    // (v2Leaf folds through v2Sibling to v2Root — a genuinely valid Merkle path) but attach it to a
+    // DIFFERENT receipt. leaf_hash is therefore proof-valid yet bound to another payload, so a
+    // path-only verifier ACCEPTS while a conformant one refuses on the leaf==SHA-256(0x00||canon(THIS
+    // payload)) self-check. This is the vector that demonstrates the binding axis rather than arguing
+    // it (unbound-but-otherwise-proof-valid); reject_v2_unbound_leaf above conflates it with a bad path.
+    add('reject_v2_lifted_anchor_valid_path', 'v2 anchor with a VALID Merkle path whose leaf is bound to a DIFFERENT receipt (a lifted anchor) is refused — the leaf must equal SHA-256(0x00||canon(payload)) of THIS receipt, so a proof-valid but unbound anchor is rejected on the self-check alone', false, 'anchor_leaf_unbound', KEY.pub, receipt({ receipt_id: 'tr_v2_lifted_anchor', issuer: 'ep:demo' }, { anchor: { alg: 'EP-MERKLE-v2', leaf_hash: v2Leaf, merkle_proof: [{ hash: v2Sibling, position: 'right' }], merkle_root: v2Root } }));
 }
 // ── REJECT class (each targets one invariant) ────────────────────────────────
 add('reject_unsupported_version', 'Unknown document version is refused', false, 'unsupported_version', KEY.pub, { '@version': 'EP-RECEIPT-v2', payload: { receipt_id: 'tr_v2' }, signature: { algorithm: 'Ed25519', value: sign({ receipt_id: 'tr_v2' }) } });

--- a/conformance/vectors/generate.mts
+++ b/conformance/vectors/generate.mts
@@ -84,8 +84,19 @@ add('reject_legacy_v1_anchor_by_default', 'A legacy EP-MERKLE-v1 (sorted-pair, u
   add('accept_with_merkle_anchor_v2', 'Valid receipt with a v2 domain-separated, payload-bound Merkle anchor', true, null, KEY.pub,
     receipt(v2Payload, { anchor: goodAnchorV2 }));
   // Self-binding: a v2 anchor whose leaf_hash is NOT SHA-256(0x00||canon(payload)) is refused.
+  // This one's Merkle PATH is also invalid (sha('not-the-real-leaf') does not fold to v2Root),
+  // so it exercises the reject but cannot ISOLATE the payload-binding self-check: a verifier that
+  // skipped the binding check and only folded the path would still refuse it.
   add('reject_v2_unbound_leaf', 'v2 anchor leaf_hash not bound to the receipt payload is refused', false, 'anchor_leaf_unbound', KEY.pub,
     receipt({ receipt_id: 'tr_v2_unbound', issuer: 'ep:demo' }, { anchor: { alg: 'EP-MERKLE-v2', leaf_hash: sha('not-the-real-leaf'), merkle_proof: [{ hash: v2Sibling, position: 'right' }], merkle_root: v2Root } }));
+  // Isolating variant (lifted anchor): reuse accept_with_merkle_anchor_v2's OWN valid anchor
+  // (v2Leaf folds through v2Sibling to v2Root — a genuinely valid Merkle path) but attach it to a
+  // DIFFERENT receipt. leaf_hash is therefore proof-valid yet bound to another payload, so a
+  // path-only verifier ACCEPTS while a conformant one refuses on the leaf==SHA-256(0x00||canon(THIS
+  // payload)) self-check. This is the vector that demonstrates the binding axis rather than arguing
+  // it (unbound-but-otherwise-proof-valid); reject_v2_unbound_leaf above conflates it with a bad path.
+  add('reject_v2_lifted_anchor_valid_path', 'v2 anchor with a VALID Merkle path whose leaf is bound to a DIFFERENT receipt (a lifted anchor) is refused — the leaf must equal SHA-256(0x00||canon(payload)) of THIS receipt, so a proof-valid but unbound anchor is rejected on the self-check alone', false, 'anchor_leaf_unbound', KEY.pub,
+    receipt({ receipt_id: 'tr_v2_lifted_anchor', issuer: 'ep:demo' }, { anchor: { alg: 'EP-MERKLE-v2', leaf_hash: v2Leaf, merkle_proof: [{ hash: v2Sibling, position: 'right' }], merkle_root: v2Root } }));
 }
 
 // ── REJECT class (each targets one invariant) ────────────────────────────────

--- a/conformance/vectors/receipts.v1.json
+++ b/conformance/vectors/receipts.v1.json
@@ -7,7 +7,7 @@
     "canonicalization": "recursive key-sorted JSON (RFC 8785-style)",
     "anchor": "SHA-256 sorted-pair Merkle"
   },
-  "count": 13,
+  "count": 14,
   "vectors": [
     {
       "id": "accept_minimal",
@@ -168,6 +168,37 @@
         "anchor": {
           "alg": "EP-MERKLE-v2",
           "leaf_hash": "407f447a518bd5dd58e4c17b09934eb0e5041816b9cebf85d2a44b70d3fba0ab",
+          "merkle_proof": [
+            {
+              "hash": "52ab2e6d1cf6ebb89e4d01bb94ca71b5df78f609154b2735251abbeb37274038",
+              "position": "right"
+            }
+          ],
+          "merkle_root": "388fbc92013502492595c9092b268c1ec0ab562ae2bec40602e83a9cca0239c3"
+        }
+      }
+    },
+    {
+      "id": "reject_v2_lifted_anchor_valid_path",
+      "description": "v2 anchor with a VALID Merkle path whose leaf is bound to a DIFFERENT receipt (a lifted anchor) is refused — the leaf must equal SHA-256(0x00||canon(payload)) of THIS receipt, so a proof-valid but unbound anchor is rejected on the self-check alone",
+      "expect": {
+        "valid": false
+      },
+      "reason": "anchor_leaf_unbound",
+      "public_key": "MCowBQYDK2VwAyEAvHy8tWNjdfodgkNNRmck2SN39TuYBpXdSdJtDOEiBaU",
+      "document": {
+        "@version": "EP-RECEIPT-v1",
+        "payload": {
+          "receipt_id": "tr_v2_lifted_anchor",
+          "issuer": "ep:demo"
+        },
+        "signature": {
+          "algorithm": "Ed25519",
+          "value": "I_SakVM9jL9VzT9ipunqYsTkSroOcJMmNKOutYgTqppYRgjW6AaTJtY6JCd-YjG_l0KgMbM2z2S9nPAz7klQAg"
+        },
+        "anchor": {
+          "alg": "EP-MERKLE-v2",
+          "leaf_hash": "49e4fa6eec990de1897dfcdd3b7a7cb6af458bf8d8a2aaddb9c61837bb26f804",
           "merkle_proof": [
             {
               "hash": "52ab2e6d1cf6ebb89e4d01bb94ca71b5df78f609154b2735251abbeb37274038",


### PR DESCRIPTION
Follows up Iman's reply on the SCITT list (2026-08-17, "Your distinction is real … please send
the generator and regenerated receipts.v1.json as a PR against current main"):
https://mailarchive.ietf.org/arch/msg/scitt/95eze1Hje5KTT2de_PVILJD-Eqo/

## What this adds

One vector, `reject_v2_lifted_anchor_valid_path` (expected refusal: `anchor_leaf_unbound`),
generated by the same generator (`generate.mjs`/`generate.mts` edited in lockstep;
`receipts.v1.json` is the generator's own regenerated output, byte-identical to running it).

It reuses `accept_with_merkle_anchor_v2`'s own valid anchor verbatim — `leaf_hash` folds
through the sibling to `merkle_root`, a genuinely valid path — but staples it to a receipt
with a different payload. So: signature valid, path valid, leaf unbound. A verifier that only
folds the path accepts it; a conformant verifier refuses on the
`leaf == SHA-256(0x00 || canon(payload))` self-check alone.

The existing `reject_v2_unbound_leaf` (`sha('not-the-real-leaf')`) fails both the binding
self-check and the path fold, so it cannot isolate a path-only verifier — this vector is the
isolating variant, per the list discussion.

## Constraints honored

- Every existing vector byte-identical (verified structurally: added=1, removed=0,
  existing-changed=0, order preserved; only `count` 13→14).
- Expected refusal is the existing `anchor_leaf_unbound` code — no new taxonomy.
- Frozen clean-room snapshot untouched.
- Verified at current main (75afac72): JavaScript + Python legs agree on all 14 vectors,
  zero disagreements. Go not run here (toolchain absent locally) — deferring to your CI's
  three-leg run as offered.

Authored by Elara (an AI agent; disclosed per our standing practice), operated by
@navigatorbuilds. The vector construction and this PR were reviewed end-to-end by the operator
flow described in the list thread.
