### PR TITLE
Authorize exact Works source relocations from the trusted migration baseline

### DIFF
--- a/scripts/schema-pr-candidate-reconcile.mjs
+++ b/scripts/schema-pr-candidate-reconcile.mjs
@@ -8,6 +8,8 @@
 // migration in the governed migration-history ledger. A candidate's remote
 // classification is a declaration, not proof that its SQL has run. This check
 // does not replace or suppress the independent live schema reconciliation.
+// An already-journaled source may move privately only after its exact hash is
+// approved in the trusted BASE tree. A candidate cannot approve its own deletion.
 
 import crypto from 'node:crypto';
 import fs from 'node:fs';
@@ -115,18 +117,47 @@ function readLedger(root, label) {
 const argumentsMap = parseArguments();
 const baseFiles = regularFiles(argumentsMap['base-root']);
 const candidateFiles = regularFiles(argumentsMap['candidate-root']);
+const baseLedger = readLedger(argumentsMap['base-root'], 'trusted base');
+const ledger = readLedger(argumentsMap['candidate-root'], 'candidate');
+const relocationPath = path.join(argumentsMap['base-root'], 'supabase', 'source-relocations.v1.json');
+let relocations = {};
+if (fs.existsSync(relocationPath)) {
+  const stat = fs.lstatSync(relocationPath);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1 || stat.size > 65536) {
+    fail('trusted source relocation approvals must be one bounded regular file');
+  }
+  let approval;
+  try { approval = JSON.parse(fs.readFileSync(relocationPath, 'utf8')); }
+  catch { fail('trusted source relocation approvals are invalid JSON'); }
+  if (approval.schema_version !== 'EP-MIGRATION-SOURCE-RELOCATIONS-v1'
+      || approval.destination_repository !== 'emiliaprotocol/emilia-company'
+      || approval.destination_root !== 'commercial/emilia-works/supabase/migrations'
+      || !approval.files || typeof approval.files !== 'object' || Array.isArray(approval.files)
+      || Object.entries(approval.files).some(([name, hash]) => !FILE_RE.test(name) || !HASH_RE.test(hash))) {
+    fail('trusted source relocation approvals are invalid');
+  }
+  relocations = approval.files;
+}
+const relocated = [];
 
 for (const [name, bytes] of baseFiles) {
   const candidate = candidateFiles.get(name);
-  if (candidate === undefined) fail(`candidate deletes base migration: ${name}`);
+  if (candidate === undefined) {
+    const version = versionOf(name);
+    if (relocations[name] === sha256(bytes) && baseLedger.remote.has(version)
+        && ledger.remote.has(version) && ledger.privateRemote.has(version)
+        && !Object.hasOwn(ledger.publicFiles, name)) {
+      relocated.push(name);
+      continue;
+    }
+    fail(`candidate deletes base migration: ${name}`);
+  }
   if (sha256(bytes) !== sha256(candidate)) {
     fail(`candidate rewrites base migration: ${name}`);
   }
 }
 
 const added = [...candidateFiles.keys()].filter((name) => !baseFiles.has(name));
-const baseLedger = readLedger(argumentsMap['base-root'], 'trusted base');
-const ledger = readLedger(argumentsMap['candidate-root'], 'candidate');
 try {
   validateMigrationHistory(argumentsMap['base-root']);
 } catch (error) {
@@ -173,4 +204,4 @@ try {
   fail(`candidate migration history is invalid: ${error.message}`);
 }
 
-console.log(`PR candidate reconciled: ${baseFiles.size} immutable base migrations, ${added.length} classified additions; live deployment is not verified by this data-only check`);
+console.log(`PR candidate reconciled: ${baseFiles.size} immutable base migrations, ${relocated.length} base-approved private source relocations, ${added.length} classified additions; live deployment is not verified by this data-only check; private destination custody is not verified`);

--- a/supabase/source-relocations.v1.json
+++ b/supabase/source-relocations.v1.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "EP-MIGRATION-SOURCE-RELOCATIONS-v1",
+  "destination_repository": "emiliaprotocol/emilia-company",
+  "destination_root": "commercial/emilia-works/supabase/migrations",
+  "custody_reference": "emiliaprotocol/emilia-company#127",
+  "files": {
+    "20260809063111_works_records.sql": "1c4bc077bfa7dc4bd3cf5667169db9be91c5ac132cef9f4816e68d403de09aa7",
+    "20260814070000_works_authority_records.sql": "71e0bc908fa946c81ffa0083ab1c021bfdbb936729be4d2113470b07699824be",
+    "20260907235809_works_accounts.sql": "9f63f7bc3c8327ca5060fe906fc3bdc84278cedfa24a778fca563ca6ffbc57c2",
+    "20260907235858_works_workflow.sql": "a64b5c85e6481eabf967e70aa7bc2bcaf21b2f5462ee06a24599195d87be1350"
+  }
+}

--- a/tests/schema-pr-candidate-reconcile.test.ts
+++ b/tests/schema-pr-candidate-reconcile.test.ts
@@ -93,6 +93,33 @@ describe('trusted-base candidate migration reconciliation', () => {
   it('rejects deleting a confirmed base migration', () => {
     const { base, candidate } = fixture(); fs.unlinkSync(path.join(candidate, 'supabase/migrations', baseFile));
     expect(run(base, candidate).output).toContain(`candidate deletes base migration: ${baseFile}`);
+
+    const ledger = readLedger(candidate);
+    ledger.private_remote_versions.push(applied);
+    delete ledger.public_files[baseFile];
+    writeLedger(candidate, ledger);
+    const approval = {
+      schema_version: 'EP-MIGRATION-SOURCE-RELOCATIONS-v1',
+      destination_repository: 'emiliaprotocol/emilia-company',
+      destination_root: 'commercial/emilia-works/supabase/migrations',
+      files: { [baseFile]: hash('select 1;\n') },
+    };
+    const approve = (root: string) => fs.writeFileSync(path.join(root, 'supabase/source-relocations.v1.json'), JSON.stringify(approval));
+    // Self-approval in untrusted candidate bytes must not authorize deletion.
+    approve(candidate);
+    expect(run(base, candidate).output).toContain(`candidate deletes base migration: ${baseFile}`);
+    approve(base);
+    expect(run(base, candidate).status).toBe(0);
+    // The unchanged remote journal, private classification and exact original
+    // hash remain mandatory even when the trusted base approves a relocation.
+    approval.files[baseFile] = hash('different bytes'); approve(base);
+    expect(run(base, candidate).status).not.toBe(0);
+    approval.files[baseFile] = hash('select 1;\n'); approve(base);
+    ledger.private_remote_versions = [privateVersion]; writeLedger(candidate, ledger);
+    expect(run(base, candidate).status).not.toBe(0);
+    ledger.private_remote_versions.push(applied);
+    ledger.remote_versions = [privateVersion]; writeLedger(candidate, ledger);
+    expect(run(base, candidate).status).not.toBe(0);
   });
 
   it('rejects substituting only a confirmed base ledger hash', () => {


### PR DESCRIPTION
This prepares the trusted-base migration checker for the owner-approved move of legacy Works into the private company repository. It does not remove any migration, change its bytes, or alter the database journal.

The checker can accept a source relocation only when the trusted base already approves that exact filename and SHA-256, the version was already journaled, and the candidate keeps it journaled and private. Candidate-only approval, wrong hashes and lost classifications are rejected. The four private copies were verified before removal and are preserved in company PR #127.

Validation: all 21 reconciliation tests pass, including the expanded deletion test. The prepared checker accepts the exact four-file relocation candidate. Live database requirements remain separate and unchanged. This PR must land before the application-removal PR.