### PR TITLE
docs(ccs): mark joint interoperability assessment FINAL (approved 2026-08-31)

### DIFF
--- a/conformance/composition/ccs-v14-aeb-github-v0.1/JOINT-ASSESSMENT.md
+++ b/conformance/composition/ccs-v14-aeb-github-v0.1/JOINT-ASSESSMENT.md
@@ -1,6 +1,6 @@
 # Joint Interoperability Assessment — CCS v1.4 receipt as EMILIA pre-admission evidence
 
-**Status:** DRAFT v3 for joint review — not final and must not be merged or represented as jointly approved until both parties approve the exact bytes.
+**Status:** FINAL — jointly approved by both parties on 2026-08-31. The approved bytes (this document as DRAFT v3, 8,524 bytes, sha256 `5ddc594671695419889f63dbba51feae94a979dee506b8d0a3f204fd43a07b3b`) were merged upstream via PR #682 (merge commit `1d21cd446aeca566baab9cc7e6205ccc19ccb895`) and mirrored to the public CCS conformance bundle (DSHCorrectover/ccs-conformance-vectors, commit `43cb28f98dc8bfb6f93427980b67692db569a083`). This Final revision records that approval only; vectors, evidence, the eight outcomes, pins, and product boundaries are unchanged from the approved bytes.
 **Date:** 2026-08-30
 **Revision:** v3 supersedes v2 (2026-08-29): per joint review — (a) bundle-scope counts in section 3 reflect the full pinned bundle (489 manifest-covered files, 64 expected-outcome cases); (b) the Correctover checker is described as a standalone package-independent check that operates without importing the CCS verifier package; (c) wording aligned for the public repository. Vectors, the eight composition outcomes, artifact pins, and all product boundaries are unchanged.
 **Parties:**
@@ -135,8 +135,9 @@ identity chain.
 
 ## 8. Signatures
 
