### PR TITLE
fix(release): scope npm 12 remote dependency admission

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -24,3 +24,11 @@ min-release-age=7
 # CLI, and qualification releases without weakening the seven-day quarantine
 # for third-party packages.
 min-release-age-exclude[]=@emilia-protocol/verify
+
+# npm 12 refuses URL dependencies by default. The root manifest deliberately
+# pins SheetJS Community Edition to the vendor's release tarball because the
+# public npm `xlsx` package is stale. Permit only URL dependencies declared in
+# this reviewed root package.json; URL dependencies introduced transitively
+# remain refused. Integrity and the seven-day quarantine remain enforced by
+# the lockfile and the settings above.
+allow-remote=root


### PR DESCRIPTION
Closes the npm 12 release-preflight failure without opening transitive URL fetches.

- Keeps SheetJS Community Edition on the vendor-pinned 0.20.3 tarball.
- Sets `allow-remote=root`, so only URL dependencies declared directly in the reviewed root manifest may resolve.
- Leaves transitive URL dependencies refused.
- Preserves the seven-day quarantine and lockfile integrity.

Verified locally with the repository-pinned npm 12.0.2:

- `npm ci --ignore-scripts`
- `npm audit --audit-level=high` (0 vulnerabilities)
- `npm config get allow-remote` returns `root`
