### PR TITLE
fix: start proof-stats lock timeout after contention

### DIFF
--- a/scripts/generate-proof-stats.mjs
+++ b/scripts/generate-proof-stats.mjs
@@ -201,8 +201,6 @@ export function acquireProofStatsRunLock({ cwd = process.cwd(), timeoutMs = PROO
         process.once(signal, listener);
     }
     process.once("exit", onExit);
-    const started = process.hrtime.bigint();
-    const elapsedMs = () => Number((process.hrtime.bigint() - started) / 1000000n);
     const describeOwner = (contender, participant) => contender
         ? `live owner pid=${contender.pid} ticket=${contender.ticket ?? "choosing"} created_at=${contender.createdAt}`
         : `unreadable owner entry ${participant.slice(participant.lastIndexOf("/") + 1)}`;
@@ -226,7 +224,8 @@ export function acquireProofStatsRunLock({ cwd = process.cwd(), timeoutMs = PROO
         owner.ticket = maxTicket + 1;
         writeLockOwner(participantPath, owner);
         let blocker = "another owner";
-        while (elapsedMs() <= timeoutMs) {
+        let blockedSince = null;
+        while (true) {
             blocker = "another owner";
             let blocked = false;
             for (const participant of lockParticipants(queuePath)) {
@@ -254,7 +253,10 @@ export function acquireProofStatsRunLock({ cwd = process.cwd(), timeoutMs = PROO
             if (!blocked) {
                 return { queuePath, release: releaseEntry };
             }
-            const remaining = timeoutMs - elapsedMs();
+            if (blockedSince === null)
+                blockedSince = process.hrtime.bigint();
+            const elapsedBlockedMs = Number((process.hrtime.bigint() - blockedSince) / 1000000n);
+            const remaining = timeoutMs - elapsedBlockedMs;
             if (remaining <= 0)
                 break;
             Atomics.wait(sleepArray, 0, 0, Math.min(effectivePollMs, remaining));

--- a/scripts/generate-proof-stats.mts
+++ b/scripts/generate-proof-stats.mts
@@ -266,9 +266,6 @@ export function acquireProofStatsRunLock({
   }
   process.once("exit", onExit);
 
-  const started = process.hrtime.bigint();
-  const elapsedMs = (): number =>
-    Number((process.hrtime.bigint() - started) / 1_000_000n);
   const describeOwner = (
     contender: ProofStatsLockOwner | null,
     participant: string,
@@ -295,7 +292,8 @@ export function acquireProofStatsRunLock({
     writeLockOwner(participantPath, owner);
 
     let blocker = "another owner";
-    while (elapsedMs() <= timeoutMs) {
+    let blockedSince: bigint | null = null;
+    while (true) {
       blocker = "another owner";
       let blocked = false;
       for (const participant of lockParticipants(queuePath)) {
@@ -324,7 +322,11 @@ export function acquireProofStatsRunLock({
       if (!blocked) {
         return { queuePath, release: releaseEntry };
       }
-      const remaining = timeoutMs - elapsedMs();
+      if (blockedSince === null) blockedSince = process.hrtime.bigint();
+      const elapsedBlockedMs = Number(
+        (process.hrtime.bigint() - blockedSince) / 1_000_000n,
+      );
+      const remaining = timeoutMs - elapsedBlockedMs;
       if (remaining <= 0) break;
       Atomics.wait(sleepArray, 0, 0, Math.min(effectivePollMs, remaining));
     }

--- a/tests/proof-stats-run-lock.test.ts
+++ b/tests/proof-stats-run-lock.test.ts
@@ -12,7 +12,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { execFileSync } from 'node:child_process';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   acquireProofStatsRunLock,
@@ -251,11 +251,26 @@ describe('proof-stats run serialization', () => {
     expect(readFileSync(path.join(queue, '.version'), 'utf8')).toBe('1\n');
   });
 
-  it('releases its own entry on normal exit', () => {
+  it('acquires uncontended before consulting the timeout clock and releases its entry', () => {
     const { root } = makeWorktreeFixture();
-    const lock = acquireProofStatsRunLock({ cwd: root, timeoutMs: 100 });
-    expect(lock.queuePath).toBe(resolveProofStatsLockQueue(root));
-    lock.release();
+    const start = 1_000_000_000n;
+    const clock = vi.spyOn(process.hrtime, 'bigint')
+      .mockReturnValueOnce(start)
+      .mockReturnValue(start + 101_000_000n);
+    let lock: ReturnType<typeof acquireProofStatsRunLock>;
+    try {
+      lock = acquireProofStatsRunLock({ cwd: root, timeoutMs: 100 });
+      expect(clock).not.toHaveBeenCalled();
+    } finally {
+      clock.mockRestore();
+    }
+    let released = false;
+    try {
+      expect(lock.queuePath).toBe(resolveProofStatsLockQueue(root));
+    } finally {
+      released = lock.release();
+    }
+    expect(released).toBe(true);
     expect(lock.release()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

A main-ref CI run on `537206639f1c27c18420f6f2e1465a817a0c8aff` falsely timed out while acquiring an uncontended proof-stats lock. The timeout clock started before participant setup, so a scheduling delay longer than the 100 ms test budget could expire the loop before its first eligibility scan.

This change:

- always performs the first contender scan;
- starts timeout accounting only after observing a real blocker;
- preserves ticket ordering, stale-owner cleanup, and live-owner timeout behavior;
- regenerates the governed JavaScript companion; and
- strengthens the existing release test with a deterministic advanced-clock regression without changing the governed test count.

Failed main job: https://github.com/emiliaprotocol/emilia-protocol/actions/runs/33747101762/job/100621995695

## Scope

Affected components:

- `scripts/generate-proof-stats.mts`
- `scripts/generate-proof-stats.mjs`
- `tests/proof-stats-run-lock.test.ts`

This does not change timeout values, protocol behavior, production authorization, public claims, or storage formats.

## Risk and security impact

- Security impact: limited to repository evidence-generation coordination. The patch removes a false refusal without weakening mutual exclusion.
- Failure/refusal behavior: a live or unreadable competing owner still blocks acquisition and produces the configured timeout without stealing the lock.
- Compatibility impact: internal tooling only; no public API or data-format change.

## Verification

| Check | Command or evidence | Result |
| --- | --- | --- |
| Regression against base | `npm run test:run -- tests/proof-stats-run-lock.test.ts` on `537206639` | RED as intended: 6 passed, 1 failed with the exact false timeout |
| Narrow tests | `npm run test:run -- tests/proof-stats-run-lock.test.ts` under Node 24.18.0 | PASS: 7/7, repeated twice |
| Standalone companion | `npm run check:standalone-runtimes` | PASS: 713 governed runtimes |
| Core types | `npm run typecheck:core` | PASS |
| Remaining types | `npm run typecheck:rest` | PASS |
| Proof-stat evidence | `TLA2TOOLS_JAR=/private/tmp/emilia-tla2tools-1.7.4.jar npm run check:proof-stats` under Node 24.18.0; pinned jar SHA-256 `936a262061c914694dfd669a543be24573c45d5aa0ff20a8b96b23d01e050e88` | PASS: 10,684 tests / 667 files; 20 Tamarin lemmas; 35 security claims; 335 vectors; 359 external hostility cases |
| Diff hygiene | `git diff --check` | PASS |

Not run / limitations:

- `npm run typecheck:strict` remains unavailable as a clean repository-wide signal because it reports the existing 1,286-error migration baseline, unrelated to these files.
- The remaining protected repository matrix is left to pull-request CI.

## Database and migrations

- [x] No database or schema change.
- [ ] Migration files are included and have been tested from a clean schema.
- [ ] Existing-data/backfill behavior has been tested.
- [ ] Production deployment is required after merge.
- [ ] Production deployment has been completed and independently verified.

Migration files: None.

Applied environments and current status: Not applicable.

Deployment/rollback notes: Revert the single commit if necessary.

## Claims and evidence

- [x] This PR makes no public or generated claim changes.
- [ ] Claim-bearing changes are backed by current executable or primary-source evidence.
- [ ] Generated claim surfaces were regenerated from their authoritative source rather than edited directly.
- [ ] Assumptions, exclusions, limitations, and time-pinned results remain explicit.
- [ ] Standards language distinguishes an individual submission, working-group adoption, and RFC status.

Claim-bearing files and supporting evidence: None. The `.mjs` file is the governed standalone companion generated from the authoritative `.mts` source.

## Secrets and sensitive data

- [x] I reviewed the diff and test output for credentials, tokens, API keys, private keys, connection strings, personal data, and confidential production or partner information.
- [x] Examples, fixtures, screenshots, and logs use synthetic or properly sanitized data.
- [x] This PR does not publicly disclose an uncoordinated vulnerability.

## Contribution checklist

- [x] Every commit includes a DCO `Signed-off-by` line matching the natural-person author.
- [x] The change is scoped to the stated purpose and does not hide unrelated generated or mechanical changes.
- [x] New behavior includes applicable positive and negative/refusal coverage.
- [x] Documentation, conformance vectors, security-case evidence, and generated context do not require changes; the governed runtime companion is synchronized.
- [x] I reviewed the complete diff as a reviewer would.