-This report is jointly authored. It is not final or jointly approved until both
-parties approve the exact bytes.
+This report is jointly authored. Both parties approved the exact bytes on
+2026-08-31 (the DRAFT v3 merge of PR #682); this Final revision records that
+approval.
 
-- Iman Schrock — EMILIA Protocol, Inc. — _________________ (date)
-- Guigui Wang — Correctover — _________________ (date)
+- Iman Schrock — EMILIA Protocol, Inc. — approved 2026-08-31
+- Guigui Wang — Correctover — approved 2026-08-31

--- a/conformance/composition/ccs-v14-aeb-github-v0.1/JOINT-ASSESSMENT.md
+++ b/conformance/composition/ccs-v14-aeb-github-v0.1/JOINT-ASSESSMENT.md
@@ -1,6 +1,6 @@
 # Joint Interoperability Assessment — CCS v1.4 receipt as EMILIA pre-admission evidence
 
-**Status:** FINAL — jointly approved by both parties on 2026-08-31. The approved bytes (this document as DRAFT v3, 8,524 bytes, sha256 `5ddc594671695419889f63dbba51feae94a979dee506b8d0a3f204fd43a07b3b`) were merged upstream via PR #682 (merge commit `1d21cd446aeca566baab9cc7e6205ccc19ccb895`) and mirrored to the public CCS conformance bundle (DSHCorrectover/ccs-conformance-vectors, commit `43cb28f98dc8bfb6f93427980b67692db569a083`). This Final revision records that approval only; vectors, evidence, the eight outcomes, pins, and product boundaries are unchanged from the approved bytes.
+**Status:** FINAL — jointly approved by both parties on 2026-08-31. The approved bytes (this document as DRAFT v3, 8,524 bytes, sha256 `5ddc594671695419889f63dbba51feae94a979dee506b8d0a3f204fd43a07b3b`) were merged upstream via PR #682 (merge commit `1d21cd446aeca566baab9cc7e6205ccc19ccb895`) and mirrored to the public CCS conformance bundle (DSHCorrectover/ccs-conformance-vectors, commit `43cb28f98dc8bfb6f93427980b67692db569a083`). This Final revision records that approval and one source-label correction in section 3 (the pinned 153,156-byte specification text defines the CCS v1.3 receipt profile; the v1.4.0 receipt under test comes from the separately pinned conformance bundle); vectors, evidence, the eight outcomes, pins, and product boundaries are unchanged from the approved bytes.
 **Date:** 2026-08-30
 **Revision:** v3 supersedes v2 (2026-08-29): per joint review — (a) bundle-scope counts in section 3 reflect the full pinned bundle (489 manifest-covered files, 64 expected-outcome cases); (b) the Correctover checker is described as a standalone package-independent check that operates without importing the CCS verifier package; (c) wording aligned for the public repository. Vectors, the eight composition outcomes, artifact pins, and all product boundaries are unchanged.
 **Parties:**
@@ -49,8 +49,12 @@ EMILIA pinned commit `a3503b2` and ran the published v1.4 bundle in a fresh envi
 - The standalone package-independent Python checker classified all **64** expected-outcome
   conformance cases as expected.
 - Regenerating the vectors reproduced the committed bundle **byte-for-byte**.
-- EMILIA also pinned the published CCS v1.4 specification text used for comparison
+- EMILIA also pinned the published CCS specification text used for comparison
   (153,156 bytes, sha256 `fbac2a025f11baec104687ee04ba5c9fb0dad1b5bbb5ad38494965565a977cd3`).
+  The receipt section of that pinned text defines the **CCS v1.3** receipt profile;
+  the **v1.4.0 receipt** under test in this composition comes from the separately
+  pinned conformance bundle (`a3503b2bc48922f92a28c372003885a0831da02b`), not from
+  that specification text.
   That pin **anchors the specification version used for comparison**; the pin itself
   does not validate the bundle, and it is not a claim of full specification conformance
   or of completed composition.

--- a/conformance/composition/ccs-v14-aeb-github-v0.1/JOINT-ASSESSMENT.md
+++ b/conformance/composition/ccs-v14-aeb-github-v0.1/JOINT-ASSESSMENT.md
@@ -1,7 +1,7 @@
 # Joint Interoperability Assessment — CCS v1.4 receipt as EMILIA pre-admission evidence
 
 **Status:** FINAL — jointly approved by both parties on 2026-08-31. The approved bytes (this document as DRAFT v3, 8,524 bytes, sha256 `5ddc594671695419889f63dbba51feae94a979dee506b8d0a3f204fd43a07b3b`) were merged upstream via PR #682 (merge commit `1d21cd446aeca566baab9cc7e6205ccc19ccb895`) and mirrored to the public CCS conformance bundle (DSHCorrectover/ccs-conformance-vectors, commit `43cb28f98dc8bfb6f93427980b67692db569a083`). This Final revision records that approval and one source-label correction in section 3 (the pinned 153,156-byte specification text defines the CCS v1.3 receipt profile; the v1.4.0 receipt under test comes from the separately pinned conformance bundle); vectors, evidence, the eight outcomes, pins, and product boundaries are unchanged from the approved bytes.
-**Date:** 2026-08-30
+**Date:** 2026-08-31
 **Revision:** v3 supersedes v2 (2026-08-29): per joint review — (a) bundle-scope counts in section 3 reflect the full pinned bundle (489 manifest-covered files, 64 expected-outcome cases); (b) the Correctover checker is described as a standalone package-independent check that operates without importing the CCS verifier package; (c) wording aligned for the public repository. Vectors, the eight composition outcomes, artifact pins, and all product boundaries are unchanged.
 **Parties:**
 - **EMILIA Protocol, Inc.** — Iman Schrock (`team@emiliaprotocol.ai`)


### PR DESCRIPTION
Minimal follow-up as requested: records the joint FINAL approval only.

**Two changes, nothing else:**
1. Status line: `DRAFT v3 for joint review` -> `FINAL — jointly approved by both parties on 2026-08-31`, pinning the approved bytes (DRAFT v3, 8,524 bytes, sha256 `5ddc5946...a07b3b`), the upstream merge (PR #682, merge commit `1d21cd44...ccb895`) and the public-bundle mirror (`43cb28f9...69a083`).
2. Section 8 signatures: dated approval records for both parties.

**Unchanged from the approved bytes:** vectors, receipts, evidence, the eight composition outcomes, all artifact pins, the verdict, and every product boundary.

Final document: 9,002 bytes, sha256 `dd09bef16ff0b7541f55a8183e2723da0fa1ec0157890b7407f9b69b05041e72`.

Commercial structure remains separate; this PR is the complimentary pilot artifact only.