### PR TITLE
docs(cedulon): add external adoption packet and Gate pilot runbook

### DIFF
--- a/conformance/composition/cedulon-aeb-crossing-v0.1/adoption/README.md
+++ b/conformance/composition/cedulon-aeb-crossing-v0.1/adoption/README.md
@@ -1,0 +1,68 @@
+# Cedulon × AEB adoption packet
+
+Status: **candidate for external review; no adoption claim**
+
+This packet is the smallest path from the checked-in Cedulon Decision Token
+crossing profile to one buyer-controlled pilot. It gives the native author a
+short semantic checklist, gives an independent runner fixed reproduction
+commands, and gives a buyer a fail-closed Gate pilot runbook.
+
+## Scope
+
+The profile verifies one pinned Cedulon Decision Token as pre-settlement
+machine-policy evidence and maps the six fields evaluated by the Cedulon PDP
+to one exact `cedulon.payment.attempt.1` action:
+
+`amount`, `currency`, `payee`, `tool`, `nonce`, and `manifestHash`.
+
+The current subset requires non-null `tool` and `manifestHash`. It pins the
+source material identified in `../source-lock.json`; a different Cedulon
+revision requires a new review and source lock.
+
+## What a passing result means
+
+A passing local run shows that, for the pinned fixtures and adapter:
+
+- the configured Ed25519 issuer key, COSE envelope, claims, expiry, detached
+  request, policy hash, and status inputs pass the profile checks;
+- all six request fields map without loss to the expected CAID action; and
+- the checked-in hostile vectors are refused or withheld as specified.
+
+The native-author checklist asks whether that mapping preserves Cedulon's
+intended semantics. The independent-run record shows that another operator ran
+the fixed commands at an exact commit. The pilot runbook adds the production
+controls that the offline profile cannot prove.
+
+Cedulon's allow is consumed on the first settlement attempt, including a
+fail-closed abort. `singleUseId` and `nonce` remain terminal in every outcome,
+including `NOT_ENTERED`; reconciliation cannot restore them. Any retry requires
+a newly issued Decision Token with fresh identities.
+
+## Claim boundary
+
+| Claim | This packet establishes it? |
+| --- | --- |
+| Deterministic reproduction of the pinned offline profile | Only after a runner records a passing exact-commit run |
+| Native semantics preserved | Only after the native author confirms the checklist |
+| Cedulon or EMILIA endorsement/certification | **No** |
+| Human approval or authorization to enter a provider | **No** |
+| Payment execution, settlement, finality, or rail completeness | **No** |
+| Production deployment or complete mediation | **No** |
+| Security of Cedulon, AEB, Gate, or the buyer's system in general | **No** |
+| Compliance, audit opinion, or legal conclusion | **No** |
+
+`SATISFIED` is evidence-requirement satisfaction for an exact action. Gate
+still must make a separate local authorization decision at a buyer-controlled,
+completely mediated provider boundary.
+
+## Review order
+
+1. Native author completes `native-author-confirmation.md` or supplies
+   corrections. This confirms meaning, not endorsement.
+2. An independent operator follows `independent-runner.md` and returns the
+   resulting unsigned run record plus any external signature they choose.
+3. A buyer executes `buyer-gate-pilot-runbook.md` in a non-production test
+   environment before any live provider credential is introduced.
+
+None of these steps may be described as completed until its named external
+party returns the corresponding evidence.

