### PR TITLE
fix: rotate ambiguous production schema check

### DIFF
--- a/.github/workflows/schema-security.yml
+++ b/.github/workflows/schema-security.yml
@@ -18,7 +18,7 @@ name: schema-security
 #   service-role key is NOT in CI.
 #
 # To make this a true deploy gate: require the unique
-# `emilia-production-schema-contract` GitHub check on main and configure the
+# `emilia-production-schema-contract-v2` GitHub check on main and configure the
 # external Vercel deployment check documented in docs/operations/DEPLOYMENT.md.
 
 env:
@@ -131,7 +131,7 @@ jobs:
         run: npm run schema:reconcile
 
   schema-contract:
-    name: emilia-production-schema-contract
+    name: emilia-production-schema-contract-v2
     if: always()
     needs: [candidate-reconciliation, live-schema-contract]
     runs-on: ubuntu-latest
@@ -158,4 +158,4 @@ jobs:
               exit 1
             }
           fi
-          echo '"emilia-production-schema-contract" is satisfied.'
+          echo '"emilia-production-schema-contract-v2" is satisfied.'

--- a/deploy/consequence-control-cloud-run/tests/test_release_trust.py
+++ b/deploy/consequence-control-cloud-run/tests/test_release_trust.py
@@ -1176,8 +1176,8 @@ class WorkflowTrustContractTests(unittest.TestCase):
         self.assertIn("if: always()", aggregator)
         self.assertIn("needs.candidate-reconciliation.result", aggregator)
         self.assertIn("needs.live-schema-contract.result", aggregator)
-        self.assertIn('name: emilia-production-schema-contract', workflow)
-        self.assertIn('"emilia-production-schema-contract" is satisfied.', workflow)
+        self.assertIn('name: emilia-production-schema-contract-v2', workflow)
+        self.assertIn('"emilia-production-schema-contract-v2" is satisfied.', workflow)
 
     def test_ci_uses_the_same_release_image_builder(self) -> None:
         workflow = (ROOT / ".github/workflows/ci.yml").read_text()

--- a/docs/operations/DEPLOYMENT.md
+++ b/docs/operations/DEPLOYMENT.md
@@ -191,7 +191,7 @@ forward and prevents a new application from reaching RPCs that are not live yet.
 `vercel.json` cannot register project Deployment Checks. Production aliasing
 remains unsafe until this external check exists in the linked Vercel project.
 The GitHub Actions check-run name is intentionally unique and stable:
-`emilia-production-schema-contract`. Do not rename it without replacing the
+`emilia-production-schema-contract-v2`. Do not rename it without replacing the
 Vercel configuration and branch-protection requirement in the same controlled
 change.
 
@@ -202,11 +202,12 @@ then add exactly one blocking production check:
 vercel project inspect
 vercel project checks --format json
 vercel project checks add \
-  --check-name "emilia-production-schema-contract" \
+  --check-name "emilia-production-schema-contract-v2" \
   --requires build-ready \
   --blocks deployment-alias \
   --targets production \
-  --source '{"kind":"git-provider","provider":"github","externalCheckName":"emilia-production-schema-contract"}' \
+  --timeout 5000 \
+  --source '{"kind":"git-provider","provider":"github","externalCheckName":"emilia-production-schema-contract-v2"}' \
   --format json
 vercel project checks --blocks deployment-alias --format json
 ```
@@ -220,14 +221,15 @@ curl --fail-with-body --request POST \
   --header "Authorization: Bearer ${VERCEL_TOKEN}" \
   --header "Content-Type: application/json" \
   --data '{
-    "name": "emilia-production-schema-contract",
+    "name": "emilia-production-schema-contract-v2",
     "requires": "build-ready",
     "blocks": "deployment-alias",
     "targets": ["production"],
+    "timeout": 5000,
     "source": {
       "kind": "git-provider",
       "provider": "github",
-      "externalCheckName": "emilia-production-schema-contract"
+      "externalCheckName": "emilia-production-schema-contract-v2"
     }
   }'
 ```
@@ -236,10 +238,37 @@ Use the CLI path when possible because it resolves the already-linked project
 and scope. Never paste token values into the command or repository. If creation
 returns an ambiguous error, list checks before retrying so a duplicate is not
 created. The resulting object must have `requires=build-ready`,
