### PR TITLE
fix(marketing): clarify private equity hero

### DIFF
--- a/app/private-equity/opengraph-image.tsx
+++ b/app/private-equity/opengraph-image.tsx
@@ -2,7 +2,7 @@
 
 import { ImageResponse } from 'next/og';
 
-export const alt = 'The Universal Authority Tollgate for portfolio AI at a customer-owned finance boundary';
+export const alt = 'An EMILIA authority tollgate before a customer-owned finance boundary';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
@@ -34,10 +34,10 @@ export default function OpenGraphImage(): ImageResponse {
           </div>
           <div style={{ display: 'flex', flexDirection: 'column' }}>
             <div style={{ display: 'flex', fontSize: 64, fontWeight: 700, lineHeight: .98, letterSpacing: -3.2 }}>
-              Give every consequential agent action a tollgate.
+              Let AI agents work. Keep each portfolio company in control.
             </div>
             <div style={{ display: 'flex', marginTop: 28, color: '#625d56', fontSize: 25, lineHeight: 1.4 }}>
-              One sponsor standard. Every company keeps control.
+              One sponsor control model. Each company owns its Gate.
             </div>
           </div>
           <div style={{ display: 'flex', color: '#625d56', fontSize: 17 }}>

--- a/app/private-equity/page.tsx
+++ b/app/private-equity/page.tsx
@@ -10,10 +10,10 @@ import PortfolioTrackedLink from './PortfolioTrackedLink';
 import css from './private-equity.module.css';
 
 const PAGE_URL = 'https://www.emiliaprotocol.ai/private-equity';
-const PAGE_TITLE = 'The Universal Authority Tollgate for Private Equity Portfolio AI';
+const PAGE_TITLE = 'Authority Controls for AI Across Private Equity Portfolios';
 const PAGE_DESCRIPTION =
-  'Scale agentic AI across private-equity portfolios without giving agents an open road into money, '
-  + 'systems, and assets. Start with one customer-owned finance tollgate.';
+  'Let AI agents work across your portfolio while each company keeps control of consequential '
+  + 'actions involving money, systems, and assets.';
 
 export const metadata: Metadata = {
   title: PAGE_TITLE,
@@ -306,11 +306,14 @@ export default async function PrivateEquityPage(): Promise<React.ReactElement> {
       <main className={css.page}>
         <section className={css.hero} aria-labelledby="pe-hero-title">
           <div className={css.heroCopy}>
-            <p className={css.eyebrow}>The Universal Authority Tollgate for portfolio AI</p>
-            <h1 id="pe-hero-title">Give private-equity portfolio AI an authority tollgate.</h1>
+            <p className={css.eyebrow}>The Universal Authority Tollgate</p>
+            <h1 id="pe-hero-title">
+              Let AI agents work. Keep each portfolio company in control.
+            </h1>
             <p className={css.heroLead}>
-              Scale agentic AI without giving agents an open road into portfolio money, systems, and
-              assets. One sponsor can standardize the control contract. Each company owns its Gate.
+              EMILIA puts a customer-owned authority tollgate before consequential actions involving
+              money, systems, and assets. Sponsors can standardize the control model. Each portfolio
+              company keeps its own authority, keys, and evidence.
             </p>
             <p className={css.boundaryStatement}>
               On completely mediated covered paths, the exact action must arrive with accepted

--- a/tests/private-equity-page.test.ts
+++ b/tests/private-equity-page.test.ts
@@ -30,8 +30,11 @@ const footer = readFileSync(resolve(ROOT, 'components/SiteFooter.tsx'), 'utf8');
 describe('private-equity portfolio customer page', () => {
   it('is an indexable, finance-first customer route with dedicated share metadata', () => {
     expect(page).toContain("alternates: { canonical: '/private-equity' }");
-    expect(page).toContain('The Universal Authority Tollgate for Private Equity Portfolio AI');
-    expect(page).toContain('Give private-equity portfolio AI an authority tollgate.');
+    expect(page).toContain('Authority Controls for AI Across Private Equity Portfolios');
+    expect(page).toContain('Let AI agents work. Keep each portfolio company in control.');
+    expect(page).toContain('The Universal Authority Tollgate');
+    expect(page).not.toContain('Give private-equity portfolio AI an authority tollgate.');
+    expect(openGraphImage).toContain('Let AI agents work. Keep each portfolio company in control.');
     expect(page).toContain("url: '/private-equity/opengraph-image'");
     expect(page).toContain('robots: { index: true, follow: true }');
     expect(openGraphImage).toContain('export const size = { width: 1200, height: 630 }');


### PR DESCRIPTION
## Outcome

Replaces the awkward private-equity noun pile with a plain-English buyer promise:

> Let AI agents work. Keep each portfolio company in control.

Keeps “The Universal Authority Tollgate” as the category line, clarifies the sponsor-versus-portfolio-company control model, and aligns the page metadata and social image.

## Verification

- 15 focused private-equity tests pass
- App typecheck passes
- Lint passes with 0 errors and pre-existing warnings only
- Full production build passes across 781 routes
- Pixel 5 and desktop hero renders visually reviewed

No protocol behavior or product claims changed.