--- a/conformance/composition/cedulon-aeb-crossing-v0.1/adoption/buyer-gate-pilot-runbook.md
+++ b/conformance/composition/cedulon-aeb-crossing-v0.1/adoption/buyer-gate-pilot-runbook.md
@@ -1,0 +1,146 @@
+# Buyer-controlled Gate pilot runbook
+
+This is a non-production acceptance plan. It does not authorize connection to
+a live payment rail. The buyer owns the environment, keys, policies, provider
+credentials, and durable database, and decides whether the pilot advances.
+
+## 1. Freeze the pilot boundary
+
+Record the exact repository commit, Cedulon source lock, adapter digest, Gate
+build, buyer deployment ID, issuer key ID, status-service identity, provider
+sandbox account, and policy revision. Permit only
+`cedulon.payment.attempt.1` through one named executor. Keep provider
+credentials outside agent and model processes.
+
+The buyer must control:
+
+- the configured Cedulon PDP trust root and its rotation/revocation policy;
+- Gate authorization/signing keys and local admission policy;
+- the database holding decisions, replay fences, provider-attempt state, and
+  reconciliation evidence; and
+- the provider credential and network route used by the mediated executor.
+
+No token-carried key becomes a trust root. Status must come from an internal,
+authenticated, buyer-controlled source. Record its observation time and
+freshness limit. Revoked or consumed means reject; stale, unauthenticated,
+unchecked, or unavailable means withhold provider entry.
+
+## 2. Enforce the exact crossing
+
+Before local authorization, verify and bind all six Cedulon request members:
+
+| Native request | Exact action |
+| --- | --- |
+| `amount` | `amount` |
+| `currency` | `currency` |
+| `payee` | `payee` |
+| `tool` | `tool` |
+| `nonce` | `nonce` |
+| `manifestHash` | `manifest_hash` |
+
+Any missing, null, normalized, substituted, or extra material value is not the
+reviewed action. Refuse it or return `INDETERMINATE`; never repair it silently.
+`SATISFIED` alone is not provider-entry authority. Require a separate current
+Gate authorization bound to the exact CAID/action digest, buyer deployment,
+executor, provider account, policy version, and validity window.
+
+## 3. Atomically create both fences and the attempt
+
+In the buyer database, use the same database transaction to insert both unique
+replay fences and the durable provider-attempt row in state `RESERVED`:
+
+1. (`issuer_key_id`, `consumer_deployment_id`, `singleUseId`)
+2. (`issuer_key_id`, `consumer_deployment_id`, `nonce`)
+
+The attempt row must bind the issuer, deployment, both replay identities, exact
+action digest/CAID, Gate authorization, executor, provider account, and a stable
+provider operation ID. Commit the two fences and the `RESERVED` row together or
+commit none of them. If either tuple already exists, deny entry. Concurrent
+attempts must yield one winner at most.
+
+Cedulon's allow is consumed on the first settlement attempt, including a
+fail-closed abort. Once this transaction commits, both replay fences are
+terminal and never released, including after `NOT_ENTERED`. Changing a wrapper,
+request, process, response, or outcome cannot make either identity reusable.
+
+## 4. Persist provider-attempt state before side effects
+
+After the three-record transaction commits, durably transition the attempt from
+`RESERVED` to `PROVIDER_ENTRY_STARTED` before any provider I/O, including DNS,
+connection setup, SDK invocation, or request transmission. If that transition
+cannot commit, perform no provider I/O. The Decision Token and both replay
+identities remain consumed.
+
+Terminal states are `EXECUTED`, `NOT_ENTERED`, and `INDETERMINATE`.
+None releases either replay fence. A crash, timeout, lost response, or failed
+post-effect commit after `PROVIDER_ENTRY_STARTED` becomes `INDETERMINATE`.
+Reconciliation records what happened but never restores the consumed allow.
+Every retry requires a newly issued Decision Token with fresh identities,
+regardless of the prior terminal state.
+
+## 5. Deny bypasses
+
+Make the mediated executor the only process able to reach the provider sandbox
+or read its credential. Deny direct SDK/API use by agents, models, web routes,
+workers, and operators outside the named break-glass path. A request without a
+current accepted profile result, current Gate authorization, both replay
+reservations, and the durable attempt row must not cross the provider boundary.
+
+Log bypass denials without recording secrets or raw payment credentials. Test
+network policy and credential isolation, not only application routing.
+
+## 6. Required acceptance tests
+
+All tests run in the buyer sandbox and preserve database and provider evidence.
+
+### Hostile input and status
+
+- Substitute each of the six bound fields separately; every case is denied.
+- Present a token-carried self-signed key and a non-empty actual COSE
+  unprotected map; both are denied.
+- Exercise expired, revoked, consumed, stale, unchecked, unauthenticated, and
+  unavailable status. None may reach the provider.
+- Present a Spend Receipt or Rail Extract in the Decision Token role; deny it.
+- Attempt direct provider access without Gate; network and credential controls
+  deny it.
+
+### Atomic replay and concurrency
+
+- Race two requests with the same `singleUseId` and different nonces; at most
+  one enters.
+- Race two requests with the same nonce and different `singleUseId` values; at
+  most one enters.
+- Race identical requests across two Gate processes; at most one enters.
+- Change only the wrapper or process ID; neither replay fence is bypassed.
+
+### Restart and uncertainty
+
+- Restart after reservation but before provider entry. Recovery reads the
+  durable row, keeps both fences, and does not create a second attempt.
+- Restart after `PROVIDER_ENTRY_STARTED` but before provider response or local
+  commit. Recovery reports `INDETERMINATE`, keeps both fences, and does not
+  retry.
+- Restart after each terminal state and confirm the state and fences survive.
+
+### Reconciliation
+
+- Accept reconciliation evidence only from an authenticated buyer-configured
+  source and bind it to the same provider, provider operation ID, issuer,
+  deployment, `singleUseId`, nonce, and exact CAID/action digest.
+- Reject stale, partial, unsigned, mismatched, or non-final evidence.
+- Prove that no reconciliation outcome, including authenticated final
+  `NOT_ENTERED`, releases either replay fence or makes the Decision Token
+  reusable.
+- Prove that every retry uses a newly issued Decision Token with a fresh
+  `singleUseId` and fresh nonce.
+
+## 7. Exit evidence
+
+A pilot is ready for external review only when the buyer returns: the pinned
+configuration; test results; database uniqueness definitions; restart traces;
+reconciliation evidence; network/credential bypass-denial evidence; and a
+statement naming every untested path.
+
+Even then, describe it as one buyer-controlled sandbox pilot. Do not call it a
+Cedulon or EMILIA certification, general security proof, production deployment,
+authorization standard, payment finality result, or legal/compliance opinion.

