### PR TITLE
fix(db): make AEB terminal migration deployable

### DIFF
--- a/supabase/migration-history.v1.json
+++ b/supabase/migration-history.v1.json
@@ -435,6 +435,6 @@
     "20260826150000_identity_proof_and_mobile_pairing_closure.sql": "eed7f69bf6f0139ad727c0c208d9c35959fcbd36611052a6860f4d5c14637549",
     "20260826160000_continuity_and_pairing_residual_closure.sql": "60a2c0571620db6fc7f8e4e69288866ad3a9dfbd4e18124b7dc4f9a05d864d86",
     "20260826170000_identity_runtime_residual_closure.sql": "b211532e1e33923a34f0c9a998704244eae78ee083b7dce503934133ac140b91",
-    "20260901190000_aeb_released_not_entered.sql": "f736ca3f444d9027e110f5368fe79c060378b1da465cd4c3c7417ba7f1119f92"
+    "20260901190000_aeb_released_not_entered.sql": "5ad206bbba31f4a318967c14cb954ec5a05f3b72fa23ad593d2442f940a84c87"
   }
 }

--- a/supabase/migrations/20260901190000_aeb_released_not_entered.sql
+++ b/supabase/migrations/20260901190000_aeb_released_not_entered.sql
@@ -12,7 +12,12 @@
 --
 -- Mirrors AEB_CONSUMPTION_DDL in packages/gate/src/aeb-consumption-store.ts.
 
-GRANT ep_aeb_store_owner TO CURRENT_USER;
+-- Production already owns the table and private schema through this NOLOGIN
+-- role. PostgreSQL 17 can retain an older membership with SET/INHERIT disabled,
+-- so a plain GRANT does not make the owner assumable by the migration runner.
+GRANT ep_aeb_store_owner TO CURRENT_USER
+  WITH INHERIT FALSE, SET TRUE;
+SET ROLE ep_aeb_store_owner;
 
 ALTER TABLE ep_aeb_consumption_operations
   ADD COLUMN IF NOT EXISTS released_at TIMESTAMPTZ NULL;
@@ -79,4 +84,5 @@ GRANT EXECUTE ON FUNCTION ep_aeb_private.release_terminal_operation(TEXT, TEXT, 
 COMMENT ON COLUMN ep_aeb_consumption_operations.released_at IS
   'Set when an authoritative non-entry made the reservation terminally RELEASED_NOT_ENTERED. The row is never deleted, so the operation key stays unreservable.';
 
+RESET ROLE;
 REVOKE ep_aeb_store_owner FROM CURRENT_USER;

--- a/tests/aeb-consumption-migration-contract.test.ts
+++ b/tests/aeb-consumption-migration-contract.test.ts
@@ -73,6 +73,15 @@ describe('AEB consumption production migration', () => {
 });
 
 describe('AEB terminal released-not-entered migration', () => {
+  it('assumes the existing no-login owner with explicit PostgreSQL 17 membership options', () => {
+    expect(terminalReleaseMigration).toContain(
+      'GRANT ep_aeb_store_owner TO CURRENT_USER\n  WITH INHERIT FALSE, SET TRUE;\nSET ROLE ep_aeb_store_owner;',
+    );
+    expect(terminalReleaseMigration).toContain(
+      'RESET ROLE;\nREVOKE ep_aeb_store_owner FROM CURRENT_USER;',
+    );
+  });
+
   it('keeps the released row and exposes only an executor-scoped terminal release', () => {
     expect(terminalReleaseMigration).toContain(
       'ADD COLUMN IF NOT EXISTS released_at TIMESTAMPTZ NULL',


### PR DESCRIPTION
## Why

The post-merge production schema contract exposed a real PostgreSQL 17 ownership boundary: `ep_aeb_consumption_operations` is owned by the NOLOGIN `ep_aeb_store_owner`, while the migration runner retained older membership rows with `SET` and `INHERIT` disabled. A plain `GRANT` did not make that owner assumable, so the reviewed migration failed before changing production.

## Change

- grant the temporary owner membership with explicit PostgreSQL 17 `SET TRUE, INHERIT FALSE` options
- assume the owner for the ALTER/function work, then reset and revoke it
- add a regression contract and refresh the governed migration hash

## Evidence

- exact migration SHA-256: `5ad206bbba31f4a318967c14cb954ec5a05f3b72fa23ad593d2442f940a84c87`
- production transaction rehearsal against `xmiiwehtivksdjbultym`: succeeded and rolled back
- `npx vitest run tests/aeb-consumption-migration-contract.test.ts`: 8/8
- `npm run check:migration-history`: 204 remote, 1 private, 5 pending, hashes/archive verified

No production schema change is claimed by this PR; deployment follows merge and an exact-byte check.