-`blocks=deployment-alias`, `targets=["production"]`, and the exact GitHub source
-above. Also require `emilia-production-schema-contract` in GitHub rules for
-`main`. A Vercel `Force Promote` bypasses Deployment Checks and requires an
-explicit incident decision; it is not a normal release path.
+`blocks=deployment-alias`, `targets=["production"]`, `timeout=5000`, and the
+exact GitHub source above. Also require
+`emilia-production-schema-contract-v2` in GitHub rules for `main`. A Vercel
+`Force Promote` bypasses Deployment Checks and requires an explicit incident
+decision; it is not a normal release path.
+
+GitHub Actions reruns retain the failed check run and create another attempt.
+Vercel can therefore bind a redeploy of the same commit to the historical
+failure even after the rerun succeeds. Preserve both results as audit evidence:
+do not delete the Actions run or bypass the deployment check. Release a new
+reviewed commit, or rotate this exact external check name together with the
+workflow, Vercel project configuration, and GitHub rule.
+
+Rotate the name fail-closed. Add the new Vercel check while the old check still
+blocks production aliasing. Merge the reviewed workflow rename under the old
+GitHub requirement; the first new production deployment may remain deliberately
+unaliased. After the new check succeeds on `main`, replace the GitHub required
+context with the v2 name, remove the old Vercel check by its inspected id, and
+redeploy that exact reviewed commit so only the successful v2 verdict controls
+aliasing:
+
+```bash
+vercel project checks --format json
+vercel project checks remove "${OLD_VERCEL_CHECK_ID}"
+vercel redeploy "${REVIEWED_DEPLOYMENT_ID}" --target production
+vercel project checks --blocks deployment-alias --format json
+```
+
+Never delete the historical GitHub Actions run. If the GitHub rule cannot be
+updated, keep the old Vercel check in place and leave the deployment unaliased;
+do not create an unguarded transition window.
 
 ```bash
 # Build

--- a/tests/agent-record-documentation-contract.test.ts
+++ b/tests/agent-record-documentation-contract.test.ts
@@ -166,14 +166,22 @@ describe('Agent Record documentation and OpenAPI lifecycle contract', () => {
   });
 
   it('pins one unique GitHub check name and exact external Vercel alias gate', () => {
-    expect(schemaWorkflow).toContain('name: emilia-production-schema-contract');
-    expect(schemaWorkflow.match(/name: emilia-production-schema-contract/g)).toHaveLength(1);
-    expect(deploymentDocs).toContain('--check-name "emilia-production-schema-contract"');
+    expect(schemaWorkflow).toContain('name: emilia-production-schema-contract-v2');
+    expect(schemaWorkflow.match(/name: emilia-production-schema-contract-v2/g)).toHaveLength(1);
+    expect(deploymentDocs).toContain('--check-name "emilia-production-schema-contract-v2"');
     expect(deploymentDocs).toContain('--requires build-ready');
     expect(deploymentDocs).toContain('--blocks deployment-alias');
     expect(deploymentDocs).toContain('--targets production');
+    expect(deploymentDocs).toContain('--timeout 5000');
     expect(deploymentDocs).toContain(
-      '"externalCheckName":"emilia-production-schema-contract"',
+      '"externalCheckName":"emilia-production-schema-contract-v2"',
+    );
+    expect(deploymentDocs).toContain('"timeout": 5000');
+    expect(deploymentDocs).toContain(
+      'vercel project checks remove "${OLD_VERCEL_CHECK_ID}"',
+    );
+    expect(deploymentDocs.replace(/\s+/g, ' ')).toContain(
+      'replace the GitHub required context with the v2 name',
     );
     expect(deploymentDocs).toContain(
       'POST /v2/projects/{projectIdOrName}/checks',


### PR DESCRIPTION
## Why

A GitHub Actions rerun preserves the failed check run and creates a successful second attempt. Vercel can bind a same-SHA redeploy to the historical failure, leaving a stale failed deployment status after the live schema contract is green.

## Change

- rotate the unique blocking check to `emilia-production-schema-contract-v2`
- preserve the existing 5,000-second deployment-check timeout
- update the exact Vercel configuration contract and tests
- document a fail-closed add, merge, required-context replacement, delete, and exact-SHA redeploy sequence
- preserve failed GitHub evidence and prohibit Force Promote as normal recovery

## Local verification

- `python3 -m unittest deploy.consequence-control-cloud-run.tests.test_release_trust` (29 passed)
- `npm exec vitest run tests/agent-record-documentation-contract.test.ts` (8 passed)
- `git diff --check`

The old Vercel check remains blocking through merge. After the v2 check succeeds on main, the old project check will be removed and the exact reviewed deployment redeployed.