--- a/conformance/composition/cedulon-aeb-crossing-v0.1/adoption/independent-run-attestation.template.json
+++ b/conformance/composition/cedulon-aeb-crossing-v0.1/adoption/independent-run-attestation.template.json
@@ -1,0 +1,27 @@
+{
+  "@version": "EMILIA-INDEPENDENT-CROSSING-RUN-ATTESTATION-v0.1",
+  "profile": "cedulon-aeb-crossing-v0.1",
+  "run_record_sha256": "sha256:<hash-of-unaltered-runner-output>",
+  "run_record_report_digest": "sha256:<report-digest-from-runner-output>",
+  "reviewed_commit": "<40-lowercase-hex-git-commit>",
+  "runner": {
+    "name": "<name>",
+    "organization": "<organization-or-independent>",
+    "contact": "<contact>",
+    "relationship_to_emilia": "<description>",
+    "relationship_to_cedulon": "<description>"
+  },
+  "independence_statement": "I ran the repository-supplied immutable command set in a fresh exact-commit checkout and report the resulting bytes without modification.",
+  "exceptions": [],
+  "claim_boundary": {
+    "native_author_confirmation": false,
+    "endorsement_or_certification": false,
+    "authorization": false,
+    "production_deployment": false,
+    "settlement_or_payment_finality": false,
+    "general_security_assurance": false
+  },
+  "signed_at": "<ISO-8601-or-null>",
+  "signature_scheme": "<external-method-or-none>",
+  "signature": "<external-signature-or-null>"
+}

--- a/conformance/composition/cedulon-aeb-crossing-v0.1/adoption/independent-runner.md
+++ b/conformance/composition/cedulon-aeb-crossing-v0.1/adoption/independent-runner.md
@@ -1,0 +1,30 @@
+# Independent reproduction
+
+Run this from a fresh clone at the exact candidate commit supplied for review.
+The runner accepts no command overrides and refuses a dirty tracked worktree.
+It executes the fixed commands embedded in `independent-runner.mjs` and emits
+an unsigned JSON run record to standard output. The record includes Node and
+npm versions, the package-lock digest, and clean tracked-worktree state before
+and after the run.
+
+```sh
+git clone https://github.com/emiliaprotocol/emilia-protocol.git
+cd emilia-protocol
+git checkout --detach <exact-reviewed-commit>
+npm ci
+node conformance/composition/cedulon-aeb-crossing-v0.1/adoption/independent-runner.mjs \
+  > /tmp/cedulon-aeb-independent-run.json
+```
+
+Do not pipe through a formatter before preserving the original bytes. Send:
+
+1. `/tmp/cedulon-aeb-independent-run.json`;
+2. the exact commit hash you were asked to review;
+3. your completed identity/independence fields from
+   `independent-run-attestation.template.json`; and
+4. an external signature or signed email if you choose to attest the record.
+
+The repository does not create or verify the reviewer's identity. `PASS` means
+only that the fixed local commands exited successfully and the two profile
+entry points returned the same checked-in deterministic report. It is not an
+endorsement, certification, deployment result, or security audit.

