### PR TITLE
test: add Cedulon Mizan leaked-refusal fixture

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -120,6 +120,9 @@ title = "emilia-protocol gitleaks config"
     # public Ed25519 conformance artifact, not a bearer credential.
     paths = [
       '''^conformance/composition/oauth-txn-challenge-aeb-v0\.1/native-fixture\.json$''',
+      # PR #733 carries the same kind of public, deterministic Ed25519
+      # conformance token under its WIMSE composition fixture.
+      '''^conformance/composition/wimse-wpt02-oauth-txn-aeb-v0\.1/oauth-txn-challenge-native-fixture\.json$''',
     ]
     regexes = [
       '''example''',

--- a/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/README.md
+++ b/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/README.md
@@ -1,0 +1,74 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Cedulon Mizan leaked-refusal × EMILIA Outcome Binding v0.1
+
+This fixture gives Cedulon and EMILIA one small, reproducible case to read in
+their own formats. It copies the exact `leaked-refusal` policy and JSONL bytes
+from Cedulon commit
+`06c3119badc269ef5d6d3596ea3b3d48219d6ba4`, checks their pinned SHA-256
+digests before parsing, and projects them through an EMILIA-owned adapter.
+
+The source decision says `silent`, which the pinned Mizan adapter maps to
+`deny`, while the sent log contains an effect on the same `id`. The EMILIA
+projection is deliberately closed:
+
+| Pinned source | EMILIA test projection |
+| --- | --- |
+| `verdict: "silent"` | `decision: "deny"` |
+| refusal `id` | `target: "cedulon:mizan-ig:ref:<id>"` |
+| refusal | `absent` predicate |
+| sent-row `id` | the same namespaced observed-effect `target` |
+| pinned Mizan class | `effect_type: "ig-dm-reply"` |
+| SHA-256 of sent `text` | observed-effect `value` |
+
+The adapter then creates two separate, fixture-only native inputs:
+
+1. a deterministic test-signed Trust Receipt carrying only the
+   reconciliation exercise and the mapped `absent` prediction; and
+2. a deterministic test-signed `EP-OUTCOME-OBSERVATION-v1` with role
+   `system_of_record`, not `independent_observer`.
+
+`verifyOutcomeBindingSet` performs the full current Trust Receipt and Outcome
+Observation verification. Both native signatures and their exact bindings
+verify. The reconciled Outcome Binding verdict is `divergent` because one
+matching effect exists where the mapped prediction requires none.
+
+## Run
+
+```bash
+node --test conformance/composition/cedulon-mizan-leaked-refusal-v0.1/run.node-test.mjs
+node conformance/composition/cedulon-mizan-leaked-refusal-v0.1/run.mjs --check
+```
+
+The result lock pins:
+
+- Outcome Binding result:
+  `sha256:80d9c6f5f2c6fd57eb0931044fc8d530c3fc34fbe11d8611c14aee9145486a15`
+- complete harness report:
+  `sha256:56eeb27a388ce7dbf7515cc85ec5bccb29a643ef097fb0d02b0385d26c8f8b37`
+
+The tests also refuse source-byte drift, a decision/effect reference
+substitution at the mapping seam, source-lock metadata tampering, and
+post-projection target tampering. The synthetic signed action and harness
+report bind the pinned upstream adapter and decision-profile hashes in
+addition to the three fixture-file hashes.
+
+## Claim boundary
+
+- The policy and JSONL inputs are unsigned source bytes. Their SHA-256 locks
+  establish byte identity to the reviewed commit, not authenticity,
+  completeness, or live-system provenance.
+- The EP keys are deterministic and publicly reproducible test keys. They
+  protect no secret and prove no real approver or source identity. Cedulon did
+  not sign the EP artifacts, and EMILIA did not verify a native Cedulon
+  Decision Record.
+- Artifact timestamps are derived after the fact from the 2023 fixture. This
+  run proves no temporal precommitment.
+- This is one shared raw fixture with two separately owned adapters. It is not
+  translation-free or native-format interoperability.
+- `divergent` and Cedulon's `effect-against-refusal` are profile-local labels
+  for the same pinned case. Neither result identifies which runtime component
+  allowed the effect or proves complete mediation.
+- The synthetic Trust Receipt identifies and signs only this reconciliation
+  exercise. Verification establishes authenticity, not admission or execution
+  authority. It does not authorize, retroactively validate, or reproduce the
+  original send decision.

--- a/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/adapter.mjs
+++ b/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/adapter.mjs
@@ -14,7 +14,6 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  MERKLE_V2_ALG,
   actionHash,
   buildReceiptAnchorV2,
   canonicalize,
@@ -103,7 +102,11 @@ function checkedBytes(name, supplied) {
   return bytes;
 }
 
-/** Load and authenticate the exact raw fixture before parsing either JSONL. */
+/**
+ * Load and authenticate the exact raw fixture before parsing either JSONL.
+ *
+ * @param {{raw?: {policy?: Uint8Array, decisions?: Uint8Array, sent?: Uint8Array}}} [options]
+ */
 export function loadPinnedFixture({ raw } = {}) {
   const sourceRaw = {
     policy: checkedBytes('policy', raw?.policy),
@@ -285,7 +288,7 @@ async function buildFixtureTrustReceipt(fixture, projection) {
     tree_size: 1,
     root_hash: `sha256:${anchor.merkle_root}`,
     log_key_id: FIXTURE_LOG_KEY_ID,
-    merkle_alg: MERKLE_V2_ALG,
+    merkle_alg: anchor.alg,
   };
   const checkpointDigest = crypto.createHash('sha256')
     .update(canonicalize(checkpoint), 'utf8').digest();
@@ -293,7 +296,7 @@ async function buildFixtureTrustReceipt(fixture, projection) {
   return {
     ...receipt,
     log_proof: {
-      alg: MERKLE_V2_ALG,
+      alg: anchor.alg,
       leaf_hash: `sha256:${anchor.leaf_hash}`,
       leaf_index: 0,
       inclusion_path: anchor.merkle_proof,

--- a/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/adapter.mjs
+++ b/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/adapter.mjs
@@ -1,0 +1,472 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * EMILIA-side projection of Cedulon's pinned Mizan `leaked-refusal` fixture.
+ *
+ * The three upstream files are unsigned raw source bytes. This adapter first
+ * checks their exact SHA-256 commitments, then projects the refusal and sent
+ * row into separately generated, fixture-only EMILIA Trust Receipt and
+ * Outcome Observation inputs. That is an adapter test, not native-format
+ * interoperability and not proof of which component allowed the send.
+ */
+import crypto from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  MERKLE_V2_ALG,
+  actionHash,
+  buildReceiptAnchorV2,
+  canonicalize,
+  contextDigest,
+} from '../../../packages/issue/index.js';
+import {
+  buildOutcomeObservation,
+  trustReceiptDigest,
+  verifyOutcomeBindingSet,
+} from '../../../packages/verify/index.js';
+import { predictedEffectsDigest } from '../../../packages/verify/effect-predicates.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = join(HERE, 'fixtures');
+const SOURCE_LOCK = JSON.parse(readFileSync(join(HERE, 'source-lock.json'), 'utf8'));
+const UTF8 = new TextDecoder('utf-8', { fatal: true });
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+const PKCS8_ED25519_PREFIX = Buffer.from('302e020100300506032b657004220420', 'hex');
+
+export const PROFILE = 'EMILIA-CEDULON-MIZAN-LEAKED-REFUSAL-v0.1';
+export const REPORT_VERSION = 'EMILIA-CEDULON-MIZAN-LEAKED-REFUSAL-REPORT-v0.1';
+export const SOURCE_COMMIT = SOURCE_LOCK.commit;
+export const SOURCE_LOCK_DIGEST = canonicalDigest(SOURCE_LOCK);
+
+const FILES = Object.freeze({
+  policy: 'policy.txt',
+  decisions: 'decisions.jsonl',
+  sent: 'sent.jsonl',
+});
+
+const FIXTURE_APPROVER_ID = 'ep:approver:fixture:cedulon-mizan';
+const FIXTURE_APPROVER_KEY_ID = 'ep:key:fixture:cedulon-mizan#1';
+const FIXTURE_LOG_KEY_ID = 'ep:log:fixture:cedulon-mizan#1';
+const FIXTURE_SOURCE_ID = 'ep:outcome-source:fixture:cedulon-mizan-sent-log';
+const FIXTURE_SOURCE_CLASS = 'cedulon.mizan.sent-log';
+const FIXTURE_OPERATION_ID = 'ep:operation:fixture:cedulon-mizan:leak-1';
+
+function sha256Hex(bytes) {
+  return crypto.createHash('sha256').update(bytes).digest('hex');
+}
+
+function sha256Text(text) {
+  return sha256Hex(Buffer.from(text, 'utf8'));
+}
+
+function canonicalDigest(value) {
+  return `sha256:${sha256Text(canonicalize(value))}`;
+}
+
+function exactKeys(value, expected) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    && Object.keys(value).length === expected.length
+    && expected.every((key) => Object.hasOwn(value, key));
+}
+
+function parseJsonl(bytes, name) {
+  let text;
+  try {
+    text = UTF8.decode(bytes);
+  } catch {
+    throw new Error(`source_utf8_invalid:${name}`);
+  }
+  if (!text.endsWith('\n') || text.includes('\r')) {
+    throw new Error(`source_jsonl_framing_invalid:${name}`);
+  }
+  const rows = text.slice(0, -1).split('\n');
+  if (rows.length === 0 || rows.some((row) => row.length === 0)) {
+    throw new Error(`source_jsonl_framing_invalid:${name}`);
+  }
+  try {
+    return rows.map((row) => JSON.parse(row));
+  } catch {
+    throw new Error(`source_json_invalid:${name}`);
+  }
+}
+
+function checkedBytes(name, supplied) {
+  const expected = SOURCE_LOCK.files[name];
+  const bytes = supplied === undefined
+    ? readFileSync(join(FIXTURE_DIR, FILES[name]))
+    : Buffer.from(supplied);
+  const actual = sha256Hex(bytes);
+  if (bytes.length !== expected.bytes || actual !== expected.sha256) {
+    throw new Error(`source_digest_mismatch:${name}`);
+  }
+  return bytes;
+}
+
+/** Load and authenticate the exact raw fixture before parsing either JSONL. */
+export function loadPinnedFixture({ raw } = {}) {
+  const sourceRaw = {
+    policy: checkedBytes('policy', raw?.policy),
+    decisions: checkedBytes('decisions', raw?.decisions),
+    sent: checkedBytes('sent', raw?.sent),
+  };
+  const policyText = UTF8.decode(sourceRaw.policy);
+  const decisions = parseJsonl(sourceRaw.decisions, 'decisions');
+  const sent = parseJsonl(sourceRaw.sent, 'sent');
+  return {
+    commit: SOURCE_COMMIT,
+    raw: sourceRaw,
+    policy_text: policyText,
+    decisions,
+    sent,
+    digests: Object.fromEntries(
+      Object.entries(sourceRaw).map(([name, bytes]) => [name, sha256Hex(bytes)]),
+    ),
+  };
+}
+
+function strictInstant(milliseconds, field) {
+  if (!Number.isSafeInteger(milliseconds)) throw new Error(`source_${field}_invalid`);
+  const value = new Date(milliseconds);
+  if (!Number.isFinite(value.getTime())) throw new Error(`source_${field}_invalid`);
+  return value.toISOString();
+}
+
+/**
+ * Pure mapping seam. It mirrors the pinned upstream adapter's three relevant
+ * choices: silent -> deny, both sides use id as ref, and the IG effect class
+ * is the fixed literal `ig-dm-reply`.
+ */
+export function projectLeakedRefusal({ decision, sent, policyDigest }) {
+  if (!exactKeys(decision, ['id', 'receivedAt', 'from', 'text', 'verdict', 'reason'])
+      || typeof decision.id !== 'string' || !decision.id
+      || typeof decision.from !== 'string' || !decision.from
+      || typeof decision.text !== 'string'
+      || decision.verdict !== 'silent'
+      || typeof decision.reason !== 'string' || !decision.reason) {
+    throw new Error('source_decision_invalid');
+  }
+  if (!exactKeys(sent, ['id', 'sentAt', 'to', 'text'])
+      || typeof sent.id !== 'string' || !sent.id
+      || typeof sent.to !== 'string' || !sent.to
+      || typeof sent.text !== 'string') {
+    throw new Error('source_sent_invalid');
+  }
+  if (decision.id !== sent.id) throw new Error('source_ref_mismatch');
+  if (!SHA256_HEX.test(policyDigest)) throw new Error('source_policy_digest_invalid');
+  if (!Number.isSafeInteger(decision.receivedAt)
+      || !Number.isSafeInteger(sent.sentAt)
+      || sent.sentAt < decision.receivedAt) {
+    throw new Error('source_time_order_invalid');
+  }
+  const target = `cedulon:mizan-ig:ref:${decision.id}`;
+  const effectClass = 'ig-dm-reply';
+  return {
+    refusal: {
+      source_verdict: 'silent',
+      decision: 'deny',
+      ref: decision.id,
+      reason_code: decision.reason,
+      request_hash: sha256Text(decision.text),
+      policy_hash: policyDigest,
+      effect_hash: null,
+      effect_class: effectClass,
+      decided_at: strictInstant(decision.receivedAt, 'receivedAt'),
+    },
+    predicted_effect: {
+      effect_type: effectClass,
+      target,
+      required_source_role: 'system_of_record',
+      required_source_class: FIXTURE_SOURCE_CLASS,
+      predicate: { op: 'absent' },
+    },
+    observed_effect: {
+      effect_type: effectClass,
+      target,
+      value: sha256Text(sent.text),
+    },
+    observed_at: strictInstant(sent.sentAt, 'sentAt'),
+    source_actor: sent.to,
+  };
+}
+
+function privateKeyFromLabel(label) {
+  const seed = crypto.createHash('sha256').update(label, 'utf8').digest();
+  return crypto.createPrivateKey({
+    key: Buffer.concat([PKCS8_ED25519_PREFIX, seed]),
+    format: 'der',
+    type: 'pkcs8',
+  });
+}
+
+function publicKeyB64u(privateKey) {
+  return crypto.createPublicKey(privateKey)
+    .export({ type: 'spki', format: 'der' }).toString('base64url');
+}
+
+function fixedNonce(label) {
+  return crypto.createHash('sha256').update(label, 'utf8').digest().subarray(0, 16).toString('base64url');
+}
+
+const APPROVER_PRIVATE_KEY = privateKeyFromLabel(`${PROFILE}:approver`);
+const LOG_PRIVATE_KEY = privateKeyFromLabel(`${PROFILE}:log`);
+const SOURCE_PRIVATE_KEY = privateKeyFromLabel(`${PROFILE}:source`);
+const APPROVER_PUBLIC_KEY = publicKeyB64u(APPROVER_PRIVATE_KEY);
+const LOG_PUBLIC_KEY = publicKeyB64u(LOG_PRIVATE_KEY);
+const SOURCE_PUBLIC_KEY = publicKeyB64u(SOURCE_PRIVATE_KEY);
+
+async function buildFixtureTrustReceipt(fixture, projection) {
+  const issuedAt = projection.refusal.decided_at;
+  const expiresAt = new Date(Date.parse(issuedAt) + 3_600_000).toISOString();
+  const action = {
+    ep_version: '1.0',
+    action_type: 'interop.cedulon-mizan.reconcile-refusal-effect',
+    target: {
+      system: 'cedulon:mizan-ig:pinned-fixture',
+      resource: `decision/${projection.refusal.ref}`,
+    },
+    parameters: {
+      source_repository: SOURCE_LOCK.repository,
+      source_commit: SOURCE_COMMIT,
+      source_fixture: SOURCE_LOCK.fixture,
+      source_lock_digest: SOURCE_LOCK_DIGEST,
+      source_policy_sha256: fixture.digests.policy,
+      source_decisions_sha256: fixture.digests.decisions,
+      source_sent_sha256: fixture.digests.sent,
+      source_mapping_sha256: SOURCE_LOCK.upstream_mapping.sha256,
+      source_decision_profile_sha256: SOURCE_LOCK.decision_profile.sha256,
+      mapped_decision: projection.refusal.decision,
+      source_verdict: projection.refusal.source_verdict,
+      reason_code: projection.refusal.reason_code,
+    },
+    initiator: 'ep:entity:fixture:cedulon-mizan-adapter',
+    policy_id: 'ep:policy:fixture:cedulon-mizan-leaked-refusal@v0.1',
+    requested_at: issuedAt,
+    predicted_effects: [projection.predicted_effect],
+    predicted_effects_digest: predictedEffectsDigest([projection.predicted_effect]),
+  };
+  const action_hash = actionHash(action);
+  const context = {
+    ep_version: '1.0',
+    context_type: 'ep.signoff.v1',
+    action_hash,
+    policy_id: action.policy_id,
+    policy_hash: `sha256:${fixture.digests.policy}`,
+    initiator: action.initiator,
+    approver: FIXTURE_APPROVER_ID,
+    approver_index: 1,
+    required_approvals: 1,
+    nonce: fixedNonce(`${PROFILE}:context:${projection.refusal.ref}`),
+    issued_at: issuedAt,
+    expires_at: expiresAt,
+  };
+  const contextHash = contextDigest(context);
+  const signoff = {
+    context_hash: `sha256:${contextHash.toString('hex')}`,
+    key_class: 'B',
+    approver_key_id: FIXTURE_APPROVER_KEY_ID,
+    signed_at: issuedAt,
+    signature: crypto.sign(null, contextHash, APPROVER_PRIVATE_KEY).toString('base64url'),
+  };
+  const receipt = {
+    receipt_id: `ep:receipt:fixture:cedulon-mizan:${projection.refusal.ref}`,
+    action,
+    action_hash,
+    contexts: [context],
+    signoffs: [signoff],
+    consumption: {
+      nonce: fixedNonce(`${PROFILE}:consumption:${projection.refusal.ref}`),
+      state: 'COMMITTED',
+      committed_at: issuedAt,
+    },
+  };
+  const anchor = buildReceiptAnchorV2(receipt);
+  const checkpoint = {
+    tree_size: 1,
+    root_hash: `sha256:${anchor.merkle_root}`,
+    log_key_id: FIXTURE_LOG_KEY_ID,
+    merkle_alg: MERKLE_V2_ALG,
+  };
+  const checkpointDigest = crypto.createHash('sha256')
+    .update(canonicalize(checkpoint), 'utf8').digest();
+  const log_signature = crypto.sign(null, checkpointDigest, LOG_PRIVATE_KEY).toString('base64url');
+  return {
+    ...receipt,
+    log_proof: {
+      alg: MERKLE_V2_ALG,
+      leaf_hash: `sha256:${anchor.leaf_hash}`,
+      leaf_index: 0,
+      inclusion_path: anchor.merkle_proof,
+      checkpoint: { ...checkpoint, log_signature },
+    },
+  };
+}
+
+/** Build the separate EMILIA-native fixture artifacts and public verifier pins. */
+export async function buildNativeInputs() {
+  const fixture = loadPinnedFixture();
+  if (fixture.decisions.length !== 1 || fixture.sent.length !== 1) {
+    throw new Error('source_population_not_singleton');
+  }
+  const projection = projectLeakedRefusal({
+    decision: fixture.decisions[0],
+    sent: fixture.sent[0],
+    policyDigest: fixture.digests.policy,
+  });
+  const receipt = await buildFixtureTrustReceipt(fixture, projection);
+  const attestedAt = new Date(Date.parse(projection.observed_at) + 1_000).toISOString();
+  const verifierNow = new Date(Date.parse(projection.observed_at) + 5_000).toISOString();
+  const observation = buildOutcomeObservation({
+    receipt_id: receipt.receipt_id,
+    receipt_digest: trustReceiptDigest(receipt),
+    action_hash: receipt.action_hash,
+    consumption_nonce: receipt.consumption.nonce,
+    operation_id: FIXTURE_OPERATION_ID,
+    source: {
+      role: 'system_of_record',
+      source_id: FIXTURE_SOURCE_ID,
+      source_class: FIXTURE_SOURCE_CLASS,
+    },
+    observed_from: projection.observed_at,
+    observed_until: projection.observed_at,
+    attested_at: attestedAt,
+    observed_effects: [projection.observed_effect],
+    signer: { privateKey: SOURCE_PRIVATE_KEY },
+  });
+  const verifier_options = {
+    receiptOptions: {
+      approverKeys: {
+        [FIXTURE_APPROVER_KEY_ID]: {
+          approver_id: FIXTURE_APPROVER_ID,
+          public_key: APPROVER_PUBLIC_KEY,
+          key_class: 'B',
+          valid_from: '2023-01-01T00:00:00.000Z',
+          valid_to: '2024-01-01T00:00:00.000Z',
+        },
+      },
+      logPublicKey: LOG_PUBLIC_KEY,
+      verificationMode: 'historical',
+      now: verifierNow,
+    },
+    sourceKeys: {
+      [FIXTURE_SOURCE_ID]: {
+        public_key: SOURCE_PUBLIC_KEY,
+        role: 'system_of_record',
+        source_class: FIXTURE_SOURCE_CLASS,
+        control_domain_id: 'fixture:cedulon-mizan',
+        status: 'active',
+        valid_from: '2023-01-01T00:00:00.000Z',
+        valid_to: '2024-01-01T00:00:00.000Z',
+      },
+    },
+    sourceRequirements: [{
+      role: 'system_of_record',
+      source_class: FIXTURE_SOURCE_CLASS,
+      min_distinct_sources: 1,
+      distinct_by: ['key'],
+      source_ids: [FIXTURE_SOURCE_ID],
+    }],
+    observationWindows: [{
+      role: 'system_of_record',
+      source_class: FIXTURE_SOURCE_CLASS,
+      relation: 'exact',
+      not_before: projection.observed_at,
+      not_after: projection.observed_at,
+      max_attestation_delay_ms: 1_000,
+    }],
+    now: verifierNow,
+    expectedReceiptId: receipt.receipt_id,
+    expectedReceiptDigest: trustReceiptDigest(receipt),
+    expectedActionHash: receipt.action_hash,
+    expectedConsumptionNonce: receipt.consumption.nonce,
+    expectedOperationId: FIXTURE_OPERATION_ID,
+  };
+  return {
+    fixture,
+    projection,
+    receipt,
+    observations: [observation],
+    verifier_options,
+  };
+}
+
+function reportCore(native, outcomeBinding) {
+  return {
+    '@version': REPORT_VERSION,
+    profile: PROFILE,
+    source: {
+      repository: SOURCE_LOCK.repository,
+      commit: SOURCE_COMMIT,
+      fixture: SOURCE_LOCK.fixture,
+      source_lock_digest: SOURCE_LOCK_DIGEST,
+      files: Object.fromEntries(
+        Object.entries(SOURCE_LOCK.files).map(([name, entry]) => [name, {
+          path: entry.path,
+          bytes: entry.bytes,
+          sha256: entry.sha256,
+        }]),
+      ),
+      upstream_mapping: {
+        path: SOURCE_LOCK.upstream_mapping.path,
+        sha256: SOURCE_LOCK.upstream_mapping.sha256,
+      },
+      decision_profile: {
+        path: SOURCE_LOCK.decision_profile.path,
+        sha256: SOURCE_LOCK.decision_profile.sha256,
+      },
+      signed_by_upstream: false,
+    },
+    mapping: {
+      kind: 'pinned-adapter-projection',
+      source_decision: native.projection.refusal,
+      predicted_effect: native.projection.predicted_effect,
+      observed_effect: native.projection.observed_effect,
+      rule: 'silent maps to deny; deny maps to an absent predicate; id maps to target cedulon:mizan-ig:ref:<id>; the sent row maps to an observed effect using the pinned IG effect class and SHA-256 text hash',
+    },
+    native_inputs: {
+      receipt: native.receipt,
+      observations: native.observations,
+      verifier_options: native.verifier_options,
+      receipt_digest: trustReceiptDigest(native.receipt),
+      observation_digests: native.observations.map(canonicalDigest),
+      fixture_only_keys: true,
+    },
+    outcome_binding: outcomeBinding,
+    claim_boundary: {
+      shared_raw_fixture: true,
+      native_format_interoperability: false,
+      upstream_logs_signed: false,
+      independent_observation: false,
+      fixture_keys_secret: false,
+      real_identity_proven: false,
+      temporal_precommitment_proven: false,
+      authorization_of_original_send: false,
+      failure_location_proven: false,
+      statement: 'The same pinned raw decision and sent-log bytes are projected through an EMILIA-owned adapter into fixture-only signed native inputs. The deterministic keys are public test material, and the timestamps are derived after the fact from the fixture. The run detects a divergent observed effect against the mapped absence predicate. It does not make Cedulon records valid EMILIA artifacts, prove a real approver or source identity, establish temporal precommitment, prove that the raw logs are authentic or complete, identify where enforcement failed, or authorize the original send.',
+    },
+  };
+}
+
+/** Authenticate, project, sign, and run the full current Outcome Binding reader. */
+export async function runPinnedFixture() {
+  const native = await buildNativeInputs();
+  const outcomeBinding = verifyOutcomeBindingSet(
+    native.receipt,
+    native.observations,
+    native.verifier_options,
+  );
+  const core = reportCore(native, outcomeBinding);
+  return { ...core, report_digest: canonicalDigest(core) };
+}
+
+export function verifyReportDigest(report) {
+  if (!report || typeof report !== 'object' || Array.isArray(report)
+      || typeof report.report_digest !== 'string'
+      || !/^sha256:[0-9a-f]{64}$/.test(report.report_digest)) return false;
+  const { report_digest, ...core } = report;
+  const expected = canonicalDigest(core);
+  return crypto.timingSafeEqual(
+    Buffer.from(report_digest.slice(7), 'hex'),
+    Buffer.from(expected.slice(7), 'hex'),
+  );
+}

--- a/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/fixtures/decisions.jsonl
+++ b/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/fixtures/decisions.jsonl
@@ -1,0 +1,1 @@
+{"id":"leak-1","receivedAt":1700003600000,"from":"user-leak","text":"in-leak","verdict":"silent","reason":"out-of-scope"}

--- a/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/fixtures/policy.txt
+++ b/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/fixtures/policy.txt
@@ -1,0 +1,1 @@
+ig-dm-policy-v1

--- a/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/fixtures/sent.jsonl
+++ b/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/fixtures/sent.jsonl
@@ -1,0 +1,1 @@
+{"id":"leak-1","sentAt":1700003605000,"to":"user-leak","text":"should-not-have-sent"}

--- a/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/result-lock.json
+++ b/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/result-lock.json
@@ -1,0 +1,10 @@
+{
+  "@version": "EMILIA-CEDULON-MIZAN-LEAKED-REFUSAL-RESULT-LOCK-v0.1",
+  "expected": {
+    "valid": false,
+    "lifecycle_state": "reconciled",
+    "outcome": "divergent"
+  },
+  "outcome_binding_result_digest": "sha256:80d9c6f5f2c6fd57eb0931044fc8d530c3fc34fbe11d8611c14aee9145486a15",
+  "report_digest": "sha256:56eeb27a388ce7dbf7515cc85ec5bccb29a643ef097fb0d02b0385d26c8f8b37"
+}

--- a/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/run.mjs
+++ b/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/run.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { runPinnedFixture } from './adapter.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const invoked = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invoked) {
+  const report = await runPinnedFixture();
+  if (process.argv.includes('--check')) {
+    const lock = JSON.parse(readFileSync(resolve(HERE, 'result-lock.json'), 'utf8'));
+    const matches = report.outcome_binding.valid === lock.expected.valid
+      && report.outcome_binding.lifecycle_state === lock.expected.lifecycle_state
+      && report.outcome_binding.outcome === lock.expected.outcome
+      && report.outcome_binding.result_digest === lock.outcome_binding_result_digest
+      && report.report_digest === lock.report_digest;
+    if (!matches) {
+      console.error(`result drift: expected ${lock.outcome_binding_result_digest} / ${lock.report_digest}, got ${report.outcome_binding.result_digest} / ${report.report_digest}`);
+      process.exitCode = 1;
+    } else {
+      console.log(JSON.stringify({
+        profile: report.profile,
+        outcome: report.outcome_binding.outcome,
+        outcome_binding_result_digest: report.outcome_binding.result_digest,
+        report_digest: report.report_digest,
+        result_lock_match: true,
+      }, null, 2));
+    }
+  } else {
+    console.log(JSON.stringify(report, null, 2));
+  }
+}
+
+export { runPinnedFixture };

--- a/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/run.node-test.mjs
+++ b/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/run.node-test.mjs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import { verifyOutcomeBindingSet } from '../../../packages/verify/index.js';
+import {
+  PROFILE,
+  SOURCE_COMMIT,
+  SOURCE_LOCK_DIGEST,
+  buildNativeInputs,
+  loadPinnedFixture,
+  projectLeakedRefusal,
+  runPinnedFixture,
+  verifyReportDigest,
+} from './adapter.mjs';
+
+const SOURCE_LOCK = JSON.parse(readFileSync(new URL('./source-lock.json', import.meta.url), 'utf8'));
+const RESULT_LOCK = JSON.parse(readFileSync(new URL('./result-lock.json', import.meta.url), 'utf8'));
+
+test('the copied source bytes match the exact Cedulon commit lock', () => {
+  const fixture = loadPinnedFixture();
+  assert.equal(SOURCE_LOCK.commit, SOURCE_COMMIT);
+  assert.equal(fixture.commit, SOURCE_COMMIT);
+  for (const name of ['policy', 'decisions', 'sent']) {
+    const expected = SOURCE_LOCK.files[name];
+    const bytes = fixture.raw[name];
+    assert.equal(bytes.length, expected.bytes, name);
+    assert.equal(crypto.createHash('sha256').update(bytes).digest('hex'), expected.sha256, name);
+  }
+});
+
+test('the adapter preserves the closed refusal/effect mapping', () => {
+  const fixture = loadPinnedFixture();
+  const projection = projectLeakedRefusal({
+    decision: fixture.decisions[0],
+    sent: fixture.sent[0],
+    policyDigest: fixture.digests.policy,
+  });
+
+  assert.deepEqual(projection.refusal, {
+    source_verdict: 'silent',
+    decision: 'deny',
+    ref: 'leak-1',
+    reason_code: 'out-of-scope',
+    request_hash: '3d72c0a9749af0024ccc1522c4a284d120248c9788e4716aae0a8b63fad06838',
+    policy_hash: '41d79f176661c3ac24181dae71506e8d5738f0470102d9cdda1dd9222cfe0805',
+    effect_hash: null,
+    effect_class: 'ig-dm-reply',
+    decided_at: '2023-11-14T23:13:20.000Z',
+  });
+  assert.deepEqual(projection.predicted_effect, {
+    effect_type: 'ig-dm-reply',
+    target: 'cedulon:mizan-ig:ref:leak-1',
+    required_source_role: 'system_of_record',
+    required_source_class: 'cedulon.mizan.sent-log',
+    predicate: { op: 'absent' },
+  });
+  assert.deepEqual(projection.observed_effect, {
+    effect_type: 'ig-dm-reply',
+    target: 'cedulon:mizan-ig:ref:leak-1',
+    value: 'b15dc10d0cfa6fd508515dd0e28a87f722225b94935852af7a447e73714a597d',
+  });
+});
+
+test('the full Outcome Binding reader verifies both native signatures and reports divergence', async () => {
+  const report = await runPinnedFixture();
+  const result = report.outcome_binding;
+
+  assert.equal(report.profile, PROFILE);
+  assert.equal(result.checks.receipt_verified, true);
+  assert.equal(result.checks.signed_predictions_bound, true);
+  assert.equal(result.checks.observations_bound_to_receipt, true);
+  assert.equal(result.checks.observation_set_reconciled, true);
+  assert.equal(result.receipt_result.valid, true, JSON.stringify(result.receipt_result.errors));
+  assert.equal(result.observation_set.observation_results[0].valid, true);
+  assert.equal(result.lifecycle_state, 'reconciled');
+  assert.equal(result.outcome, 'divergent');
+  assert.equal(result.valid, false);
+  assert.match(result.result_digest, /^sha256:[0-9a-f]{64}$/);
+  assert.equal(result.result_digest, RESULT_LOCK.outcome_binding_result_digest);
+  assert.equal(result.observation_set.evaluations[0].outcome, 'divergent');
+  assert.match(result.observation_set.evaluations[0].reasons.join(' '), /predicted absent/);
+  assert.equal(report.claim_boundary.shared_raw_fixture, true);
+  assert.equal(report.claim_boundary.native_format_interoperability, false);
+  assert.equal(report.claim_boundary.failure_location_proven, false);
+  assert.equal(report.claim_boundary.fixture_keys_secret, false);
+  assert.equal(report.claim_boundary.real_identity_proven, false);
+  assert.equal(report.claim_boundary.temporal_precommitment_proven, false);
+});
+
+test('the signed action and report bind the load-bearing source metadata', async () => {
+  const native = await buildNativeInputs();
+  const parameters = native.receipt.action.parameters;
+  assert.equal(parameters.source_lock_digest, SOURCE_LOCK_DIGEST);
+  assert.equal(parameters.source_mapping_sha256, SOURCE_LOCK.upstream_mapping.sha256);
+  assert.equal(
+    parameters.source_decision_profile_sha256,
+    SOURCE_LOCK.decision_profile.sha256,
+  );
+
+  const report = await runPinnedFixture();
+  assert.equal(report.source.source_lock_digest, SOURCE_LOCK_DIGEST);
+  assert.equal(report.source.upstream_mapping.sha256, SOURCE_LOCK.upstream_mapping.sha256);
+  assert.equal(report.source.decision_profile.sha256, SOURCE_LOCK.decision_profile.sha256);
+
+  const tampered = structuredClone(report);
+  tampered.source.upstream_mapping.sha256 = '0'.repeat(64);
+  assert.equal(verifyReportDigest(tampered), false);
+});
+
+test('the fixture and its result digest are deterministic', async () => {
+  const first = await runPinnedFixture();
+  const second = await runPinnedFixture();
+  assert.equal(first.outcome_binding.result_digest, second.outcome_binding.result_digest);
+  assert.equal(first.report_digest, second.report_digest);
+  assert.equal(first.report_digest, RESULT_LOCK.report_digest);
+  assert.equal(verifyReportDigest(first), true);
+});
+
+test('any source-byte drift is refused before JSONL interpretation', () => {
+  const fixture = loadPinnedFixture();
+  const hostile = {
+    ...fixture.raw,
+    sent: Buffer.from(fixture.raw.sent.toString('utf8').replace('should-not-have-sent', 'changed-effect')),
+  };
+  assert.throws(
+    () => loadPinnedFixture({ raw: hostile }),
+    /source_digest_mismatch:sent/,
+  );
+});
+
+test('a decision/effect reference substitution is refused by the mapping seam', () => {
+  const fixture = loadPinnedFixture();
+  assert.throws(
+    () => projectLeakedRefusal({
+      decision: fixture.decisions[0],
+      sent: { ...fixture.sent[0], id: 'leak-2' },
+      policyDigest: fixture.digests.policy,
+    }),
+    /source_ref_mismatch/,
+  );
+});
+
+test('post-projection target tampering cannot retain a valid native observation', async () => {
+  const native = await buildNativeInputs();
+  const hostile = structuredClone(native.observations);
+  hostile[0].observed_effects[0].target = 'cedulon:mizan-ig:ref:leak-2';
+
+  const result = verifyOutcomeBindingSet(native.receipt, hostile, native.verifier_options);
+  assert.equal(result.valid, false);
+  assert.equal(result.lifecycle_state, 'indeterminate');
+  assert.match(result.errors.join(' '), /outcome_source_signature_invalid/);
+});

--- a/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/source-lock.json
+++ b/conformance/composition/cedulon-mizan-leaked-refusal-v0.1/source-lock.json
@@ -1,0 +1,36 @@
+{
+  "@version": "EMILIA-CEDULON-MIZAN-SOURCE-LOCK-v0.1",
+  "repository": "https://github.com/dogrucanemek-alt/cedulon.git",
+  "commit": "06c3119badc269ef5d6d3596ea3b3d48219d6ba4",
+  "fixture": "interop/mizan-ig/fixtures/leaked-refusal",
+  "files": {
+    "policy": {
+      "path": "interop/mizan-ig/fixtures/leaked-refusal/policy.txt",
+      "bytes": 16,
+      "git_blob_sha1": "a8cebe51982fe6af61051086339e8df87b935449",
+      "sha256": "41d79f176661c3ac24181dae71506e8d5738f0470102d9cdda1dd9222cfe0805"
+    },
+    "decisions": {
+      "path": "interop/mizan-ig/fixtures/leaked-refusal/decisions.jsonl",
+      "bytes": 122,
+      "git_blob_sha1": "6097a346e194ead4439989e6e83dd61bce35c59b",
+      "sha256": "2db5f0a8491aa34031223d9d4e732620a1df86bb37747972fa86e9095dd48d72"
+    },
+    "sent": {
+      "path": "interop/mizan-ig/fixtures/leaked-refusal/sent.jsonl",
+      "bytes": 86,
+      "git_blob_sha1": "30d74774566f71a3cedac8c85a4aaef3146d8fed",
+      "sha256": "cfd9037ef183c04364d2c32951b108be2740d4b75bdd2f9cb83dc1ac7fd5d131"
+    }
+  },
+  "upstream_mapping": {
+    "path": "interop/mizan-ig/ig-adapter.mjs",
+    "git_blob_sha1": "ea1cab2c3c5b97af73669a76ca255ed4f5c66111",
+    "sha256": "3d9a710cab9121f7a78f9a8443568cd4fd1b3388e5fe6b27480512fef2f22d05"
+  },
+  "decision_profile": {
+    "path": "spec/draft-dogru-cedulon-decision-profile-01.txt",
+    "git_blob_sha1": "0ecbfa4513278071c0060498e4bae4d45674cd15",
+    "sha256": "555d2fe2294670d49140af1f54c39ca61865488dc6e07f7971b9a7386a227116"
+  }
+}


### PR DESCRIPTION
## Summary

- pin the exact leaked-refusal policy and JSONL bytes from Cedulon commit `06c3119badc269ef5d6d3596ea3b3d48219d6ba4`
- bind the upstream adapter, decision profile, and source lock into the fixture-only signed action and report
- project the refusal and observed send through the full EMILIA Outcome Binding reader
- lock the reproducible `reconciled / divergent` result and reject source drift, reference substitution, metadata tampering, and target tampering
- recognize PR #733's public deterministic OAuth JWT fixture so full-history secret scans do not fail on an unrelated remote branch

## Verification

- `node --test conformance/composition/cedulon-mizan-leaked-refusal-v0.1/run.node-test.mjs` (8/8)
- `node conformance/composition/cedulon-mizan-leaked-refusal-v0.1/run.mjs --check`
- Outcome Binding Node tests (50/50)
- `gitleaks detect --source . --verbose --redact --exit-code 1 --no-banner`
- `npm run check:repository-boundary`
- `npm run check:public-conformance-claims`
- `npm run check:authority-claims`
- `npm run check:llm-context`
- ESLint with ignored files explicitly included

## Claim boundary

This is one shared unsigned raw fixture interpreted by separately owned adapters. The deterministic keys are public test material and the timestamps are derived after the fact. The result proves neither native-format interoperability, real identity, temporal precommitment, authority over the original send, nor the location of an enforcement failure.