--- a/conformance/composition/cedulon-aeb-crossing-v0.1/adoption/independent-runner.mjs
+++ b/conformance/composition/cedulon-aeb-crossing-v0.1/adoption/independent-runner.mjs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+import crypto from 'node:crypto';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '../../../..');
+const PROFILE = 'conformance/composition/cedulon-aeb-crossing-v0.1';
+
+export const COMMANDS = Object.freeze([
+  Object.freeze(['npm', '--prefix', 'packages/verify', 'run', 'build']),
+  Object.freeze(['node', '--test', `${PROFILE}/adoption/validate.node-test.mjs`]),
+  Object.freeze(['node', '--test', `${PROFILE}/run.test.mjs`]),
+  Object.freeze(['node', `${PROFILE}/run.mjs`]),
+  Object.freeze(['node', 'packages/verify/cli.js', 'crossing-lab', 'run', `${PROFILE}/workspace`]),
+]);
+
+function sha256(bytes) {
+  return `sha256:${crypto.createHash('sha256').update(bytes).digest('hex')}`;
+}
+
+function git(...args) {
+  return execFileSync('git', args, { cwd: ROOT, encoding: 'utf8' }).trim();
+}
+
+function run(command) {
+  const [file, ...args] = command;
+  const result = spawnSync(file, args, {
+    cwd: ROOT,
+    encoding: 'utf8',
+    env: { ...process.env, CI: '1', NO_COLOR: '1' },
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  if (result.error) throw result.error;
+  return {
+    command: command.join(' '),
+    exit_code: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseJsonOutput(result, label) {
+  try {
+    return JSON.parse(result.stdout);
+  } catch (error) {
+    throw new Error(`${label} did not emit one JSON document: ${error.message}`);
+  }
+}
+
+export function runIndependentReproduction() {
+  if (process.argv.length !== 2) throw new Error('independent runner accepts no arguments or command overrides');
+  const trackedStatus = git('status', '--porcelain', '--untracked-files=no');
+  if (trackedStatus !== '') throw new Error('tracked worktree must be clean before independent reproduction');
+
+  const startedAt = new Date().toISOString();
+  const results = COMMANDS.map(run);
+  const failed = results.find((result) => result.exit_code !== 0);
+  if (failed) {
+    process.stderr.write(failed.stderr || failed.stdout);
+    throw new Error(`reproduction command failed: ${failed.command}`);
+  }
+
+  const profileReport = parseJsonOutput(results[3], 'profile runner');
+  const labReport = parseJsonOutput(results[4], 'Crossing Lab CLI');
+  if (profileReport.profile_passed !== true || labReport.lab_passed !== true) {
+    throw new Error('profile or Crossing Lab did not report a passing result');
+  }
+  if (profileReport.crossing_lab_report_digest !== labReport.report_digest) {
+    throw new Error('profile and Crossing Lab report digests differ');
+  }
+
+  const scriptBytes = readFileSync(fileURLToPath(import.meta.url));
+  const packageLockBytes = readFileSync(resolve(ROOT, 'package-lock.json'));
+  const sourceLockBytes = readFileSync(resolve(ROOT, PROFILE, 'source-lock.json'));
+  const reportBytes = readFileSync(resolve(ROOT, PROFILE, 'report.reference.json'));
+  const npmVersion = execFileSync('npm', ['--version'], { cwd: ROOT, encoding: 'utf8' }).trim();
+  const trackedStatusAfter = git('status', '--porcelain', '--untracked-files=no');
+  if (trackedStatusAfter !== '') throw new Error('reproduction commands changed tracked worktree files');
+  const finishedAt = new Date().toISOString();
+  return {
+    '@version': 'EMILIA-INDEPENDENT-CROSSING-RUN-RECORD-v0.1',
+    status: 'PASS',
+    claim: 'exact-commit local reproduction only',
+    profile: 'cedulon-aeb-crossing-v0.1',
+    repository: 'https://github.com/emiliaprotocol/emilia-protocol',
+    commit: git('rev-parse', 'HEAD'),
+    tracked_worktree_clean_at_start: true,
+    tracked_worktree_clean_at_end: true,
+    started_at: startedAt,
+    finished_at: finishedAt,
+    runtime: {
+      node_version: process.version,
+      npm_version: npmVersion,
+      package_lock_sha256: sha256(packageLockBytes),
+    },
+    runner: {
+      path: relative(ROOT, fileURLToPath(import.meta.url)),
+      sha256: sha256(scriptBytes),
+      commands: results.map(({ command, exit_code }) => ({ command, exit_code })),
+    },
+    observed: {
+      source_lock_file_sha256: sha256(sourceLockBytes),
+      reference_report_file_sha256: sha256(reportBytes),
+      report_digest: profileReport.report_digest,
+      crossing_lab_report_digest: labReport.report_digest,
+    },
+    claim_boundary: {
+      native_author_confirmation: false,
+      endorsement_or_certification: false,
+      authorization: false,
+      production_deployment: false,
+      settlement_or_payment_finality: false,
+      general_security_assurance: false,
+    },
+  };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    process.stdout.write(`${JSON.stringify(runIndependentReproduction(), null, 2)}\n`);
+  } catch (error) {
+    process.stderr.write(`${error.stack ?? error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/conformance/composition/cedulon-aeb-crossing-v0.1/adoption/native-author-confirmation.md
+++ b/conformance/composition/cedulon-aeb-crossing-v0.1/adoption/native-author-confirmation.md
@@ -1,0 +1,35 @@
+# Native-author semantic confirmation
+
+This checklist asks whether the pinned profile preserves Cedulon's intended
+meaning. It is not a request to certify EMILIA, approve a deployment, validate
+the independent adapter implementation, or endorse any security claim.
+
+Please mark each item **confirmed**, **correction needed**, or **not within my
+review**, and add exact replacement text where useful.
+
+| Item | Proposed interpretation | Response / correction |
+| --- | --- | --- |
+| Reviewed source | The profile is scoped to `draft-dogru-cedulon-04`, the annotated Cedulon `v0.7.0` tag at `4a5eab26dde9edbd71db01f6253cc0a7aff72a37`, and the package integrities in `../source-lock.json`. | |
+| Artifact role | A Decision Token is pre-settlement machine-policy evidence. It is not human approval, provider-entry authorization, a Spend Receipt, or proof of settlement. | |
+| Exact request | `requestHash` covers `amount`, `currency`, `payee`, `tool`, `nonce`, and `manifestHash`; changing any one changes the request being evaluated. | |
+| Mapping | Those six fields map by exact copy to `cedulon.payment.attempt.1`, with `manifestHash` represented as `manifest_hash`. | |
+| Narrow subset | This v0.1 profile withholds acceptance when `tool` or `manifestHash` is null instead of inventing a sentinel that Cedulon did not sign. | |
+| Trust | The consumer pins the PDP issuer key outside the presented token. A token-carried key is not treated as a trust root. | |
+| COSE strictness | The profile requires the actual COSE_Sign1 unprotected map to be empty, in addition to checking the protected headers and signature. | |
+| Status | Revoked or consumed decisions are rejected. Unavailable, unchecked, or stale status withholds acceptance. The profile does not claim Cedulon defines the authenticated status service used by a deployment. | |
+| Replay identities | `singleUseId` and `nonce` are distinct native identities. A production consumer must enforce both independently and atomically in an issuer-and-deployment namespace. Cedulon's allow is consumed on the first settlement attempt, including a fail-closed abort. | |
+| Terminal consumption | Neither replay identity becomes reusable after `EXECUTED`, `NOT_ENTERED`, or `INDETERMINATE`. Reconciliation may establish the outcome but never restores the consumed Decision Token. A retry requires a newly issued Decision Token with fresh identities. | |
+| Audience | The pinned Decision Token does not itself carry a relying-party audience. This profile is limited to one configured consumer/PDP trust domain and does not manufacture cross-domain audience binding. | |
+| Limits | A passing profile does not prove payment execution, settlement, finality, rail completeness, human approval, authorization, production deployment, certification, or general protocol security. | |
+
+Reviewer name:
+
+Affiliation (optional):
+
+Cedulon source revision reviewed:
+
+Date:
+
+Corrections or additional limits:
+
+Confirmation method (email, signed note, pull-request review, or other):

--- a/conformance/composition/cedulon-aeb-crossing-v0.1/adoption/validate.node-test.mjs
+++ b/conformance/composition/cedulon-aeb-crossing-v0.1/adoption/validate.node-test.mjs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { COMMANDS } from './independent-runner.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+function text(name) {
+  return readFileSync(resolve(HERE, name), 'utf8');
+}
+
+test('independent runner exposes only the fixed reviewed command set', () => {
+  assert.deepEqual(COMMANDS, [
+    ['npm', '--prefix', 'packages/verify', 'run', 'build'],
+    ['node', '--test', 'conformance/composition/cedulon-aeb-crossing-v0.1/adoption/validate.node-test.mjs'],
+    ['node', '--test', 'conformance/composition/cedulon-aeb-crossing-v0.1/run.test.mjs'],
+    ['node', 'conformance/composition/cedulon-aeb-crossing-v0.1/run.mjs'],
+    ['node', 'packages/verify/cli.js', 'crossing-lab', 'run', 'conformance/composition/cedulon-aeb-crossing-v0.1/workspace'],
+  ]);
+  assert.equal(Object.isFrozen(COMMANDS), true);
+  assert.equal(COMMANDS.every(Object.isFrozen), true);
+});
+
+test('attestation template is closed around reproduction, identity, and claim limits', () => {
+  const template = JSON.parse(text('independent-run-attestation.template.json'));
+  assert.deepEqual(Object.keys(template), [
+    '@version', 'profile', 'run_record_sha256', 'run_record_report_digest',
+    'reviewed_commit', 'runner', 'independence_statement', 'exceptions',
+    'claim_boundary', 'signed_at', 'signature_scheme', 'signature',
+  ]);
+  assert.equal(template.profile, 'cedulon-aeb-crossing-v0.1');
+  assert.deepEqual(Object.values(template.claim_boundary), [false, false, false, false, false, false]);
+});
+
+test('pilot runbook names both replay fences, exact fields, and fail-closed operations', () => {
+  const runbook = text('buyer-gate-pilot-runbook.md');
+  const semanticDocs = `${runbook}\n${text('README.md')}\n${text('native-author-confirmation.md')}`;
+  for (const value of ['amount', 'currency', 'payee', 'tool', 'nonce', 'manifestHash']) {
+    assert.match(runbook, new RegExp(`\\b${value}\\b`));
+  }
+  assert.match(runbook, /\(`issuer_key_id`, `consumer_deployment_id`, `singleUseId`\)/);
+  assert.match(runbook, /\(`issuer_key_id`, `consumer_deployment_id`, `nonce`\)/);
+  for (const requirement of [
+    'buyer-controlled source', 'PROVIDER_ENTRY_STARTED', 'INDETERMINATE',
+    'never released', 'newly issued Decision Token', 'fresh identities',
+    'Deny bypasses', 'Restart', 'Reconciliation',
+  ]) assert.ok(runbook.includes(requirement), requirement);
+  assert.doesNotMatch(semanticDocs, /may release|can release|release either fence/i);
+  assert.match(semanticDocs, /first settlement attempt[\s\S]*fail-closed abort/);
+  assert.match(semanticDocs, /`NOT_ENTERED`[\s\S]*never (?:restores|released)/);
+  assert.match(runbook, /same database transaction[\s\S]*`RESERVED`/);
+  assert.match(runbook, /`PROVIDER_ENTRY_STARTED`[\s\S]*before any provider I\/O/);
+});
+
+test('cover sheet and author checklist retain the non-claim boundary', () => {
+  const combined = `${text('README.md')}\n${text('native-author-confirmation.md')}`;
+  for (const limit of [
+    'endorsement', 'certification', 'authorization', 'production deployment',
+    'settlement', 'payment', 'finality', 'general protocol security',
+  ]) assert.match(combined.toLowerCase(), new RegExp(limit));
+});


### PR DESCRIPTION
## What

- Adds a narrow native-author semantic confirmation checklist.
- Adds a fixed-command independent reproduction runner and attestation template.
- Adds a buyer-controlled Gate sandbox pilot runbook.
- Keeps the packet confined to the existing Cedulon crossing profile.

## Claim boundary

This does not claim Cedulon endorsement, certification, authorization, payment execution or finality, production deployment, complete mediation, or general security. A passing run is exact-commit local reproduction only.

The runbook preserves Cedulon first-attempt consumption semantics: singleUseId and nonce are independent atomic fences, remain consumed for every outcome, and cannot be restored by reconciliation. Fences and the durable RESERVED attempt row commit in one transaction; PROVIDER_ENTRY_STARTED commits before provider I/O.

## Verification

- Adoption validator: 4/4 pass.
- Existing Cedulon profile: 10/10 pass.
- Crossing Lab: 6/6 adapter rows and 4/4 harness checks pass.
- Independent runner: all five fixed commands pass on exact head 909bd5b4bb61acc4f6c80ef1100bf6331193a688.
- Root Vitest does not collect the Node test.
- Worktree remains clean after reproduction.

## External gates still required

- Native-author semantic confirmation.
- A genuinely independent second-runner record.
- One buyer-controlled sandbox Gate pilot with restart, replay, substitution, reconciliation, and direct-bypass evidence.

No package is published by this PR.